### PR TITLE
feat: Phase 1 — 실제 마이그레이터 + 트랜잭션 무결성 (Postgres 기반)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,21 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +51,12 @@ jobs:
 
       - name: Test
         run: pnpm test
+        env:
+          RUN_DB_TESTS: '1'
+          DB_HOST: localhost
+          DB_PORT: '5432'
+          DB_USER: postgres
+          DB_PASSWORD: postgres
 
       - name: Build
         run: pnpm build

--- a/docs/superpowers/plans/2026-06-06-phase1-foundation-migrator-and-transactions.md
+++ b/docs/superpowers/plans/2026-06-06-phase1-foundation-migrator-and-transactions.md
@@ -1,0 +1,600 @@
+# Phase 1 — Foundation: Real Migrator + Transaction Integrity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Hydra a real, versioned, idempotent schema migrator that runs on connect, and fix the transaction-threading bug so multi-write operations are actually atomic — with no user-facing behavior change.
+
+**Architecture:** Generate versioned SQL with `drizzle-kit generate` into `drizzle/`, ship it at runtime, and apply it via drizzle-orm's `migrate()` inside `PostgresAdapter.runMigrations()` (called from `ConnectWorkspaceHandler` after connect). Separately, thread the transaction handle (`tx`) into repository writes via an optional executor parameter so `CreateProjectHandler`'s two writes run inside one BEGIN/COMMIT. A new DB integration-test harness (using the existing docker-compose Postgres, gated by `RUN_DB_TESTS=1`) backs these with real tests.
+
+**Tech Stack:** Electron + TypeScript, Drizzle ORM (`drizzle-orm/node-postgres`), `pg`, drizzle-kit, Vitest, electron-forge.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md` (§4.4.3, §8.1, §10, §12.1).
+
+> **Commit convention:** This repo uses Korean Conventional Commits (e.g. `feat:`, `fix:`, `chore:`). End every commit message with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer (omitted from the examples below for brevity).
+
+---
+
+## File Structure
+
+**Created:**
+- `src/main/core/database/__testutils__/pgTestDb.ts` — test-only helper: create/drop an isolated Postgres database against the docker-compose instance. One responsibility: throwaway-DB lifecycle for integration tests.
+- `src/main/core/database/__testutils__/pgTestDb.test.ts` — self-check that the harness can create/drop a DB.
+- `src/main/core/database/migrate/migrationsPath.ts` — resolves the migrations folder for dev vs packaged builds. Only imported by main-process runtime (never by tests), so it may import `electron`.
+- `src/main/core/database/repository/drizzle/executor.ts` — Drizzle executor types (`DrizzleDb`, `DrizzleTx`, `DrizzleExecutor`).
+- `src/main/core/database/repository/interfaces/RepoExecutor.ts` — dialect-neutral `RepoExecutor` type used in repository interfaces.
+- `src/main/core/database/adapter/PostgresAdapter.migrate.test.ts` — integration test for `runMigrations()`.
+- `src/main/core/database/transaction.atomicity.test.ts` — integration test proving transactional rollback.
+- `drizzle/` — generated migration SQL + `meta/_journal.json` (committed).
+
+**Modified:**
+- `src/main/core/database/adapter/DatabaseAdapter.ts` — `runMigrations(migrationsFolder: string)` signature.
+- `src/main/core/database/adapter/PostgresAdapter.ts` — implement `runMigrations` with `migrate()`.
+- `src/main/handler/workspace/ConnectWorkspaceHandler.ts` — call `runMigrations()` after connect.
+- `src/main/core/database/repository/interfaces/ProjectRepository.ts` — add optional `executor` to `create`/`linkUser`.
+- `src/main/core/database/repository/drizzle/DrizzleProjectRepository.ts` — honor the executor.
+- `src/main/handler/projects/CreateProjectHandler.ts` — pass `tx` into the repo writes.
+- `forge.config.ts` — `extraResource: ['./drizzle']`.
+- `.github/workflows/ci.yml` — add a Postgres service + `RUN_DB_TESTS` env.
+
+---
+
+## Task 1: DB integration-test harness
+
+**Files:**
+- Create: `src/main/core/database/__testutils__/pgTestDb.ts`
+- Test: `src/main/core/database/__testutils__/pgTestDb.test.ts`
+
+- [ ] **Step 1: Write the harness helper**
+
+```ts
+// src/main/core/database/__testutils__/pgTestDb.ts
+// 통합 테스트용 격리 데이터베이스 생성/삭제 헬퍼 (docker-compose Postgres 대상)
+
+import { Client } from 'pg'
+
+export function pgTestConfig() {
+  return {
+    host: process.env.DB_HOST ?? 'localhost',
+    port: Number(process.env.DB_PORT ?? 5432),
+    user: process.env.DB_USER ?? 'postgres',
+    password: process.env.DB_PASSWORD ?? 'postgres'
+  }
+}
+
+// 유지보수용 'postgres' DB에 접속해 고유 이름의 테스트 DB를 생성
+export async function createTestDatabase(): Promise<string> {
+  const name = `hydra_test_${Date.now()}_${Math.floor(Math.random() * 1_000_000)}`
+  const client = new Client({ ...pgTestConfig(), database: 'postgres' })
+  await client.connect()
+  try {
+    await client.query(`CREATE DATABASE "${name}"`)
+  } finally {
+    await client.end()
+  }
+  return name
+}
+
+export async function dropTestDatabase(name: string): Promise<void> {
+  const client = new Client({ ...pgTestConfig(), database: 'postgres' })
+  await client.connect()
+  try {
+    await client.query(`DROP DATABASE IF EXISTS "${name}" WITH (FORCE)`)
+  } finally {
+    await client.end()
+  }
+}
+```
+
+- [ ] **Step 2: Write the self-check test**
+
+```ts
+// src/main/core/database/__testutils__/pgTestDb.test.ts
+import { Client } from 'pg'
+import { describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from './pgTestDb'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('pgTestDb harness', () => {
+  it('creates and drops an isolated database', async () => {
+    const name = await createTestDatabase()
+    const client = new Client({ ...pgTestConfig(), database: name })
+    await client.connect() // DB가 실제로 존재함을 증명
+    await client.end()
+    await dropTestDatabase(name)
+    expect(name).toMatch(/^hydra_test_/)
+  })
+})
+```
+
+- [ ] **Step 3: Start the local Postgres and run the test**
+
+Run (PowerShell):
+```powershell
+pnpm docker:up
+$env:RUN_DB_TESTS='1'; pnpm test -- src/main/core/database/__testutils__/pgTestDb.test.ts
+```
+Expected: PASS (1 test). If `RUN_DB_TESTS` is unset the suite is **skipped**, which is also acceptable locally.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/core/database/__testutils__/
+git commit -m "test: 통합 테스트용 Postgres DB 격리 하니스 추가"
+```
+
+---
+
+## Task 2: Generate the initial migration
+
+**Files:**
+- Create: `drizzle/0000_*.sql`, `drizzle/meta/_journal.json`, `drizzle/meta/0000_snapshot.json` (via tooling)
+
+- [ ] **Step 1: Generate migration SQL from the current schema**
+
+Run:
+```bash
+pnpm db:generate
+```
+Expected: creates a `drizzle/` directory containing `0000_<name>.sql` and a `meta/` folder. `drizzle-kit generate` diffs schema files against migration history and needs **no database connection**.
+
+- [ ] **Step 2: Verify the SQL covers all 15 tables**
+
+Run (PowerShell):
+```powershell
+Select-String -Path drizzle/0000_*.sql -Pattern 'CREATE TABLE' | Measure-Object | Select-Object -ExpandProperty Count
+```
+Expected: `15` (users, projects, users_projects_link, milestones, issues, files, issues_files_link, comments, labels, issues_labels_link, tasks, issue_relations, notifications, integrations, invite_codes).
+
+- [ ] **Step 3: Commit the generated migration**
+
+```bash
+git add drizzle/
+git commit -m "chore: 초기 스키마 마이그레이션 생성 (drizzle-kit generate)"
+```
+
+---
+
+## Task 3: Implement `runMigrations()` (TDD)
+
+**Files:**
+- Test: `src/main/core/database/adapter/PostgresAdapter.migrate.test.ts`
+- Modify: `src/main/core/database/adapter/DatabaseAdapter.ts:19`
+- Modify: `src/main/core/database/adapter/PostgresAdapter.ts:145-147`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+// src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
+import { resolve } from 'node:path'
+import { sql } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from '../__testutils__/pgTestDb'
+import { PostgresAdapter } from './PostgresAdapter'
+
+const migrationsFolder = resolve(process.cwd(), 'drizzle')
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('PostgresAdapter.runMigrations', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  })
+
+  it('creates all application tables', async () => {
+    await adapter.runMigrations(migrationsFolder)
+    const db = adapter.getConnection()
+    const res = await db.execute(
+      sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
+    )
+    const names = res.rows.map((r) => r.table_name as string)
+    expect(names).toEqual(expect.arrayContaining(['users', 'projects', 'issues', 'comments', 'notifications']))
+  })
+
+  it('is idempotent on a second run', async () => {
+    await expect(adapter.runMigrations(migrationsFolder)).resolves.not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (PowerShell):
+```powershell
+$env:RUN_DB_TESTS='1'; pnpm test -- src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
+```
+Expected: FAIL on "creates all application tables" — `runMigrations` is a no-op, so no tables exist and `arrayContaining` fails. (Vitest strips types, so passing the extra `migrationsFolder` argument runs fine even before the signature change.)
+
+- [ ] **Step 3: Update the interface signature**
+
+In `src/main/core/database/adapter/DatabaseAdapter.ts`, change line 19:
+```ts
+  runMigrations(migrationsFolder: string): Promise<void>
+```
+
+- [ ] **Step 4: Implement the migrator in PostgresAdapter**
+
+In `src/main/core/database/adapter/PostgresAdapter.ts`, add the import near the other drizzle imports (after line 6):
+```ts
+import { migrate } from 'drizzle-orm/node-postgres/migrator'
+```
+Replace the no-op `runMigrations` (lines 145-147) with:
+```ts
+  async runMigrations(migrationsFolder: string): Promise<void> {
+    if (!this.db) {
+      throw new Error('Database not connected. Call connect() first.')
+    }
+    await migrate(this.db, { migrationsFolder })
+  }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run (PowerShell):
+```powershell
+$env:RUN_DB_TESTS='1'; pnpm test -- src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm typecheck:node`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/core/database/adapter/DatabaseAdapter.ts src/main/core/database/adapter/PostgresAdapter.ts src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
+git commit -m "feat: drizzle migrate() 기반 runMigrations 구현"
+```
+
+---
+
+## Task 4: Resolve migrations path + wire into connect + package it
+
+**Files:**
+- Create: `src/main/core/database/migrate/migrationsPath.ts`
+- Modify: `src/main/handler/workspace/ConnectWorkspaceHandler.ts:38-47`
+- Modify: `forge.config.ts:8-14`
+
+- [ ] **Step 1: Create the migrations-folder resolver**
+
+```ts
+// src/main/core/database/migrate/migrationsPath.ts
+// 마이그레이션 SQL 폴더 경로 해석 (dev: 레포 루트, packaged: resources)
+// 주의: 이 모듈은 메인 프로세스 런타임에서만 import 한다 (electron 의존성, 테스트에서 import 금지)
+
+import { join, resolve } from 'node:path'
+import { app } from 'electron'
+
+export function getMigrationsFolder(): string {
+  if (app.isPackaged) {
+    return join(process.resourcesPath, 'drizzle')
+  }
+  return resolve(process.cwd(), 'drizzle')
+}
+```
+
+- [ ] **Step 2: Call `runMigrations()` right after connect**
+
+In `src/main/handler/workspace/ConnectWorkspaceHandler.ts`, add the import after line 3:
+```ts
+import { getMigrationsFolder } from '@/database/migrate/migrationsPath'
+```
+Then, immediately after the `await adapter.connect({ ... })` block (after line 45) and before `const db = adapter.getConnection()`, add:
+```ts
+    // 스키마를 최신 마이그레이션으로 적용 (멱등)
+    await adapter.runMigrations(getMigrationsFolder())
+```
+
+- [ ] **Step 3: Ship the `drizzle/` folder in packaged builds**
+
+In `forge.config.ts`, add `extraResource` to `packagerConfig` (after line 13, `executableName: 'hydra'`):
+```ts
+    executableName: 'hydra',
+    extraResource: ['./drizzle']
+```
+
+- [ ] **Step 4: Verify typecheck and build**
+
+Run: `pnpm typecheck && pnpm build`
+Expected: both succeed.
+
+- [ ] **Step 5: Manual dev verification (fresh DB)**
+
+Because `migrate()` applies `CREATE TABLE` statements, run it against a **fresh** database (a DB previously created by `drizzle-kit push` already has the tables and would error). For dev, reset once:
+```powershell
+pnpm docker:down
+docker volume rm hydra_hydra_data
+pnpm docker:up
+```
+Then launch the app (`pnpm dev`), connect to the workspace, and confirm it connects without error and tables exist (e.g. via `pnpm db:studio`). Existing-workspace (already-populated) migration is handled in Phase 3 — see Notes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/core/database/migrate/migrationsPath.ts src/main/handler/workspace/ConnectWorkspaceHandler.ts forge.config.ts
+git commit -m "feat: 연결 시 마이그레이션 자동 실행 + drizzle 폴더 패키징"
+```
+
+---
+
+## Task 5: Fix transaction atomicity (TDD)
+
+**Files:**
+- Create: `src/main/core/database/repository/interfaces/RepoExecutor.ts`
+- Create: `src/main/core/database/repository/drizzle/executor.ts`
+- Test: `src/main/core/database/transaction.atomicity.test.ts`
+- Modify: `src/main/core/database/repository/interfaces/ProjectRepository.ts`
+- Modify: `src/main/core/database/repository/drizzle/DrizzleProjectRepository.ts:16-32,79-85`
+- Modify: `src/main/handler/projects/CreateProjectHandler.ts:20-35`
+
+- [ ] **Step 1: Write the failing atomicity test**
+
+```ts
+// src/main/core/database/transaction.atomicity.test.ts
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PostgresAdapter } from './adapter/PostgresAdapter'
+import { DrizzleProjectRepository } from './repository/drizzle/DrizzleProjectRepository'
+import * as schema from './schema/drizzle/schema'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from './__testutils__/pgTestDb'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('transaction atomicity', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+    await adapter.runMigrations(resolve(process.cwd(), 'drizzle'))
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  })
+
+  it('rolls back the project insert when a later write throws', async () => {
+    const db = adapter.getConnection()
+    const repo = new DrizzleProjectRepository(db)
+
+    const userId = randomUUID()
+    await db.insert(schema.users).values({ user_id: userId, user_name: 'tester', user_role: 'admin' })
+
+    const projectId = randomUUID()
+    await expect(
+      adapter.transaction(async (tx) => {
+        await repo.create(
+          { projectId, projectName: 'P', projectKey: 'P1', createdBy: userId, startDate: new Date(), endDate: new Date() },
+          tx
+        )
+        throw new Error('boom') // insert 이후 강제 롤백
+      })
+    ).rejects.toThrow('boom')
+
+    const found = await db.select().from(schema.projects).where(eq(schema.projects.project_id, projectId))
+    expect(found).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (PowerShell):
+```powershell
+$env:RUN_DB_TESTS='1'; pnpm test -- src/main/core/database/transaction.atomicity.test.ts
+```
+Expected: FAIL — current `create()` ignores the `tx` arg and writes via the pooled `this.db`, so the insert commits independently of the rolled-back transaction and `found` has length 1.
+
+- [ ] **Step 3: Define the executor types**
+
+```ts
+// src/main/core/database/repository/interfaces/RepoExecutor.ts
+// 리포지토리 쓰기에 주입할 수 있는 실행 핸들 (db 또는 트랜잭션). 구현체가 구체 타입으로 좁힌다.
+export type RepoExecutor = unknown
+```
+
+```ts
+// src/main/core/database/repository/drizzle/executor.ts
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
+import type * as schema from '../../schema/drizzle/schema'
+
+export type DrizzleDb = NodePgDatabase<typeof schema>
+// tx 핸들 타입을 transaction 콜백 인자에서 직접 추출 (drizzle 내부 제네릭에 의존하지 않음)
+export type DrizzleTx = Parameters<Parameters<DrizzleDb['transaction']>[0]>[0]
+export type DrizzleExecutor = DrizzleDb | DrizzleTx
+```
+
+- [ ] **Step 4: Add the optional executor to the ProjectRepository interface**
+
+In `src/main/core/database/repository/interfaces/ProjectRepository.ts`, add the import at the top:
+```ts
+import type { RepoExecutor } from './RepoExecutor'
+```
+Change the `create` and `linkUser` signatures to:
+```ts
+  create(data: CreateProjectData, executor?: RepoExecutor): Promise<ProjectRecord>
+  linkUser(linkId: string, userId: string, projectId: string, executor?: RepoExecutor): Promise<void>
+```
+
+- [ ] **Step 5: Honor the executor in the Drizzle implementation**
+
+In `src/main/core/database/repository/drizzle/DrizzleProjectRepository.ts`, add the import after line 4:
+```ts
+import type { RepoExecutor } from '../interfaces/RepoExecutor'
+import type { DrizzleExecutor } from './executor'
+```
+Change `create` (lines 18-32) to accept and use the executor:
+```ts
+  async create(data: CreateProjectData, executor: RepoExecutor = this.db): Promise<ProjectRecord> {
+    const ex = executor as DrizzleExecutor
+    const rows = await ex
+      .insert(projects)
+      .values({
+        project_id: data.projectId,
+        project_name: data.projectName,
+        project_key: data.projectKey,
+        project_desc: data.projectDesc ?? null,
+        project_created_by: data.createdBy,
+        project_start_date: data.startDate ?? null,
+        project_end_date: data.endDate ?? null
+      })
+      .returning()
+    return rows[0] as ProjectRecord
+  }
+```
+Change `linkUser` (lines 79-85) to:
+```ts
+  async linkUser(linkId: string, userId: string, projectId: string, executor: RepoExecutor = this.db): Promise<void> {
+    const ex = executor as DrizzleExecutor
+    await ex.insert(usersProjectsLink).values({
+      user_project_link_id: linkId,
+      user_id: userId,
+      project_id: projectId
+    })
+  }
+```
+
+- [ ] **Step 6: Run the atomicity test to verify it passes**
+
+Run (PowerShell):
+```powershell
+$env:RUN_DB_TESTS='1'; pnpm test -- src/main/core/database/transaction.atomicity.test.ts
+```
+Expected: PASS — `create()` now runs on the transaction, so the rollback removes the project and `found` has length 0.
+
+- [ ] **Step 7: Thread `tx` through the production handler**
+
+In `src/main/handler/projects/CreateProjectHandler.ts`, change the transaction block (lines 20-35) so the callback receives `tx` and passes it to both writes:
+```ts
+      const project = await this.repos.db.transaction(async (tx) => {
+        const project = await this.repos.projects.create(
+          {
+            projectId,
+            projectName: params.projectName,
+            projectKey: params.projectKey,
+            projectDesc: params.projectDesc,
+            createdBy: params.userId,
+            startDate: new Date(),
+            endDate: new Date()
+          },
+          tx
+        )
+
+        // 사용자-프로젝트 연결 생성 (동일 트랜잭션)
+        await this.repos.projects.linkUser(CoreUtil.getUuid(), params.userId, project.project_id, tx)
+
+        return project
+      })
+```
+
+- [ ] **Step 8: Typecheck and run the full main test suite**
+
+Run (PowerShell):
+```powershell
+pnpm typecheck:node
+$env:RUN_DB_TESTS='1'; pnpm test
+```
+Expected: typecheck clean; all tests pass (existing 3 unit tests + new integration tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/core/database/repository/interfaces/RepoExecutor.ts src/main/core/database/repository/interfaces/ProjectRepository.ts src/main/core/database/repository/drizzle/executor.ts src/main/core/database/repository/drizzle/DrizzleProjectRepository.ts src/main/handler/projects/CreateProjectHandler.ts src/main/core/database/transaction.atomicity.test.ts
+git commit -m "fix: 프로젝트 생성 트랜잭션이 실제로 원자적이도록 tx 핸들 전달"
+```
+
+---
+
+## Task 6: Run DB-gated tests in CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a Postgres service and enable the DB tests**
+
+In `.github/workflows/ci.yml`, under `jobs.ci` (after `runs-on: ubuntu-latest`, before `steps:`), add:
+```yaml
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+```
+Then change the existing `Test` step to set the DB env so the gated suites run:
+```yaml
+      - name: Test
+        run: pnpm test
+        env:
+          RUN_DB_TESTS: '1'
+          DB_HOST: localhost
+          DB_PORT: '5432'
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+```
+(`POSTGRES_DB: postgres` keeps the maintenance database the harness connects to for `CREATE DATABASE`/`DROP DATABASE`.)
+
+- [ ] **Step 2: Validate the workflow YAML locally**
+
+Run (PowerShell):
+```powershell
+pnpm exec js-yaml .github/workflows/ci.yml > $null; if ($LASTEXITCODE -eq 0) { 'yaml ok' } else { 'yaml error' }
+```
+Expected: `yaml ok`. (If `js-yaml` is unavailable, visually confirm indentation matches the surrounding steps — two spaces under `steps:` items.)
+
+- [ ] **Step 3: Commit and verify on CI**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: Postgres 서비스 추가 및 DB 통합 테스트 활성화"
+```
+Push the branch and confirm the CI run's **Test** step executes the integration suites (not skipped) and passes.
+
+---
+
+## Notes / Risks
+
+- **Existing populated databases:** `migrate()` runs `CREATE TABLE`, so it errors against a DB that already has the schema (e.g. one created by `drizzle-kit push`). This is fine for fresh dev DBs and unreleased v3. **Baselining / in-place migration of already-populated workspaces is Phase 3's scope** (spec §8.2–§8.4), where the `users` auth-column migration and schema-version detection are designed.
+- **`drizzle-kit push` stays a dev-only tool** and must never run against a user DB (spec §8.1). After this phase, prefer `pnpm db:generate` + the runtime migrator.
+- **DB-gated tests** only run when `RUN_DB_TESTS=1` and a reachable Postgres exists; otherwise they skip. This keeps `pnpm test` green for contributors without Docker while CI runs them for real.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 scope = spec §8.1 migrator + §10 transaction bug + §11 test harness/CI):**
+- Real versioned migrator (`generate` → `migrate()` on connect): Tasks 2, 3, 4. ✅
+- Ship migrations at runtime (extraResource): Task 4 Step 3. ✅
+- `runMigrations()` called in `ConnectWorkspaceHandler`: Task 4 Step 2. ✅
+- Transaction-threading bug fixed + atomicity proven: Task 5. ✅
+- DB integration-test harness + CI against real Postgres: Tasks 1, 6. ✅
+- Out of Phase 1 (deferred, noted): existing-DB baselining, MySQL adapter, repo `.returning()`/`ilike` portability, auth columns — covered by later-phase plans.
+
+**Placeholder scan:** No `TBD`/`TODO`/"handle edge cases". Every code step shows complete code; every run step states the expected result. ✅
+
+**Type consistency:** `runMigrations(migrationsFolder: string)` is consistent across the interface (Task 3 Step 3), the impl (Task 3 Step 4), the call site (Task 4 Step 2), and tests. `RepoExecutor` (interface) / `DrizzleExecutor` (impl) names are used consistently in Task 5 Steps 3–7. `create`/`linkUser` signatures match between interface and impl. `pgTestConfig`/`createTestDatabase`/`dropTestDatabase` names match across the harness and all three integration tests. ✅
+
+---
+
+## Execution Handoff
+
+(Filled in after presenting to the user.)

--- a/docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md
@@ -190,12 +190,14 @@ document the exact grant the workspace admin must create the service account wit
 
 ### 6.2 Type-portability rules (`schema.mysql.ts` ≠ naive copy of `schema.pg.ts`)
 
-1. **UUID PK**: switch generation from `uuidv4()` to **`uuidv7()`** (already available in
-   `uuid@13`) so ids are time-ordered — avoids InnoDB clustered-index fragmentation on MySQL
-   and helps PG locality. Store as `binary(16)` on MySQL where feasible (or `char(36)` with an
-   `ascii_bin`/`utf8mb4_bin` collation) so PK/FK joins are byte-exact and indexes stay small.
-   If existing v4 ids must be preserved for migrated PG workspaces, keep them but apply v7 for
-   new rows.
+1. **UUID PK** (decided): switch generation from `uuidv4()` to **`uuidv7()`** (already in
+   `uuid@13`) so ids are time-ordered — avoids InnoDB clustered-index fragmentation on MySQL and
+   helps PG index locality. **New rows use v7; existing v4 ids in already-populated PG workspaces
+   are left as-is** (PKs are not rewritten — v4 and v7 coexist safely, only insert locality
+   differs). Store the UUID as **`char(36)` with an `ascii_bin` collation** on MySQL (decided
+   over `binary(16)`: simpler cross-DBMS parity, human-readable in DB tools, no app-side byte
+   conversion; the larger index size is acceptable at this app's single-team desktop scale). PG
+   keeps its native `uuid` type.
 2. **Timestamps**: MySQL uses **`datetime({ fsp: 3 })`** (DATETIME — no 2038 limit, no implicit
    session-TZ conversion), **not** `timestamp()`. Set mysql2 connection `timezone: 'Z'`. Pin
    fractional precision to milliseconds on **both** engines (`timestamp({ precision: 3 })` on
@@ -355,11 +357,10 @@ the transaction-threading change (§4.4.3); audit every multi-write handler the 
 
 ## 13. Open Questions / Risks
 
-- **UUIDv7 vs preserving v4**: confirm whether existing PG workspaces' v4 ids must be preserved
-  (affects whether v7 is global or new-rows-only).
-- **`binary(16)` vs `char(36)`** for MySQL UUID storage: `binary(16)` is materially better but
-  touches every FK column; validate with an insert-throughput/fragmentation benchmark on
-  `issues`/`comments` before committing.
+- ✅ **RESOLVED — UUIDv7**: new rows generate v7; existing v4 ids are left as-is (new-rows-only,
+  not a global rewrite). See §6.2.1.
+- ✅ **RESOLVED — MySQL UUID storage**: `char(36)` with `ascii_bin` collation (chosen over
+  `binary(16)` for simplicity / readability / cross-DBMS parity). See §6.2.1.
 - **Drizzle cross-dialect typing**: the "one repository set" goal needs a small spike to confirm
   the query-builder types compose across pg/mysql with an injected `db`/`schema` (the highest
   implementation-uncertainty item).

--- a/docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md
@@ -1,0 +1,379 @@
+# MySQL Support + Authentication Redesign — Design Spec
+
+- **Date**: 2026-06-06
+- **Status**: Approved (design); pending implementation plan
+- **Author**: jujoycode (with Claude Code)
+- **Branch target**: `feature/*` (new)
+
+---
+
+## 1. Summary
+
+Make Hydra work on **both PostgreSQL and MySQL** (multi-DBMS, selectable per workspace at
+connect time), and **replace the current authentication model** ("DB connection = auth /
+member = PostgreSQL ROLE") with a **unified app-level local account login** (login ID +
+password hash + persisted session) that works identically on both engines.
+
+This spec incorporates the findings of a DBA-perspective design review (46 verified findings)
+so that the cross-DBMS port does not silently break at runtime.
+
+## 2. Locked Decisions
+
+| # | Decision |
+|---|----------|
+| 1 | Support **both** PostgreSQL and MySQL. `WorkspaceConfig.dbms: 'postgresql' \| 'mysql'`, chosen at connect. |
+| 2 | **App-level authentication, unified** for both engines. Remove `createRole`/`dropRole` and the DB-ROLE model entirely. |
+| 3 | New auth = **local account login**: login ID (`user_sn`) + password (hashed) + persisted local session. |
+| 4 | DB connection uses a **single shared service account** per workspace. **Credentials are NOT embedded in the invite** — the member enters the shared DB password once at connect (as today). The invite carries only `host/port/dbName/dbms`. |
+| 5 | Login identifier = **new column `user_sn`** (unique, not null), distinct from the existing `user_id` UUID PK. |
+| 6 | Session = **persisted via Electron `safeStorage`** for auto-login, with expiry + "remember me". |
+
+## 3. Non-Goals
+
+- Per-user DB-level privilege separation / DB-level audit (intentionally dropped with the ROLE model; see §9).
+- A server/broker tier in front of the database (considered and rejected for offline-first; revisit later if true per-user DB authorization is needed).
+- Encryption-at-rest for the `integrations` table secrets (pre-existing gap; noted but out of scope here).
+- Migrating other DBMS engines beyond PostgreSQL and MySQL.
+
+---
+
+## 4. Architecture
+
+### 4.1 Adapter & factory
+
+```
+ConnectWorkspaceHandler
+  └─ createAdapter(config.dbms)              ← NEW factory
+       ├─ PostgresAdapter   (pg     + schema.pg.ts)
+       └─ MySqlAdapter      (mysql2 + schema.mysql.ts)   ← NEW
+  └─ adapter.connect(config)
+  └─ adapter.runMigrations()                ← NEW: real migrator (see §8), called on connect
+  └─ RepositoryContainer.init(db, schema)   ← inject (db, schema)
+       └─ ONE portable repository set (dialect-neutral)
+```
+
+- `DatabaseAdapter` interface is **simplified**: drop `createRole`/`dropRole`. Keep
+  `connect`, `getConnection`, `transaction`, `runMigrations`, and error wrapping
+  (`wrapPgError` / new `wrapMySqlError` mapping MySQL errno → the same business errors).
+- Add `mysql2` dependency. Keep `pg`, `drizzle-orm`, `drizzle-kit`.
+
+### 4.2 Dual schema strategy
+
+- Two files: `schema.pg.ts` (`pgTable`, `uuid`) and `schema.mysql.ts` (`mysqlTable`).
+- **Column-set parity test** (Vitest): assert both files define the same tables and the same
+  column names, so they cannot drift silently.
+- Type-mapping rules between the two files are defined in §6.2 (NOT a naive 1:1 copy).
+
+### 4.3 Repository de-coupling
+
+- Repositories currently hardcode `NodePgDatabase<typeof schema>` in their constructors
+  (all 11 files). Change to a **dialect-neutral handle** (`db`) + injected `schema`.
+- The repository implementations must use **only the portable subset** of the query builder
+  (see §4.4). A single repository set serves both engines.
+
+### 4.4 Cross-dialect query semantics — the portable repository base
+
+These are the runtime-breaking divergences found in review. All must be handled in a shared
+base, not per-call:
+
+1. **No `.returning()`** (MySQL/mysql2 has no `RETURNING`; 20 call sites today).
+   → Use **read-after-write**: UUID is already generated app-side, so `INSERT` (no
+   `.returning()`), then `SELECT … WHERE id = <thatId>` and return that row. For `UPDATE`,
+   capture the id from the WHERE clause and re-`SELECT`. Wrap insert/update + select in a
+   transaction. Do **not** use `$returningId()` (does not work for app-supplied UUID PKs,
+   and is unavailable on update).
+2. **No `ilike()`** (pg-core only). → Replace with `lower(col) LIKE lower(?)`, valid and
+   case-insensitive on both engines regardless of collation. Escape LIKE wildcards (`%`, `_`)
+   in user input. Optionally route through an adapter `caseInsensitiveLike(col, pattern)`
+   helper so the pg adapter can keep native `ilike`.
+3. **Transactions thread the `tx` handle.** Today `CreateProjectHandler` opens a transaction
+   but the callback ignores `tx` and the repos use their captured pool `db`, so writes run
+   **outside** the BEGIN/COMMIT (a real atomicity bug on PG today; impossible to honor on
+   MySQL with pooled connections). → `transaction(fn)` passes `tx`; write methods accept an
+   optional executor (`create(data, executor = this.db)`) and the handler passes `tx`. **Never
+   mix DDL into an app transaction on MySQL** (DDL auto-commits).
+4. **Booleans / counts** are already handled by Drizzle codecs (TINYINT 0/1 → JS boolean,
+   counts wrapped in `Number()`); no change required (review **refuted** these as problems).
+
+---
+
+## 5. Authentication Design
+
+### 5.1 Connect flow (per workspace)
+
+1. Member opens a saved workspace (or applies an invite carrying `host/port/dbName/dbms`).
+2. Member enters the **shared DB service-account password** once (re-entered each connect, as
+   today; never stored in the invite). Optionally cached via `safeStorage`.
+3. App connects with the shared service account → runs `runMigrations()` → determines DB state
+   (empty / old-schema / current; see §8).
+4. App shows the **login screen** (local account). Member authenticates with `user_sn` +
+   password against the `users` table.
+5. On success, a session is created and persisted (§5.4).
+
+### 5.2 Login
+
+- Lookup: `where(eq(users.user_sn, normalize(input)))`, then verify password hash.
+- **Normalize `user_sn` and `user_email`** (trim + lowercase) via one shared helper, applied at
+  **both insert and lookup**, so uniqueness and auth are case-insensitive identically on both
+  engines (avoids the MySQL CI-collation vs PG CS-collation divergence). Store the normalized
+  form; keep a display name separately if needed.
+
+### 5.3 Password hashing
+
+- **Algorithm**: Node built-in `crypto.scrypt` (no native module / Electron rebuild pain),
+  per-user random salt (≥16 bytes).
+- **Parameters must be explicit and stored with the hash.** Node's default `maxmem` (32 MiB)
+  makes `N=2^17` throw; pick parameters that fit (e.g. `N=2^15, r=8, p=1`) **and** pass an
+  explicit `maxmem`. Store as a self-describing string:
+  `scrypt$N=32768,r=8,p=1$<saltB64>$<hashB64>` so parameters can evolve without breaking old
+  hashes.
+- **Column**: `user_password_hash varchar(255)` (fixed-length encoded output; not `TEXT`).
+  Use a **binary/ascii collation** for this column on MySQL so comparison is byte-exact and
+  never collation-folded.
+
+### 5.4 Session
+
+- Opaque session record persisted via `safeStorage`: `{ userId, userSn, issuedAt, expiresAt }`.
+- "Remember me" extends `expiresAt`; otherwise a shorter TTL.
+- On app mount, `bootstrap()` reads the session, checks expiry, re-opens the DB connection, and
+  **re-verifies the user row still exists and `user_status = 'active'`** before granting access.
+- **`user_status` invalidation**: flipping a user to `inactive` is honored on the next
+  bootstrap / sensitive operation (no server to push revocation; documented limitation — an
+  in-flight session persists until relaunch or the next re-verify).
+
+### 5.5 First-admin bootstrap
+
+- The ROLE model's auto-create-admin-on-first-connect is removed. Replace with an explicit
+  **setup flow**: when the app connects to a DB whose `users` table is empty, show a
+  "create admin account" screen (set `user_sn` + password) instead of login. Guard the seeding
+  against concurrent runs (§8.4).
+
+### 5.6 Member onboarding
+
+- Admin creates a member with `user_sn`, display fields, `user_role`, and an **initial
+  password** (admin-set). Member logs in with it. (Optional, deferred: force password change on
+  first login.)
+- `CreateMemberHandler` no longer calls `createRole`; it only inserts the `users` row (with
+  hashed initial password).
+
+### 5.7 Least-privilege service account (GRANT contract)
+
+The runtime app performs **no DDL** (migrations run via a separate path — see §8). Ship and
+document the exact grant the workspace admin must create the service account with:
+
+- **PostgreSQL** (not the DB owner): `CONNECT` on DB; `USAGE` on schema; `SELECT,INSERT,UPDATE,
+  DELETE` on all tables; `USAGE` on sequences; `ALTER DEFAULT PRIVILEGES` so future tables stay
+  reachable.
+- **MySQL 8**: `GRANT SELECT,INSERT,UPDATE,DELETE ON workspace_db.*` — never `*.*`, never
+  `ALL PRIVILEGES` (which includes DDL).
+- Optionally, `ConnectWorkspaceHandler` probes that the account is non-owner / lacks DDL and
+  warns otherwise.
+- Schema creation/migration runs under a **separate higher-privileged migration role**, used
+  out-of-band, not the runtime service account.
+
+---
+
+## 6. Data Model Changes
+
+### 6.1 `users` table
+
+| Column | Change | Notes |
+|--------|--------|-------|
+| `user_id` uuid PK | keep | internal id; see §6.2 for UUID generation change |
+| **`user_sn`** | 🟢 ADD `varchar(255)` UNIQUE NOT NULL | normalized login handle |
+| **`user_password_hash`** | 🟢 ADD `varchar(255)` NOT NULL | scrypt, binary/ascii collation (§5.3) |
+| **`user_status`** | 🟢 ADD `varchar(20)` default `'active'` | `active` / `inactive`; wired into bootstrap + delete paths |
+| `user_db_role` | 🔴 REMOVE (deprecate first) | do NOT drop until new login path proven (§8.3) |
+| `user_name`, `user_email` | keep | display; `user_email` also normalized (§5.2) |
+| `user_role` `'admin'\|'member'` | keep | app-level authorization gate |
+| `user_created_at`, `user_updated_at` | keep | type rules per §6.2 |
+
+### 6.2 Type-portability rules (`schema.mysql.ts` ≠ naive copy of `schema.pg.ts`)
+
+1. **UUID PK**: switch generation from `uuidv4()` to **`uuidv7()`** (already available in
+   `uuid@13`) so ids are time-ordered — avoids InnoDB clustered-index fragmentation on MySQL
+   and helps PG locality. Store as `binary(16)` on MySQL where feasible (or `char(36)` with an
+   `ascii_bin`/`utf8mb4_bin` collation) so PK/FK joins are byte-exact and indexes stay small.
+   If existing v4 ids must be preserved for migrated PG workspaces, keep them but apply v7 for
+   new rows.
+2. **Timestamps**: MySQL uses **`datetime({ fsp: 3 })`** (DATETIME — no 2038 limit, no implicit
+   session-TZ conversion), **not** `timestamp()`. Set mysql2 connection `timezone: 'Z'`. Pin
+   fractional precision to milliseconds on **both** engines (`timestamp({ precision: 3 })` on
+   PG; consider PG `timestamptz` for unambiguous UTC round-trips). Standardize on **UTC**
+   everywhere.
+3. **UNIQUE text columns** must be **bounded `varchar`**, never `TEXT` (MySQL `ERROR 1170`).
+   - `project_key` → `varchar(50)`-ish, keep UNIQUE (load-bearing: `ProjectValidator` does a
+     count-then-insert TOCTOU, so the DB constraint is the only real duplicate guard).
+   - `invite_codes.code` → it is **never queried** (`ApplyInviteHandler` decodes base64
+     directly; no `findByCode`). **Drop the UNIQUE** (or move uniqueness to `invite_code_id`);
+     keep the payload in a non-indexed column. (Also avoids the long-base64 prefix-collision
+     problem.)
+   - `user_sn` → `varchar(255)` (≤ 1020 bytes < 3072 limit; fine under DYNAMIC row format).
+4. **Collation**: define login-handle / email semantics once via app-layer normalization
+   (§5.2). For id and hash columns use binary/ascii collations.
+5. **Defaults**: `.defaultNow()` / `.default('member')` etc. generate per-dialect DDL — verify
+   each on MySQL; never add a `NOT NULL` column without a default to a populated table (§8.2).
+6. **Secondary indexes**: the schema currently defines **none**. Add explicit indexes on the
+   FK / filter columns repositories actually query (e.g. `issues.project_id`,
+   `comments.issue_id`, `notifications.user_id`, `tasks.issue_id`, link-table FKs) — critical
+   on MySQL where the clustered PK makes unindexed filters table-scan.
+
+### 6.3 `WorkspaceConfig` + invite payload
+
+- `WorkspaceConfig` gains `dbms: 'postgresql' | 'mysql'`.
+- Invite payload gains `dbms`; **carries no DB credentials** (decision #4). Keep existing
+  `host/port/dbName/expiresAt`. Invite expiry already round-trips UTC ISO correctly — no change.
+
+---
+
+## 7. Connection & Operations
+
+- **Retry/backoff**: wrap the eager connect warm-up in bounded retries (e.g. 3 attempts,
+  exponential backoff) for transient errno only (`ECONNRESET`/`ETIMEDOUT`/`EAI_AGAIN`); never
+  retry auth/permission codes (`28P01`, `28000`, `42501`, `3D000`).
+- **Timeouts**: set a statement/query timeout and connection-health policy so a hung query
+  doesn't block IPC handlers indefinitely.
+- **Pooling**: define explicit pool policy for both engines (the pg Pool currently uses
+  defaults; MySQL needs its own).
+- **Charset**: assert/verify `utf8mb4` on MySQL at connect (the app connects to a pre-existing
+  DB and must not silently assume it).
+- **Isolation**: default isolation differs (PG READ COMMITTED vs MySQL REPEATABLE READ); set an
+  explicit isolation level for app transactions so behavior matches across engines.
+- **SSL**: replicate the cert-path-based SSL config in the MySQL adapter; cleartext passwords to
+  a remote DB are riskier now that one shared account exposes the whole workspace.
+
+---
+
+## 8. Migration Strategy
+
+**The codebase has no migrator today** (`runMigrations()` is a no-op, no `drizzle/` output, no
+version table; the only apply path is the destructive dev tool `drizzle-kit push`). This is a
+new workstream and a prerequisite for everything else.
+
+### 8.1 Build a real migrator
+
+- `drizzle-kit generate` → versioned SQL into `drizzle/pg` and `drizzle/mysql`; **ship those SQL
+  folders inside the packaged app** (electron-forge `extraResource`) so they exist at runtime.
+- Implement `runMigrations()` in each adapter using drizzle-orm's `migrate()`
+  (`drizzle-orm/node-postgres/migrator`, `drizzle-orm/mysql2/migrator`), which records applied
+  versions in `__drizzle_migrations` and is safe to re-run.
+- **Call `runMigrations()` in `ConnectWorkspaceHandler`** right after `connect()` and before any
+  repo access (currently never called).
+- **Never run `drizzle-kit push` against a user-owned DB.**
+- Maintain the two migration histories deliberately; add a **CI job that runs the MySQL
+  migration against a real MySQL 8.0 container** (the `ERROR 1170` / type failures only surface
+  at DDL execution time, not at typecheck).
+
+### 8.2 `users` columns — multi-step migration
+
+A single `ALTER TABLE … ADD COLUMN … NOT NULL` (for `user_sn`, `user_password_hash`) fails on a
+populated table (first connect already auto-created an admin row). Do it in steps:
+
+1. Add columns **nullable** (or with a temporary sentinel).
+2. **Backfill**: `user_sn` from an existing handle; `user_password_hash` left as a
+   "must-reset" marker that drives a forced initial-password setup on next login.
+3. Add the `NOT NULL` / `UNIQUE` constraints.
+
+PG supports transactional DDL (wrap each migration in a transaction); **MySQL DDL auto-commits**
+— guard MySQL migrations with per-statement idempotency checks and explicit failure recovery.
+
+### 8.3 `user_db_role` deprecation
+
+Dropping `user_db_role` is irreversible and it is the only key the current login path
+(`findByDbRole`) uses. **Keep it until the new login path is implemented and proven**, then drop
+in a later migration.
+
+### 8.4 State detection + concurrency
+
+- Use the version table to distinguish **empty** (full create) / **old schema** (auth
+  migration) / **current** (nothing) — startup behavior depends on this.
+- Guard concurrent startup migrations and first-admin seeding (multiple members/instances
+  against the same shared account) with an **advisory lock** (PG `pg_advisory_lock`; MySQL
+  `GET_LOCK`).
+
+### 8.5 Backup / rollback
+
+- Surface a **pre-migration backup recommendation** (`pg_dump` / `mysqldump`) since the target
+  is user-owned production data.
+- Provide down-migrations where feasible; document that MySQL has no transactional DDL so
+  rollback is best-effort + restore-from-backup.
+
+---
+
+## 9. Security Considerations
+
+- **No DB credentials in the invite** (decision #4) — eliminates the "anyone with the invite gets
+  full DML" exposure.
+- **Loss of DB-level per-user revocation/rotation/audit** is an accepted trade-off of the shared
+  service account. Mitigate with: least-privilege grant (§5.7), `user_status` deactivation, and
+  app-level `user_role` authorization. If true per-user DB authorization is later required,
+  revisit a broker tier.
+- **Password hash storage**: binary/ascii collation, explicit scrypt params stored with the hash.
+- **Backups now contain password hashes**; the `integrations` table already stores Slack/GitHub
+  secrets in plaintext (pre-existing). Note for a future at-rest-encryption effort (out of scope).
+- **No dynamic SQL** in the new login path (parameterized Drizzle only); the removed
+  `createRole`/`dropRole` were the only string-interpolated raw SQL.
+
+---
+
+## 10. Pre-existing Bug to Fix (independent of MySQL)
+
+`CreateProjectHandler` opens a transaction whose callback ignores `tx`; the repos use the pool
+`db`, so `create` + `linkUser` run **outside** the BEGIN/COMMIT. A `linkUser` failure leaves an
+**orphaned project** with no rollback — a real atomicity bug on PostgreSQL today. Fix as part of
+the transaction-threading change (§4.4.3); audit every multi-write handler the same way.
+
+---
+
+## 11. Testing Strategy
+
+- Unit: password hashing (params round-trip, wrong-password rejection), `user_sn`/email
+  normalization, session expiry + `user_status` invalidation.
+- Repository portability: run the **same repository test suite against both** a real PostgreSQL
+  and a real MySQL container (read-after-write, search/`lower-LIKE`, transactions/atomicity).
+- Schema parity test (§4.2).
+- Migration tests: fresh-create, old→new auth migration on a populated `users` table, idempotent
+  re-run, concurrent-run lock.
+- CI: real MySQL 8.0 + PostgreSQL containers; run migrations + the cross-engine suite.
+
+---
+
+## 12. Phasing (incremental)
+
+1. **Foundation**: build the real migrator (§8.1), versioned SQL, version table, call on connect.
+   Fix the transaction-threading bug (§10). No behavior change yet.
+2. **Portable repositories**: remove `.returning()` (read-after-write), `ilike` → `lower-LIKE`,
+   dialect-neutral `db` handle, secondary indexes, UUIDv7. Still PostgreSQL-only, but portable.
+3. **Auth redesign**: `user_sn`/`user_password_hash`/`user_status`, login screen, scrypt,
+   session, first-admin bootstrap, member onboarding, least-privilege grant docs, connect-time
+   password entry. Deprecate (don't drop) `user_db_role`. Migration for existing PG workspaces.
+4. **MySQL adapter**: `schema.mysql.ts` (type rules §6.2), `MySqlAdapter` + `wrapMySqlError`,
+   factory, `mysql2`, `dbms` in config/invite, charset/TZ/pool/SSL, CI against MySQL.
+5. **Cleanup**: drop `user_db_role`, finalize docs, remove ROLE remnants.
+
+---
+
+## 13. Open Questions / Risks
+
+- **UUIDv7 vs preserving v4**: confirm whether existing PG workspaces' v4 ids must be preserved
+  (affects whether v7 is global or new-rows-only).
+- **`binary(16)` vs `char(36)`** for MySQL UUID storage: `binary(16)` is materially better but
+  touches every FK column; validate with an insert-throughput/fragmentation benchmark on
+  `issues`/`comments` before committing.
+- **Drizzle cross-dialect typing**: the "one repository set" goal needs a small spike to confirm
+  the query-builder types compose across pg/mysql with an injected `db`/`schema` (the highest
+  implementation-uncertainty item).
+- **Existing-workspace UX** for the forced initial-password reset after the auth migration.
+
+---
+
+## Appendix A — DBA review traceability
+
+DBA-perspective review: 7 lenses, 56 agents, each finding adversarially verified against the real
+code; **46 confirmed/plausible, 3 refuted**. High-severity themes folded into this spec:
+`.returning()` (§4.4.1), `ilike` (§4.4.2), transaction handle (§4.4.3, §10), TEXT-UNIQUE
+(§6.2.3), timestamp/TZ (§6.2.2), random-UUID clustered PK (§6.2.1), `user_sn` collation
+(§5.2/§6.2.4), invite-credential exposure (§5.1/decision #4), least-privilege (§5.7),
+no-migrator + multi-step `users` migration + `user_db_role` drop (§8). Refuted (no action):
+boolean TINYINT mapping and count/bigint return types (handled by Drizzle codecs); "startup
+migration locking difference" (no startup migrator exists yet).

--- a/drizzle/0000_tearful_ender_wiggin.sql
+++ b/drizzle/0000_tearful_ender_wiggin.sql
@@ -1,0 +1,162 @@
+CREATE TABLE "comments" (
+	"comment_id" uuid PRIMARY KEY NOT NULL,
+	"issue_id" uuid NOT NULL,
+	"comment_content" text NOT NULL,
+	"comment_created_by" uuid,
+	"comment_updated_by" uuid,
+	"comment_created_at" timestamp DEFAULT now(),
+	"comment_updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "files" (
+	"file_id" uuid PRIMARY KEY NOT NULL,
+	"file_name" text NOT NULL,
+	"file_path" text NOT NULL,
+	"file_type" text NOT NULL,
+	"file_size" integer,
+	"file_created_at" timestamp DEFAULT now(),
+	"file_updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "integrations" (
+	"integration_id" uuid PRIMARY KEY NOT NULL,
+	"integration_type" varchar(50) NOT NULL,
+	"integration_config" text NOT NULL,
+	"integration_enabled" boolean DEFAULT false,
+	"integration_created_at" timestamp DEFAULT now(),
+	"integration_updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "invite_codes" (
+	"invite_code_id" uuid PRIMARY KEY NOT NULL,
+	"code" text NOT NULL,
+	"workspace_name" text NOT NULL,
+	"host" text NOT NULL,
+	"port" integer NOT NULL,
+	"db_name" text NOT NULL,
+	"created_by" text,
+	"created_at" timestamp DEFAULT now(),
+	"expires_at" timestamp,
+	CONSTRAINT "invite_codes_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "issue_relations" (
+	"relation_id" uuid PRIMARY KEY NOT NULL,
+	"source_issue_id" uuid NOT NULL,
+	"target_issue_id" uuid NOT NULL,
+	"relation_type" varchar(50) NOT NULL,
+	"relation_created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "issues" (
+	"issue_id" uuid PRIMARY KEY NOT NULL,
+	"project_id" uuid NOT NULL,
+	"issue_title" text NOT NULL,
+	"issue_key" text NOT NULL,
+	"issue_desc" text,
+	"issue_status" varchar(50),
+	"issue_priority" varchar(50),
+	"issue_category" varchar(100),
+	"issue_created_by" uuid,
+	"issue_modified_by" uuid,
+	"issue_assigned_to" uuid,
+	"issue_milestone_id" uuid,
+	"issue_created_at" timestamp DEFAULT now(),
+	"issue_updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "issues_files_link" (
+	"issue_file_link_id" uuid PRIMARY KEY NOT NULL,
+	"issue_id" uuid,
+	"file_id" uuid
+);
+--> statement-breakpoint
+CREATE TABLE "issues_labels_link" (
+	"issue_label_link_id" uuid PRIMARY KEY NOT NULL,
+	"issue_id" uuid,
+	"label_id" uuid
+);
+--> statement-breakpoint
+CREATE TABLE "labels" (
+	"label_id" uuid PRIMARY KEY NOT NULL,
+	"label_name" varchar(100) NOT NULL,
+	"label_color" varchar(7) NOT NULL,
+	"label_created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "milestones" (
+	"milestone_id" uuid PRIMARY KEY NOT NULL,
+	"project_id" uuid NOT NULL,
+	"milestone_title" text NOT NULL,
+	"milestone_desc" text,
+	"milestone_due_date" timestamp,
+	"milestone_status" varchar(50) DEFAULT 'open',
+	"milestone_created_at" timestamp DEFAULT now(),
+	"milestone_updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"notification_id" uuid PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"notification_type" varchar(50) NOT NULL,
+	"notification_title" text NOT NULL,
+	"notification_message" text,
+	"notification_read" boolean DEFAULT false,
+	"notification_link" text,
+	"notification_created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "projects" (
+	"project_id" uuid PRIMARY KEY NOT NULL,
+	"project_name" text NOT NULL,
+	"project_key" text NOT NULL,
+	"project_desc" text,
+	"project_created_by" uuid,
+	"project_modified_by" uuid,
+	"project_start_date" timestamp,
+	"project_end_date" timestamp,
+	CONSTRAINT "projects_project_key_unique" UNIQUE("project_key")
+);
+--> statement-breakpoint
+CREATE TABLE "tasks" (
+	"task_id" uuid PRIMARY KEY NOT NULL,
+	"issue_id" uuid,
+	"task_title" text NOT NULL,
+	"task_completed" boolean DEFAULT false,
+	"task_order" integer DEFAULT 0,
+	"task_created_by" uuid,
+	"task_created_at" timestamp DEFAULT now(),
+	"task_updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"user_id" uuid PRIMARY KEY NOT NULL,
+	"user_name" varchar(255),
+	"user_email" varchar(255),
+	"user_db_role" varchar(255),
+	"user_avatar_path" varchar(1024),
+	"user_role" varchar(50) DEFAULT 'member',
+	"user_created_at" timestamp,
+	"user_updated_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "users_projects_link" (
+	"user_project_link_id" uuid PRIMARY KEY NOT NULL,
+	"user_id" uuid,
+	"project_id" uuid
+);
+--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_issue_id_issues_issue_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("issue_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issue_relations" ADD CONSTRAINT "issue_relations_source_issue_id_issues_issue_id_fk" FOREIGN KEY ("source_issue_id") REFERENCES "public"."issues"("issue_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issue_relations" ADD CONSTRAINT "issue_relations_target_issue_id_issues_issue_id_fk" FOREIGN KEY ("target_issue_id") REFERENCES "public"."issues"("issue_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues" ADD CONSTRAINT "issues_project_id_projects_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("project_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues" ADD CONSTRAINT "issues_issue_milestone_id_milestones_milestone_id_fk" FOREIGN KEY ("issue_milestone_id") REFERENCES "public"."milestones"("milestone_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues_files_link" ADD CONSTRAINT "issues_files_link_issue_id_issues_issue_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("issue_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues_files_link" ADD CONSTRAINT "issues_files_link_file_id_files_file_id_fk" FOREIGN KEY ("file_id") REFERENCES "public"."files"("file_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues_labels_link" ADD CONSTRAINT "issues_labels_link_issue_id_issues_issue_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("issue_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues_labels_link" ADD CONSTRAINT "issues_labels_link_label_id_labels_label_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."labels"("label_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "milestones" ADD CONSTRAINT "milestones_project_id_projects_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("project_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_issue_id_issues_issue_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("issue_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users_projects_link" ADD CONSTRAINT "users_projects_link_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users_projects_link" ADD CONSTRAINT "users_projects_link_project_id_projects_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("project_id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1049 @@
+{
+  "id": "be85ba57-3f06-4a83-81ee-e6e848468796",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_content": {
+          "name": "comment_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_created_by": {
+          "name": "comment_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_updated_by": {
+          "name": "comment_updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_created_at": {
+          "name": "comment_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_issue_id_issues_issue_id_fk": {
+          "name": "comments_issue_id_issues_issue_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "file_updated_at": {
+          "name": "file_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_config": {
+          "name": "integration_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_enabled": {
+          "name": "integration_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "integration_created_at": {
+          "name": "integration_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "integration_updated_at": {
+          "name": "integration_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "invite_code_id": {
+          "name": "invite_code_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_name": {
+          "name": "db_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_relations": {
+      "name": "issue_relations",
+      "schema": "",
+      "columns": {
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_created_at": {
+          "name": "relation_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issue_relations_source_issue_id_issues_issue_id_fk": {
+          "name": "issue_relations_source_issue_id_issues_issue_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_relations_target_issue_id_issues_issue_id_fk": {
+          "name": "issue_relations_target_issue_id_issues_issue_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_desc": {
+          "name": "issue_desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_status": {
+          "name": "issue_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_priority": {
+          "name": "issue_priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_category": {
+          "name": "issue_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_created_by": {
+          "name": "issue_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_modified_by": {
+          "name": "issue_modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_assigned_to": {
+          "name": "issue_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_milestone_id": {
+          "name": "issue_milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_created_at": {
+          "name": "issue_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "issue_updated_at": {
+          "name": "issue_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issues_project_id_projects_project_id_fk": {
+          "name": "issues_project_id_projects_project_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_issue_milestone_id_milestones_milestone_id_fk": {
+          "name": "issues_issue_milestone_id_milestones_milestone_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "issue_milestone_id"
+          ],
+          "columnsTo": [
+            "milestone_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_files_link": {
+      "name": "issues_files_link",
+      "schema": "",
+      "columns": {
+        "issue_file_link_id": {
+          "name": "issue_file_link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issues_files_link_issue_id_issues_issue_id_fk": {
+          "name": "issues_files_link_issue_id_issues_issue_id_fk",
+          "tableFrom": "issues_files_link",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_files_link_file_id_files_file_id_fk": {
+          "name": "issues_files_link_file_id_files_file_id_fk",
+          "tableFrom": "issues_files_link",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "file_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_labels_link": {
+      "name": "issues_labels_link",
+      "schema": "",
+      "columns": {
+        "issue_label_link_id": {
+          "name": "issue_label_link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "issues_labels_link_issue_id_issues_issue_id_fk": {
+          "name": "issues_labels_link_issue_id_issues_issue_id_fk",
+          "tableFrom": "issues_labels_link",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_labels_link_label_id_labels_label_id_fk": {
+          "name": "issues_labels_link_label_id_labels_label_id_fk",
+          "tableFrom": "issues_labels_link",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "label_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_color": {
+          "name": "label_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_created_at": {
+          "name": "label_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_title": {
+          "name": "milestone_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_desc": {
+          "name": "milestone_desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_due_date": {
+          "name": "milestone_due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_status": {
+          "name": "milestone_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "milestone_created_at": {
+          "name": "milestone_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "milestone_updated_at": {
+          "name": "milestone_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_project_id_projects_project_id_fk": {
+          "name": "milestones_project_id_projects_project_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_title": {
+          "name": "notification_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_message": {
+          "name": "notification_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_read": {
+          "name": "notification_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "notification_link": {
+          "name": "notification_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_created_at": {
+          "name": "notification_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_user_id_fk": {
+          "name": "notifications_user_id_users_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_desc": {
+          "name": "project_desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_created_by": {
+          "name": "project_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_modified_by": {
+          "name": "project_modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_start_date": {
+          "name": "project_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_end_date": {
+          "name": "project_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_project_key_unique": {
+          "name": "projects_project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_title": {
+          "name": "task_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_completed": {
+          "name": "task_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "task_order": {
+          "name": "task_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "task_created_by": {
+          "name": "task_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_created_at": {
+          "name": "task_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "task_updated_at": {
+          "name": "task_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_issue_id_issues_issue_id_fk": {
+          "name": "tasks_issue_id_issues_issue_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_db_role": {
+          "name": "user_db_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_avatar_path": {
+          "name": "user_avatar_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "user_created_at": {
+          "name": "user_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_updated_at": {
+          "name": "user_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_projects_link": {
+      "name": "users_projects_link",
+      "schema": "",
+      "columns": {
+        "user_project_link_id": {
+          "name": "user_project_link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_projects_link_user_id_users_user_id_fk": {
+          "name": "users_projects_link_user_id_users_user_id_fk",
+          "tableFrom": "users_projects_link",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_projects_link_project_id_projects_project_id_fk": {
+          "name": "users_projects_link_project_id_projects_project_id_fk",
+          "tableFrom": "users_projects_link",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1780721022192,
+      "tag": "0000_tearful_ender_wiggin",
+      "breakpoints": true
+    }
+  ]
+}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -10,7 +10,8 @@ const config: ForgeConfig = {
     icon: 'build/icon',
     appBundleId: 'com.hydra.app',
     name: 'hydra',
-    executableName: 'hydra'
+    executableName: 'hydra',
+    extraResource: ['./drizzle']
   },
   makers: [
     new MakerSquirrel({

--- a/src/main/core/database/__testutils__/pgTestDb.test.ts
+++ b/src/main/core/database/__testutils__/pgTestDb.test.ts
@@ -1,0 +1,15 @@
+// src/main/core/database/__testutils__/pgTestDb.test.ts
+import { Client } from 'pg'
+import { describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from './pgTestDb'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('pgTestDb harness', () => {
+  it('creates and drops an isolated database', async () => {
+    const name = await createTestDatabase()
+    const client = new Client({ ...pgTestConfig(), database: name })
+    await client.connect() // DB가 실제로 존재함을 증명
+    await client.end()
+    await dropTestDatabase(name)
+    expect(name).toMatch(/^hydra_test_/)
+  })
+})

--- a/src/main/core/database/__testutils__/pgTestDb.ts
+++ b/src/main/core/database/__testutils__/pgTestDb.ts
@@ -1,0 +1,36 @@
+// src/main/core/database/__testutils__/pgTestDb.ts
+// 통합 테스트용 격리 데이터베이스 생성/삭제 헬퍼 (docker-compose Postgres 대상)
+
+import { Client } from 'pg'
+
+export function pgTestConfig() {
+  return {
+    host: process.env.DB_HOST ?? 'localhost',
+    port: Number(process.env.DB_PORT ?? 5432),
+    user: process.env.DB_USER ?? 'postgres',
+    password: process.env.DB_PASSWORD ?? 'postgres'
+  }
+}
+
+// 유지보수용 'postgres' DB에 접속해 고유 이름의 테스트 DB를 생성
+export async function createTestDatabase(): Promise<string> {
+  const name = `hydra_test_${Date.now()}_${Math.floor(Math.random() * 1_000_000)}`
+  const client = new Client({ ...pgTestConfig(), database: 'postgres' })
+  await client.connect()
+  try {
+    await client.query(`CREATE DATABASE "${name}"`)
+  } finally {
+    await client.end()
+  }
+  return name
+}
+
+export async function dropTestDatabase(name: string): Promise<void> {
+  const client = new Client({ ...pgTestConfig(), database: 'postgres' })
+  await client.connect()
+  try {
+    await client.query(`DROP DATABASE IF EXISTS "${name}" WITH (FORCE)`)
+  } finally {
+    await client.end()
+  }
+}

--- a/src/main/core/database/adapter/DatabaseAdapter.ts
+++ b/src/main/core/database/adapter/DatabaseAdapter.ts
@@ -16,6 +16,6 @@ export interface DatabaseAdapter {
   getConnection(): unknown
   createRole(roleName: string, password: string): Promise<void>
   dropRole(roleName: string): Promise<void>
-  runMigrations(): Promise<void>
+  runMigrations(migrationsFolder: string): Promise<void>
   transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T>
 }

--- a/src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
+++ b/src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'node:path'
+import { sql } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from '../__testutils__/pgTestDb'
+import { PostgresAdapter } from './PostgresAdapter'
+
+const migrationsFolder = resolve(process.cwd(), 'drizzle')
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('PostgresAdapter.runMigrations', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  })
+
+  it('creates all application tables', async () => {
+    await adapter.runMigrations(migrationsFolder)
+    const db = adapter.getConnection()
+    const res = await db.execute(
+      sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
+    )
+    const names = res.rows.map((r) => r.table_name as string)
+    expect(names).toEqual(expect.arrayContaining(['users', 'projects', 'issues', 'comments', 'notifications']))
+  })
+
+  it('is idempotent on a second run', async () => {
+    await expect(adapter.runMigrations(migrationsFolder)).resolves.not.toThrow()
+  })
+})

--- a/src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
+++ b/src/main/core/database/adapter/PostgresAdapter.migrate.test.ts
@@ -24,9 +24,7 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('PostgresAdapter.runMigrations'
   it('creates all application tables', async () => {
     await adapter.runMigrations(migrationsFolder)
     const db = adapter.getConnection()
-    const res = await db.execute(
-      sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
-    )
+    const res = await db.execute(sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`)
     const names = res.rows.map((r) => r.table_name as string)
     expect(names).toEqual(expect.arrayContaining(['users', 'projects', 'issues', 'comments', 'notifications']))
   })

--- a/src/main/core/database/adapter/PostgresAdapter.ts
+++ b/src/main/core/database/adapter/PostgresAdapter.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import { sql } from 'drizzle-orm'
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import { drizzle } from 'drizzle-orm/node-postgres'
+import { migrate } from 'drizzle-orm/node-postgres/migrator'
 import { Pool } from 'pg'
 import { DatabaseError } from '@/error/DatabaseError'
 import { ErrorCode } from '@/interface/CoreInterface'
@@ -142,8 +143,11 @@ export class PostgresAdapter implements DatabaseAdapter {
     await this.db.execute(sql.raw(`DROP ROLE IF EXISTS "${escapedRole}"`))
   }
 
-  async runMigrations(): Promise<void> {
-    console.log('Migrations: use drizzle-kit push')
+  async runMigrations(migrationsFolder: string): Promise<void> {
+    if (!this.db) {
+      throw new Error('Database not connected. Call connect() first.')
+    }
+    await migrate(this.db, { migrationsFolder })
   }
 
   async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {

--- a/src/main/core/database/migrate/migrationsPath.ts
+++ b/src/main/core/database/migrate/migrationsPath.ts
@@ -1,0 +1,12 @@
+// 마이그레이션 SQL 폴더 경로 해석 (dev: 레포 루트, packaged: resources)
+// 주의: 이 모듈은 메인 프로세스 런타임에서만 import 한다 (electron 의존성, 테스트에서 import 금지)
+
+import { join, resolve } from 'node:path'
+import { app } from 'electron'
+
+export function getMigrationsFolder(): string {
+  if (app.isPackaged) {
+    return join(process.resourcesPath, 'drizzle')
+  }
+  return resolve(process.cwd(), 'drizzle')
+}

--- a/src/main/core/database/repository/drizzle/DrizzleProjectRepository.ts
+++ b/src/main/core/database/repository/drizzle/DrizzleProjectRepository.ts
@@ -9,14 +9,17 @@ import type {
   ProjectRepository,
   UpdateProjectData
 } from '../interfaces/ProjectRepository'
+import type { RepoExecutor } from '../interfaces/RepoExecutor'
+import type { DrizzleExecutor } from './executor'
 
 const { projects, usersProjectsLink } = schema
 
 export class DrizzleProjectRepository implements ProjectRepository {
   constructor(private db: NodePgDatabase<typeof schema>) {}
 
-  async create(data: CreateProjectData): Promise<ProjectRecord> {
-    const rows = await this.db
+  async create(data: CreateProjectData, executor: RepoExecutor = this.db): Promise<ProjectRecord> {
+    const ex = executor as DrizzleExecutor
+    const rows = await ex
       .insert(projects)
       .values({
         project_id: data.projectId,
@@ -76,8 +79,9 @@ export class DrizzleProjectRepository implements ProjectRepository {
     return true
   }
 
-  async linkUser(linkId: string, userId: string, projectId: string): Promise<void> {
-    await this.db.insert(usersProjectsLink).values({
+  async linkUser(linkId: string, userId: string, projectId: string, executor: RepoExecutor = this.db): Promise<void> {
+    const ex = executor as DrizzleExecutor
+    await ex.insert(usersProjectsLink).values({
       user_project_link_id: linkId,
       user_id: userId,
       project_id: projectId

--- a/src/main/core/database/repository/drizzle/executor.ts
+++ b/src/main/core/database/repository/drizzle/executor.ts
@@ -1,0 +1,7 @@
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
+import type * as schema from '../../schema/drizzle/schema'
+
+export type DrizzleDb = NodePgDatabase<typeof schema>
+// tx 핸들 타입을 transaction 콜백 인자에서 직접 추출 (drizzle 내부 제네릭에 의존하지 않음)
+export type DrizzleTx = Parameters<Parameters<DrizzleDb['transaction']>[0]>[0]
+export type DrizzleExecutor = DrizzleDb | DrizzleTx

--- a/src/main/core/database/repository/interfaces/ProjectRepository.ts
+++ b/src/main/core/database/repository/interfaces/ProjectRepository.ts
@@ -1,5 +1,7 @@
 // 프로젝트 리포지토리 인터페이스
 
+import type { RepoExecutor } from './RepoExecutor'
+
 export interface CreateProjectData {
   projectId: string
   projectName: string
@@ -30,13 +32,13 @@ export interface ProjectRecord {
 }
 
 export interface ProjectRepository {
-  create(data: CreateProjectData): Promise<ProjectRecord>
+  create(data: CreateProjectData, executor?: RepoExecutor): Promise<ProjectRecord>
   findAll(): Promise<ProjectRecord[]>
   findById(projectId: string): Promise<ProjectRecord | null>
   findByUserId(userId: string): Promise<ProjectRecord[]>
   update(projectId: string, data: UpdateProjectData): Promise<ProjectRecord>
   delete(projectId: string): Promise<boolean>
-  linkUser(linkId: string, userId: string, projectId: string): Promise<void>
+  linkUser(linkId: string, userId: string, projectId: string, executor?: RepoExecutor): Promise<void>
   unlinkUser(userId: string, projectId: string): Promise<void>
   countByCreator(userId: string): Promise<number>
   countByName(name: string): Promise<number>

--- a/src/main/core/database/repository/interfaces/RepoExecutor.ts
+++ b/src/main/core/database/repository/interfaces/RepoExecutor.ts
@@ -1,0 +1,2 @@
+// 리포지토리 쓰기에 주입할 수 있는 실행 핸들 (db 또는 트랜잭션). 구현체가 구체 타입으로 좁힌다.
+export type RepoExecutor = unknown

--- a/src/main/core/database/transaction.atomicity.test.ts
+++ b/src/main/core/database/transaction.atomicity.test.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PostgresAdapter } from './adapter/PostgresAdapter'
+import { DrizzleProjectRepository } from './repository/drizzle/DrizzleProjectRepository'
+import * as schema from './schema/drizzle/schema'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from './__testutils__/pgTestDb'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('transaction atomicity', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+    await adapter.runMigrations(resolve(process.cwd(), 'drizzle'))
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  })
+
+  it('rolls back the project insert when a later write throws', async () => {
+    const db = adapter.getConnection()
+    const repo = new DrizzleProjectRepository(db)
+
+    const userId = randomUUID()
+    await db.insert(schema.users).values({ user_id: userId, user_name: 'tester', user_role: 'admin' })
+
+    const projectId = randomUUID()
+    await expect(
+      adapter.transaction(async (tx) => {
+        await repo.create(
+          { projectId, projectName: 'P', projectKey: 'P1', createdBy: userId, startDate: new Date(), endDate: new Date() },
+          tx
+        )
+        throw new Error('boom') // insert 이후 강제 롤백
+      })
+    ).rejects.toThrow('boom')
+
+    const found = await db.select().from(schema.projects).where(eq(schema.projects.project_id, projectId))
+    expect(found).toHaveLength(0)
+  })
+})

--- a/src/main/core/database/transaction.atomicity.test.ts
+++ b/src/main/core/database/transaction.atomicity.test.ts
@@ -2,10 +2,10 @@ import { randomUUID } from 'node:crypto'
 import { resolve } from 'node:path'
 import { eq } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from './__testutils__/pgTestDb'
 import { PostgresAdapter } from './adapter/PostgresAdapter'
 import { DrizzleProjectRepository } from './repository/drizzle/DrizzleProjectRepository'
 import * as schema from './schema/drizzle/schema'
-import { createTestDatabase, dropTestDatabase, pgTestConfig } from './__testutils__/pgTestDb'
 
 describe.runIf(process.env.RUN_DB_TESTS === '1')('transaction atomicity', () => {
   let adapter: PostgresAdapter
@@ -34,7 +34,14 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('transaction atomicity', () => 
     await expect(
       adapter.transaction(async (tx) => {
         await repo.create(
-          { projectId, projectName: 'P', projectKey: 'P1', createdBy: userId, startDate: new Date(), endDate: new Date() },
+          {
+            projectId,
+            projectName: 'P',
+            projectKey: 'P1',
+            createdBy: userId,
+            startDate: new Date(),
+            endDate: new Date()
+          },
           tx
         )
         throw new Error('boom') // insert 이후 강제 롤백

--- a/src/main/handler/projects/CreateProjectHandler.ts
+++ b/src/main/handler/projects/CreateProjectHandler.ts
@@ -17,19 +17,22 @@ export class CreateProjectHandler extends CoreBaseHandler<IpcChannel.PROJECT_CRE
     const projectId = CoreUtil.getUuid()
 
     try {
-      const project = await this.repos.db.transaction(async () => {
-        const project = await this.repos.projects.create({
-          projectId,
-          projectName: params.projectName,
-          projectKey: params.projectKey,
-          projectDesc: params.projectDesc,
-          createdBy: params.userId,
-          startDate: new Date(),
-          endDate: new Date()
-        })
+      const project = await this.repos.db.transaction(async (tx) => {
+        const project = await this.repos.projects.create(
+          {
+            projectId,
+            projectName: params.projectName,
+            projectKey: params.projectKey,
+            projectDesc: params.projectDesc,
+            createdBy: params.userId,
+            startDate: new Date(),
+            endDate: new Date()
+          },
+          tx
+        )
 
-        // 사용자-프로젝트 연결 생성
-        await this.repos.projects.linkUser(CoreUtil.getUuid(), params.userId, project.project_id)
+        // 사용자-프로젝트 연결 생성 (동일 트랜잭션)
+        await this.repos.projects.linkUser(CoreUtil.getUuid(), params.userId, project.project_id, tx)
 
         return project
       })

--- a/src/main/handler/workspace/ConnectWorkspaceHandler.ts
+++ b/src/main/handler/workspace/ConnectWorkspaceHandler.ts
@@ -1,6 +1,7 @@
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
 import { PostgresAdapter } from '@/database/adapter/PostgresAdapter'
+import { getMigrationsFolder } from '@/database/migrate/migrationsPath'
 import { RepositoryContainer } from '@/database/RepositoryContainer'
 import {
   DrizzleCommentRepository,
@@ -43,6 +44,9 @@ export class ConnectWorkspaceHandler extends CoreBaseHandler<IpcChannel.WORKSPAC
       password: params.password,
       sslCertPath: params.sslCertPath
     })
+
+    // 스키마를 최신 마이그레이션으로 적용 (멱등)
+    await adapter.runMigrations(getMigrationsFolder())
 
     const db = adapter.getConnection() as NodePgDatabase<typeof schema>
     const userRepo = new DrizzleUserRepository(db)


### PR DESCRIPTION
## Summary

MySQL 다중 DBMS 지원 스펙의 **Phase 1 (Foundation)** 구현. Postgres 전용 기반 작업이며 사용자 동작 변화는 없습니다.

- **실제 버전드 마이그레이터**: `drizzle-kit generate`로 15개 테이블 SQL 생성(`drizzle/`), `PostgresAdapter.runMigrations()`를 `drizzle-orm/node-postgres/migrator`의 `migrate()`로 구현. 연결 시 `ConnectWorkspaceHandler`에서 멱등 실행. 패키징 빌드에 `drizzle/` 포함(`extraResource`).
- **트랜잭션 원자성 버그 수정**: `CreateProjectHandler`가 `tx`를 무시하고 풀 `db`로 쓰던 문제 수정. 리포지토리 쓰기에 선택적 `executor` 인자를 추가해 `create`/`linkUser`가 동일 트랜잭션에서 실행되도록 함 (`RepoExecutor`/`DrizzleExecutor` 타입 도입).
- **DB 통합 테스트 하니스 + CI**: 격리 Postgres DB 생성/삭제 헬퍼(`pgTestDb`), 마이그레이터/원자성 통합 테스트(`RUN_DB_TESTS=1` 게이트), CI에 Postgres 16 서비스 추가.

스펙 `docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md` §8.1·§10·§11 / §12 Phase 1 범위. MySQL 어댑터는 Phase 4 예정.

## Test Plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:ci` — 0 errors
- [x] `pnpm test` — 19 passed, 4 skipped (DB-gated)
- [x] `pnpm build` — success
- [x] CI Postgres job에서 `RUN_DB_TESTS=1` 통합 테스트 실제 PASS 확인 (마이그레이터 테이블 생성·멱등성, 트랜잭션 롤백)

🤖 Generated with [Claude Code](https://claude.com/claude-code)