### PR TITLE
feat: Phase 3 — 인증 재설계 (로그인/세션/scrypt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ out
 
 # Prisma
 src/main/core/database/prisma/generated
+
+# Superpowers brainstorm artifacts
+.superpowers

--- a/docs/superpowers/plans/2026-06-10-phase3-auth-redesign.md
+++ b/docs/superpowers/plans/2026-06-10-phase3-auth-redesign.md
@@ -1,0 +1,1714 @@
+# Phase 3 — Authentication Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace "DB connection = authentication" with a real per-user local login (username + scrypt password + session) layered on top of the shared workspace connection, including a first-admin setup flow, member onboarding without PostgreSQL ROLEs, and a split brand-panel auth UI that becomes the app's UX baseline.
+
+**Architecture:** Three isolated concerns. (1) **Auth core** (`src/main/core/auth/`): pure, unit-testable password hashing, identifier normalization, and session-record TTL logic. (2) **Auth data + flow**: new `users` columns + migration, repository lookups, IPC handlers (login / setup-admin / logout / session-status), and an advisory-lock-guarded first-admin seed; `ConnectWorkspaceHandler` stops auto-creating an admin and instead reports whether setup is needed; `createRole`/`dropRole` are removed. (3) **Auth UI** (renderer): a session layer in the auth store, `/login` + `/setup` routes with a reworked guard, and `LoginPage` + `AdminSetupPage` in a split brand-panel layout. PostgreSQL-only (MySQL is Phase 4).
+
+**Tech Stack:** Electron + TypeScript, Node `crypto.scrypt`, Electron `safeStorage`, Drizzle ORM + `pg`, drizzle-kit, TanStack Router, Zustand, shadcn/ui + Tailwind, Vitest.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-10-phase3-auth-redesign-design.md` (and parent `2026-06-06-mysql-support-and-auth-redesign-design.md` §5/§6/§8/§9/§11).
+
+> **Commit convention:** Korean Conventional Commits (`feat:`/`fix:`/`refactor:`/`test:`/`docs:`/`chore:`/`style:`). End every commit message body with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer (omitted below for brevity).
+
+> **Environment:** Windows + PowerShell. Git prints harmless `LF will be replaced by CRLF` warnings — ignore. **Only `git add` the specific paths each task lists** — never `git add -A`/`.` (working tree carries unrelated CRLF noise). CI runs `pnpm lint:ci` = `biome check .` (strict, no auto-fix) and treats **formatter mismatches as errors** — after editing, run `pnpm exec biome check <files>` and commit any format result. DB-gated tests run only with `RUN_DB_TESTS=1` + a reachable Postgres (`pnpm docker:up`); they skip otherwise.
+
+---
+
+## Design decisions baked into this plan
+
+- **Pre-release → clean schema.** New `users` columns are `NOT NULL`/`UNIQUE`; the migration is a plain `ALTER TABLE ADD COLUMN` applied to a fresh/empty `users` table. Dev DBs must be reset (`docker volume rm`) before manual testing because `ADD COLUMN ... NOT NULL` fails on a table with rows (the old auto-admin row).
+- **Login identifier = `user_sn`** (separate username), normalized `trim().toLowerCase()` at insert and lookup. `user_email` also normalized.
+- **No forced first-login change; session = 1 day, remember-me = 30 days.**
+- **`user_db_role` kept but deprecated** (no read/write); `createRole`/`dropRole` removed. Drop column is Phase 5.
+- **Password hash never leaves main:** auth IPC responses return `SafeUser = Omit<UserRecord,'user_password_hash'>`.
+- **First-admin seed race** guarded by `pg_advisory_xact_lock` inside a transaction (transaction-scoped lock auto-releases; avoids the pooled-connection footgun of session-scoped `pg_advisory_lock`).
+
+---
+
+## Execution prerequisites & ordering
+
+- **Tasks are strictly sequential.** Task N's new types/files/aliases exist by the time Task N+1 runs (e.g. `SafeUser` from Task 5, the `AUTH_*` channels from Task 6, and the `@/auth` alias from Task 7 Step 1 are all in place before any later task imports them). Do not reorder.
+- **Phase 1/2 artifacts already exist and are reused** (verify if unsure): `src/main/core/database/repository/drizzle/executor.ts` (exports `DrizzleDb`, `DrizzleExecutor`, `DrizzleTx`), `repository/interfaces/RepoExecutor.ts` (`RepoExecutor`), `repository/drizzle/readAfterWrite.ts` (`selectById`), and `database/__testutils__/pgTestDb.ts` (`createTestDatabase`/`dropTestDatabase`/`pgTestConfig`).
+- **The `@/auth` alias (Task 7 Step 1) must be added before any `@/auth/*` import is typechecked.** It is the first step of Task 7 for this reason.
+- After editing any file, run `pnpm exec biome check <files>` (CI uses strict `biome check`; a formatter mismatch fails CI even if local `pnpm lint` auto-fixed your working tree).
+
+---
+
+## File Structure
+
+**Created (main):**
+- `src/main/core/auth/password.ts` — `hashPassword` / `verifyPassword` (scrypt, self-describing string).
+- `src/main/core/auth/password.test.ts` — unit tests.
+- `src/main/core/auth/normalize.ts` — `normalizeHandle`.
+- `src/main/core/auth/normalize.test.ts` — unit tests.
+- `src/main/core/auth/session.ts` — pure session-record + TTL (`createSessionRecord`, `isExpired`, `SESSION_TTL_MS`).
+- `src/main/core/auth/session.test.ts` — unit tests.
+- `src/main/core/auth/SessionManager.ts` — safeStorage persistence (singleton, mirrors `WorkspaceManager`).
+- `src/main/handler/auth/LoginHandler.ts`, `SetupAdminHandler.ts`, `LogoutHandler.ts`, `SessionStatusHandler.ts`.
+- `src/main/core/auth/auth.integration.test.ts` — DB-gated integration tests.
+
+**Created (renderer):**
+- `src/renderer/src/components/pages/LoginPage.tsx`
+- `src/renderer/src/components/pages/AdminSetupPage.tsx`
+- `src/renderer/src/components/templates/AuthLayout.tsx` — shared split brand-panel shell.
+
+**Modified (main):**
+- `schema/drizzle/schema.ts` (users columns) → migration `drizzle/0002_*.sql`.
+- `repository/interfaces/UserRepository.ts`, `repository/drizzle/DrizzleUserRepository.ts`.
+- `adapter/PostgresAdapter.ts`, `adapter/DatabaseAdapter.ts` (remove createRole/dropRole).
+- `interface/ipc.ts` (channels + payloads + `WorkspaceStatusResponse`), `interface/types/auth.ts`, `interface/types/workspace.ts`.
+- `handler/workspace/ConnectWorkspaceHandler.ts`, `handler/workspace/WorkspaceStatusHandler.ts`.
+- `handler/auth/CreateMemberHandler.ts`, `DeleteUserHandler.ts`, `UpdateUserHandler.ts`, `ListUsersHandler.ts`, `index.ts` (UpdateUser/ListUsers gain `toSafeUser` so the password hash never crosses IPC).
+- `electron.vite.config.ts` + `tsconfig.node.json` (`@/auth` alias).
+
+**Modified (renderer):**
+- `stores/auth.ts`, `types/auth.ts`, `routers/routes.tsx`, `routers/routerContext.ts` (+ wherever the router context is built), `components/pages/WorkspacePage.tsx`, `components/pages/MembersPage.tsx`, and `locales/` (new `auth` namespace + a `member` validation/label key).
+
+---
+
+## Task 1: Auth core — password hashing (scrypt)
+
+**Files:**
+- Create: `src/main/core/auth/password.ts`
+- Test: `src/main/core/auth/password.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/main/core/auth/password.test.ts
+import { describe, expect, it } from 'vitest'
+import { hashPassword, verifyPassword } from './password'
+
+describe('password hashing', () => {
+  it('produces a self-describing scrypt string', async () => {
+    const encoded = await hashPassword('correct horse battery staple')
+    expect(encoded).toMatch(/^scrypt\$N=32768,r=8,p=1\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+$/)
+  })
+
+  it('verifies the correct password', async () => {
+    const encoded = await hashPassword('hunter2')
+    expect(await verifyPassword('hunter2', encoded)).toBe(true)
+  })
+
+  it('rejects a wrong password', async () => {
+    const encoded = await hashPassword('hunter2')
+    expect(await verifyPassword('hunter3', encoded)).toBe(false)
+  })
+
+  it('uses a random salt (two hashes of same input differ)', async () => {
+    const a = await hashPassword('same')
+    const b = await hashPassword('same')
+    expect(a).not.toBe(b)
+    expect(await verifyPassword('same', a)).toBe(true)
+    expect(await verifyPassword('same', b)).toBe(true)
+  })
+
+  it('returns false on a malformed stored hash instead of throwing', async () => {
+    expect(await verifyPassword('x', 'not-a-valid-hash')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test -- src/main/core/auth/password.test.ts`
+Expected: FAIL (module `./password` not found).
+
+- [ ] **Step 3: Implement `password.ts`**
+
+```ts
+// src/main/core/auth/password.ts
+// scrypt 비밀번호 해싱. 파라미터를 해시 문자열에 함께 저장해 향후 진화 가능.
+// 형식: scrypt$N=32768,r=8,p=1$<saltB64>$<hashB64>
+
+import { randomBytes, scrypt as scryptCb, timingSafeEqual } from 'node:crypto'
+import { promisify } from 'node:util'
+
+const scrypt = promisify(scryptCb)
+
+const N = 32768 // 2^15
+const R = 8
+const P = 1
+const KEYLEN = 64
+// 메모리 ≈ 128*N*r ≈ 33.5MiB > Node 기본 maxmem(32MiB) → 명시적 maxmem 필수
+const MAXMEM = 64 * 1024 * 1024
+
+export async function hashPassword(plain: string): Promise<string> {
+  const salt = randomBytes(16)
+  const derived = (await scrypt(plain, salt, KEYLEN, { N, r: R, p: P, maxmem: MAXMEM })) as Buffer
+  return `scrypt$N=${N},r=${R},p=${P}$${salt.toString('base64')}$${derived.toString('base64')}`
+}
+
+export async function verifyPassword(plain: string, encoded: string): Promise<boolean> {
+  try {
+    const parts = encoded.split('$')
+    if (parts.length !== 4 || parts[0] !== 'scrypt') return false
+    const params = Object.fromEntries(parts[1].split(',').map((kv) => kv.split('=')))
+    const n = Number(params.N)
+    const r = Number(params.r)
+    const p = Number(params.p)
+    if (!n || !r || !p) return false
+    const salt = Buffer.from(parts[2], 'base64')
+    const expected = Buffer.from(parts[3], 'base64')
+    const derived = (await scrypt(plain, salt, expected.length, { N: n, r, p, maxmem: MAXMEM })) as Buffer
+    return derived.length === expected.length && timingSafeEqual(derived, expected)
+  } catch {
+    return false
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm test -- src/main/core/auth/password.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck + lint the new files**
+
+Run: `pnpm typecheck:node` (no errors) and `pnpm exec biome check src/main/core/auth/` (no errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/core/auth/password.ts src/main/core/auth/password.test.ts
+git commit -m "feat: scrypt 비밀번호 해싱 모듈 추가 (자기기술 형식)"
+```
+
+---
+
+## Task 2: Auth core — normalize + session record
+
+**Files:**
+- Create: `src/main/core/auth/normalize.ts`, `src/main/core/auth/session.ts`
+- Test: `src/main/core/auth/normalize.test.ts`, `src/main/core/auth/session.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/main/core/auth/normalize.test.ts
+import { describe, expect, it } from 'vitest'
+import { normalizeHandle } from './normalize'
+
+describe('normalizeHandle', () => {
+  it('trims and lowercases', () => {
+    expect(normalizeHandle('  JuJoyCode ')).toBe('jujoycode')
+    expect(normalizeHandle('A@B.COM')).toBe('a@b.com')
+  })
+})
+```
+
+```ts
+// src/main/core/auth/session.test.ts
+import { describe, expect, it } from 'vitest'
+import { createSessionRecord, isExpired, SESSION_TTL_MS } from './session'
+
+const user = { user_id: 'u1', user_sn: 'admin' }
+const NOW = 1_700_000_000_000
+
+describe('session record', () => {
+  it('default TTL is 1 day', () => {
+    const s = createSessionRecord(user, false, NOW)
+    expect(s.expiresAt - s.issuedAt).toBe(SESSION_TTL_MS.default)
+    expect(SESSION_TTL_MS.default).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('remember-me TTL is 30 days', () => {
+    const s = createSessionRecord(user, true, NOW)
+    expect(s.expiresAt - s.issuedAt).toBe(SESSION_TTL_MS.remember)
+    expect(SESSION_TTL_MS.remember).toBe(30 * 24 * 60 * 60 * 1000)
+  })
+
+  it('carries userId + userSn', () => {
+    const s = createSessionRecord(user, false, NOW)
+    expect(s.userId).toBe('u1')
+    expect(s.userSn).toBe('admin')
+  })
+
+  it('isExpired compares against now', () => {
+    const s = createSessionRecord(user, false, NOW)
+    expect(isExpired(s, NOW + 1000)).toBe(false)
+    expect(isExpired(s, s.expiresAt + 1)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm test -- src/main/core/auth/normalize.test.ts src/main/core/auth/session.test.ts`
+Expected: FAIL (modules not found).
+
+- [ ] **Step 3: Implement `normalize.ts`**
+
+```ts
+// src/main/core/auth/normalize.ts
+// 로그인 핸들/이메일 정규화 — insert 와 lookup 양쪽에서 동일하게 적용한다.
+export function normalizeHandle(value: string): string {
+  return value.trim().toLowerCase()
+}
+```
+
+- [ ] **Step 4: Implement `session.ts`**
+
+```ts
+// src/main/core/auth/session.ts
+// 세션 레코드(순수 로직). 영속화는 SessionManager가 담당한다.
+
+export interface SessionRecord {
+  userId: string
+  userSn: string
+  issuedAt: number
+  expiresAt: number
+}
+
+const DAY = 24 * 60 * 60 * 1000
+export const SESSION_TTL_MS = { default: DAY, remember: 30 * DAY } as const
+
+export function createSessionRecord(
+  user: { user_id: string; user_sn: string },
+  rememberMe: boolean,
+  now: number
+): SessionRecord {
+  const ttl = rememberMe ? SESSION_TTL_MS.remember : SESSION_TTL_MS.default
+  return { userId: user.user_id, userSn: user.user_sn, issuedAt: now, expiresAt: now + ttl }
+}
+
+export function isExpired(session: SessionRecord, now: number): boolean {
+  return now >= session.expiresAt
+}
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `pnpm test -- src/main/core/auth/normalize.test.ts src/main/core/auth/session.test.ts`
+Expected: PASS (1 + 4 tests).
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `pnpm typecheck:node`
+```bash
+git add src/main/core/auth/normalize.ts src/main/core/auth/normalize.test.ts src/main/core/auth/session.ts src/main/core/auth/session.test.ts
+git commit -m "feat: 핸들 정규화 + 세션 레코드(TTL) 코어 추가"
+```
+
+---
+
+## Task 3: Auth core — SessionManager (safeStorage persistence)
+
+**Files:**
+- Create: `src/main/core/auth/SessionManager.ts`
+
+Mirrors `WorkspaceManager` (encrypt with `safeStorage` when available, plaintext fallback; file under `app.getPath('userData')`).
+
+- [ ] **Step 1: Implement `SessionManager.ts`**
+
+```ts
+// src/main/core/auth/SessionManager.ts
+// 세션 레코드를 safeStorage로 암호화해 userData/session.json 에 영속화 (WorkspaceManager 패턴).
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { app, safeStorage } from 'electron'
+import type { SessionRecord } from './session'
+
+export class SessionManager {
+  private static instance: SessionManager | null = null
+  private storePath: string
+
+  private constructor() {
+    this.storePath = join(app.getPath('userData'), 'session.json')
+  }
+
+  static getInstance(): SessionManager {
+    if (!SessionManager.instance) {
+      SessionManager.instance = new SessionManager()
+    }
+    return SessionManager.instance
+  }
+
+  load(): SessionRecord | null {
+    if (!existsSync(this.storePath)) return null
+    try {
+      const raw = readFileSync(this.storePath)
+      const json = safeStorage.isEncryptionAvailable() ? safeStorage.decryptString(raw) : raw.toString('utf-8')
+      return JSON.parse(json) as SessionRecord
+    } catch {
+      return null
+    }
+  }
+
+  save(session: SessionRecord): void {
+    const json = JSON.stringify(session)
+    if (safeStorage.isEncryptionAvailable()) {
+      writeFileSync(this.storePath, safeStorage.encryptString(json))
+    } else {
+      writeFileSync(this.storePath, json, 'utf-8')
+    }
+  }
+
+  clear(): void {
+    if (existsSync(this.storePath)) rmSync(this.storePath)
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck + lint + commit**
+
+Run: `pnpm typecheck:node` and `pnpm exec biome check src/main/core/auth/`
+```bash
+git add src/main/core/auth/SessionManager.ts
+git commit -m "feat: SessionManager — safeStorage 기반 세션 영속화"
+```
+
+(No unit test: this is thin I/O over Electron `safeStorage`; its behavior is exercised by the Task 8 integration path and the pure logic lives in `session.ts`. `load()` returns `null` on a missing or corrupted file — treated as "no session" / re-authenticate, a deliberate fail-closed default.)
+
+---
+
+## Task 4: Schema — `users` auth columns + migration 0002
+
+**Files:**
+- Modify: `src/main/core/database/schema/drizzle/schema.ts` (users table, lines 6-15)
+- Create (tooling): `drizzle/0002_*.sql` + updated `drizzle/meta/`
+
+- [ ] **Step 1: Add the columns to the `users` table**
+
+Replace the current `users` definition with (keep `user_db_role`, add the three new columns):
+
+```ts
+export const users = pgTable('users', {
+  user_id: uuid('user_id').primaryKey(),
+  user_sn: varchar('user_sn', { length: 255 }).notNull().unique(),
+  user_password_hash: varchar('user_password_hash', { length: 255 }).notNull(),
+  user_status: varchar('user_status', { length: 20 }).default('active'),
+  user_name: varchar('user_name', { length: 255 }),
+  user_email: varchar('user_email', { length: 255 }),
+  user_db_role: varchar('user_db_role', { length: 255 }),
+  user_avatar_path: varchar('user_avatar_path', { length: 1024 }),
+  user_role: varchar('user_role', { length: 50 }).default('member'),
+  user_created_at: timestamp('user_created_at'),
+  user_updated_at: timestamp('user_updated_at')
+})
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `pnpm db:generate`
+Expected: a new `drizzle/0002_<name>.sql` with `ALTER TABLE "users" ADD COLUMN ...` for `user_sn`, `user_password_hash`, `user_status` (plus the unique constraint on `user_sn`), and updated `drizzle/meta/`. No `CREATE TABLE`.
+
+- [ ] **Step 3: Verify the migration content**
+
+Run (PowerShell):
+```powershell
+Select-String -Path drizzle/0002_*.sql -Pattern 'ADD COLUMN' | Measure-Object | Select-Object -ExpandProperty Count
+Select-String -Path drizzle/0002_*.sql -Pattern 'CREATE TABLE' | Measure-Object | Select-Object -ExpandProperty Count
+```
+Expected: first ≥ 3, second 0.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm typecheck:node` (will show errors in `DrizzleUserRepository`/handlers until Tasks 5-7 — that's expected; confirm the only errors are about the new columns / missing fields, not schema syntax). If the schema file itself has a syntax error, fix it before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/core/database/schema/drizzle/schema.ts drizzle/
+git commit -m "feat: users 인증 컬럼(user_sn/password_hash/status) + 마이그레이션 0002"
+```
+
+---
+
+## Task 5: Repository — auth-aware UserRepository
+
+**Files:**
+- Modify: `src/main/core/database/repository/interfaces/UserRepository.ts`
+- Modify: `src/main/core/database/repository/drizzle/DrizzleUserRepository.ts`
+
+- [ ] **Step 1: Update the interface types**
+
+In `UserRepository.ts`, update `UserRecord`, `CreateUserData`, and the interface:
+
+```ts
+import type { RepoExecutor } from './RepoExecutor'
+
+export interface UserRecord {
+  user_id: string
+  user_sn: string
+  user_password_hash: string
+  user_status: string | null
+  user_name: string | null
+  user_email: string | null
+  user_db_role: string | null
+  user_avatar_path: string | null
+  user_role: 'admin' | 'member'
+  user_created_at: Date | null
+  user_updated_at: Date | null
+}
+
+// 비밀번호 해시를 제외한, 렌더러로 보낼 수 있는 안전한 사용자 형태
+export type SafeUser = Omit<UserRecord, 'user_password_hash'>
+
+export interface CreateUserData {
+  userId: string
+  userSn: string
+  passwordHash: string
+  userName?: string | null
+  userEmail?: string | null
+  userRole?: 'admin' | 'member'
+  userStatus?: string
+  userAvatarPath?: string | null
+}
+
+export interface UpdateUserData {
+  userName?: string
+  userEmail?: string
+  userAvatarPath?: string | null
+  userStatus?: string
+}
+
+export interface UserRepository {
+  findById(userId: string): Promise<UserRecord | null>
+  findBySn(userSn: string): Promise<UserRecord | null>
+  findAll(): Promise<UserRecord[]>
+  create(data: CreateUserData, executor?: RepoExecutor): Promise<UserRecord>
+  update(userId: string, data: UpdateUserData): Promise<UserRecord>
+  delete(userId: string): Promise<boolean>
+  count(executor?: RepoExecutor): Promise<number>
+}
+```
+
+(Removed `findByDbRole`; `userDbRole` no longer part of `CreateUserData`. `findByDbRole` callers are removed in Task 7.)
+
+- [ ] **Step 2: Update `DrizzleUserRepository`**
+
+```ts
+// Drizzle 기반 사용자 리포지토리 구현
+
+import { eq, sql } from 'drizzle-orm'
+import * as schema from '../../schema/drizzle/schema'
+import type { CreateUserData, UpdateUserData, UserRecord, UserRepository } from '../interfaces/UserRepository'
+import type { RepoExecutor } from '../interfaces/RepoExecutor'
+import type { DrizzleDb, DrizzleExecutor } from './executor'
+import { selectById } from './readAfterWrite'
+
+const { users } = schema
+
+export class DrizzleUserRepository implements UserRepository {
+  constructor(private db: DrizzleDb) {}
+
+  async findById(userId: string): Promise<UserRecord | null> {
+    const rows = await this.db.select().from(users).where(eq(users.user_id, userId)).limit(1)
+    return (rows[0] as UserRecord) ?? null
+  }
+
+  async findBySn(userSn: string): Promise<UserRecord | null> {
+    const rows = await this.db.select().from(users).where(eq(users.user_sn, userSn)).limit(1)
+    return (rows[0] as UserRecord) ?? null
+  }
+
+  async findAll(): Promise<UserRecord[]> {
+    const rows = await this.db.select().from(users)
+    return rows as UserRecord[]
+  }
+
+  async create(data: CreateUserData, executor: RepoExecutor = this.db): Promise<UserRecord> {
+    const ex = executor as DrizzleExecutor
+    const now = new Date()
+    await ex.insert(users).values({
+      user_id: data.userId,
+      user_sn: data.userSn,
+      user_password_hash: data.passwordHash,
+      user_status: data.userStatus ?? 'active',
+      user_name: data.userName ?? null,
+      user_email: data.userEmail ?? null,
+      user_role: data.userRole ?? 'member',
+      user_avatar_path: data.userAvatarPath ?? null,
+      user_created_at: now,
+      user_updated_at: now
+    })
+    return selectById<UserRecord>(ex, users, users.user_id, data.userId)
+  }
+
+  async update(userId: string, data: UpdateUserData): Promise<UserRecord> {
+    const values: Record<string, unknown> = { user_updated_at: new Date() }
+    if (data.userName !== undefined) values.user_name = data.userName
+    if (data.userEmail !== undefined) values.user_email = data.userEmail
+    if (data.userAvatarPath !== undefined) values.user_avatar_path = data.userAvatarPath
+    if (data.userStatus !== undefined) values.user_status = data.userStatus
+
+    await this.db.update(users).set(values).where(eq(users.user_id, userId))
+    return selectById<UserRecord>(this.db, users, users.user_id, userId)
+  }
+
+  async delete(userId: string): Promise<boolean> {
+    await this.db.delete(users).where(eq(users.user_id, userId))
+    return true
+  }
+
+  async count(executor: RepoExecutor = this.db): Promise<number> {
+    const ex = executor as DrizzleExecutor
+    const rows = await ex.select({ count: sql<number>`count(*)` }).from(users)
+    return Number(rows[0].count)
+  }
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm typecheck:node`
+Expected: errors remain only in handlers that still reference `findByDbRole` / old `CreateUserData` (fixed in Task 7) and IPC types (Task 6). The repository file itself must be clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/core/database/repository/interfaces/UserRepository.ts src/main/core/database/repository/drizzle/DrizzleUserRepository.ts
+git commit -m "feat: UserRepository에 findBySn + 인증 컬럼 + 실행자(tx) 지원, findByDbRole 제거"
+```
+
+---
+
+## Task 6: IPC — channels, payloads, types
+
+**Files:**
+- Modify: `src/main/core/interface/ipc.ts`, `src/main/core/interface/types/auth.ts`, `src/main/core/interface/types/workspace.ts`
+
+- [ ] **Step 1: Add auth channels to `IpcChannel`**
+
+In `ipc.ts`, in the `// AUTH-` block of the `IpcChannel` enum, add:
+```ts
+  AUTH_LOGIN = 'authLogin',
+  AUTH_LOGOUT = 'authLogout',
+  AUTH_SETUP_ADMIN = 'authSetupAdmin',
+  AUTH_SESSION_STATUS = 'authSessionStatus',
+```
+
+- [ ] **Step 2: Update auth types**
+
+In `interface/types/auth.ts`:
+```ts
+import type { SafeUser, UserRecord } from '../../database/repository/interfaces/UserRepository'
+
+export type User = SafeUser
+
+export interface AuthDeleteUserParams {
+  id: string
+  shouldSoftDelete: boolean
+}
+
+export interface AuthUpdateUserParams {
+  userId: string
+  userName?: string
+  userAvatarKey?: string | null
+}
+
+// 관리자가 멤버를 만들 때 (ROLE 생성 없음, 초기 비밀번호 설정)
+export interface CreateMemberParams {
+  userSn: string
+  userName: string
+  userEmail: string
+  initialPassword: string
+  userRole?: 'admin' | 'member'
+}
+
+export interface LoginParams {
+  userSn: string
+  password: string
+  rememberMe?: boolean
+}
+
+export interface SetupAdminParams {
+  userSn: string
+  userName: string
+  userEmail?: string
+  password: string
+}
+
+export interface SessionStatusResponse {
+  authenticated: boolean
+  user: SafeUser | null
+}
+```
+
+(`User` now aliases `SafeUser` so the renderer never sees `user_password_hash`. `UserRecord` import kept for any consumer that needs the full row type server-side.)
+
+- [ ] **Step 3: Update `WorkspaceStatusResponse`**
+
+In `interface/types/workspace.ts`, replace:
+```ts
+export interface WorkspaceStatusResponse {
+  connected: boolean
+  needsSetup: boolean
+}
+```
+(Drops `user`/`isFirstLogin` — connect no longer authenticates a user.)
+
+- [ ] **Step 4: Wire payloads in `ipc.ts`**
+
+Add imports near the existing auth/workspace type imports:
+```ts
+import type {
+  AuthDeleteUserParams,
+  AuthUpdateUserParams,
+  CreateMemberParams,
+  LoginParams,
+  SessionStatusResponse,
+  SetupAdminParams
+} from './types/auth'
+```
+Add to the `// AUTH-` block of `IpcPayloads`:
+```ts
+  [IpcChannel.AUTH_LOGIN]: {
+    send: LoginParams
+    receive: BaseIpcResponse<SafeUser>
+  }
+  [IpcChannel.AUTH_LOGOUT]: {
+    send: undefined
+    receive: BaseIpcResponse<boolean>
+  }
+  [IpcChannel.AUTH_SETUP_ADMIN]: {
+    send: SetupAdminParams
+    receive: BaseIpcResponse<SafeUser>
+  }
+  [IpcChannel.AUTH_SESSION_STATUS]: {
+    send: undefined
+    receive: BaseIpcResponse<SessionStatusResponse>
+  }
+```
+Change `AUTH_CREATE_MEMBER` and `AUTH_UPDATE_USER` receive types from `UserRecord` to `SafeUser`. Add a `SafeUser` import to `ipc.ts`:
+```ts
+import type { SafeUser, UserRecord } from '../database/repository/interfaces/UserRepository'
+```
+(`UserRecord` import stays only if still referenced; if biome flags it as unused after switching auth payloads to `SafeUser`, drop it.) Update `AUTH_LIST_USERS` receive to `BaseIpcResponse<SafeUser[]>`.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm typecheck:node`
+Expected: errors now only in the handlers (Task 7) and renderer (Tasks 9-13). The interface files compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/core/interface/ipc.ts src/main/core/interface/types/auth.ts src/main/core/interface/types/workspace.ts
+git commit -m "feat: 인증 IPC 채널/페이로드 + SafeUser + WorkspaceStatusResponse 변경"
+```
+
+---
+
+## Task 7: Handlers — login / setup / logout / session + connect rework + member/delete
+
+**Files:**
+- Create: `src/main/handler/auth/LoginHandler.ts`, `SetupAdminHandler.ts`, `LogoutHandler.ts`, `SessionStatusHandler.ts`
+- Modify: `src/main/handler/auth/CreateMemberHandler.ts`, `DeleteUserHandler.ts`, `src/main/handler/auth/index.ts`
+- Modify: `src/main/handler/workspace/ConnectWorkspaceHandler.ts`, `WorkspaceStatusHandler.ts`
+- Modify: `src/main/core/database/adapter/PostgresAdapter.ts`, `adapter/DatabaseAdapter.ts`
+
+This task is the wiring core. Implement in this order. **Do Step 1 (the `@/auth` alias) FIRST** — every later step imports from `@/auth/*` and will fail to typecheck without it.
+
+- [ ] **Step 1: Add the `@/auth` path alias (do this before anything that imports `@/auth/*`)**
+
+In `electron.vite.config.ts`, in the **main** process `resolve.alias` object, add the `@/auth` entry alongside the existing ones (insert in the same style as the neighbors, e.g. right before `'@/base'`):
+```ts
+'@/auth': resolve('src/main/core/auth'),
+```
+In `tsconfig.node.json`, add the matching entry to `compilerOptions.paths`:
+```json
+"@/auth/*": ["src/main/core/auth/*"],
+```
+Read both files first to match their exact existing formatting. After this step, `@/auth/password`, `@/auth/normalize`, `@/auth/session`, `@/auth/SessionManager`, `@/auth/safeUser` all resolve.
+
+- [ ] **Step 2: Add a `toSafeUser` helper + advisory-lock constant**
+
+Create `src/main/core/auth/safeUser.ts`:
+```ts
+import type { SafeUser, UserRecord } from '@/database/repository/interfaces/UserRepository'
+
+// 비밀번호 해시를 제거해 렌더러로 안전하게 보낼 형태로 변환
+export function toSafeUser(user: UserRecord): SafeUser {
+  const { user_password_hash, ...safe } = user
+  return safe
+}
+
+// 첫 관리자 시드 임계구역을 보호하는 advisory lock 키 (트랜잭션 스코프)
+export const FIRST_ADMIN_LOCK_KEY = 481975
+```
+
+- [ ] **Step 3: Remove `createRole`/`dropRole` from the adapter**
+
+In `adapter/DatabaseAdapter.ts`, delete the two interface lines:
+```ts
+  createRole(roleName: string, password: string): Promise<void>
+  dropRole(roleName: string): Promise<void>
+```
+In `adapter/PostgresAdapter.ts`, delete the `createRole` and `dropRole` method implementations (the only string-interpolated raw SQL). Leave `transaction`, `runMigrations`, `getConnection`, `connect`, `disconnect`, `isConnected` intact. Remove the now-unused `sql` import **only if** nothing else uses it (it is used by `runMigrations`? no — `migrate` is separate; check: `sql` was imported for `createRole`/`dropRole`'s `sql.raw`. After removal, if `sql` is unused, drop the import).
+
+- [ ] **Step 4: Rewrite `CreateMemberHandler`** (full replacement — removes the `createRole` call and the old `dbRoleName`/`dbPassword` params)
+
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { normalizeHandle } from '@/auth/normalize'
+import { hashPassword } from '@/auth/password'
+import { toSafeUser } from '@/auth/safeUser'
+import { type CreateMemberParams, IpcChannel } from '@/interface/CoreInterface'
+import { CoreUtil } from '@/util/CoreUtil'
+
+export class CreateMemberHandler extends CoreBaseHandler<IpcChannel.AUTH_CREATE_MEMBER> {
+  constructor() {
+    super(IpcChannel.AUTH_CREATE_MEMBER)
+  }
+
+  async handler(params: CreateMemberParams) {
+    const passwordHash = await hashPassword(params.initialPassword)
+    const user = await this.repos.users.create({
+      userId: CoreUtil.getUuid(),
+      userSn: normalizeHandle(params.userSn),
+      passwordHash,
+      userName: params.userName,
+      userEmail: params.userEmail ? normalizeHandle(params.userEmail) : null,
+      userRole: params.userRole ?? 'member'
+    })
+    return { data: toSafeUser(user), error: null }
+  }
+}
+```
+
+(Imports use the `@/auth` alias added in Step 1.)
+
+- [ ] **Step 5: Rewrite `DeleteUserHandler` (drop ROLE) + sanitize `UpdateUserHandler` / `ListUsersHandler`**
+
+`DeleteUserHandler.ts` — drop the `dropRole` call:
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { type AuthDeleteUserParams, IpcChannel } from '@/interface/CoreInterface'
+
+export class DeleteUserHandler extends CoreBaseHandler<IpcChannel.AUTH_DELETE_USER> {
+  constructor() {
+    super(IpcChannel.AUTH_DELETE_USER)
+  }
+
+  async handler(params: AuthDeleteUserParams) {
+    await this.repos.users.delete(params.id)
+    return { data: null, error: null }
+  }
+}
+```
+
+**Critical (no hash leak):** `UpdateUserHandler` and `ListUsersHandler` currently return the raw `UserRecord` (now containing `user_password_hash`), but their IPC payloads changed to `SafeUser`/`SafeUser[]` in Task 6. Strip the hash with `toSafeUser`.
+
+`UpdateUserHandler.ts` — change the return:
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { toSafeUser } from '@/auth/safeUser'
+import { type AuthUpdateUserParams, IpcChannel } from '@/interface/CoreInterface'
+
+export class UpdateUserHandler extends CoreBaseHandler<IpcChannel.AUTH_UPDATE_USER> {
+  constructor() {
+    super(IpcChannel.AUTH_UPDATE_USER)
+  }
+
+  async handler(params: AuthUpdateUserParams) {
+    const user = await this.repos.users.update(params.userId, {
+      userName: params.userName,
+      userAvatarPath: params.userAvatarKey ?? null
+    })
+    return { data: toSafeUser(user), error: null }
+  }
+}
+```
+
+`ListUsersHandler.ts` — map through `toSafeUser`:
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { toSafeUser } from '@/auth/safeUser'
+import { IpcChannel } from '@/interface/CoreInterface'
+
+export class ListUsersHandler extends CoreBaseHandler<IpcChannel.AUTH_LIST_USERS> {
+  constructor() {
+    super(IpcChannel.AUTH_LIST_USERS)
+  }
+
+  async handler() {
+    const users = await this.repos.users.findAll()
+    return { data: users.map(toSafeUser), error: null }
+  }
+}
+```
+
+- [ ] **Step 6: `LoginHandler`**
+
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { normalizeHandle } from '@/auth/normalize'
+import { verifyPassword } from '@/auth/password'
+import { toSafeUser } from '@/auth/safeUser'
+import { createSessionRecord } from '@/auth/session'
+import { SessionManager } from '@/auth/SessionManager'
+import { DatabaseError } from '@/error/DatabaseError'
+import { ErrorCode, IpcChannel, type LoginParams } from '@/interface/CoreInterface'
+
+export class LoginHandler extends CoreBaseHandler<IpcChannel.AUTH_LOGIN> {
+  constructor() {
+    super(IpcChannel.AUTH_LOGIN)
+  }
+
+  async handler(params: LoginParams) {
+    const sn = normalizeHandle(params.userSn)
+    const user = await this.repos.users.findBySn(sn)
+    // 사용자 열거 방지를 위해 미존재/오답/비활성 모두 동일한 일반 오류
+    const ok = user ? await verifyPassword(params.password, user.user_password_hash) : false
+    if (!user || !ok || user.user_status === 'inactive') {
+      throw new DatabaseError(ErrorCode.AUTH_ERROR, '아이디 또는 비밀번호가 올바르지 않습니다.', null)
+    }
+    const session = createSessionRecord({ user_id: user.user_id, user_sn: user.user_sn }, params.rememberMe ?? false, Date.now())
+    SessionManager.getInstance().save(session)
+    return { data: toSafeUser(user), error: null }
+  }
+}
+```
+
+> `verifyPassword` runs only when `user` is non-null (guarded by `user ? ... : false`), so a missing user fails fast without a hash comparison. The generic error message covers missing-user / wrong-password / inactive alike to prevent user enumeration.
+
+- [ ] **Step 7: `SetupAdminHandler`** (advisory-lock-guarded first-admin seed)
+
+```ts
+import { sql } from 'drizzle-orm'
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { normalizeHandle } from '@/auth/normalize'
+import { hashPassword } from '@/auth/password'
+import { FIRST_ADMIN_LOCK_KEY, toSafeUser } from '@/auth/safeUser'
+import { createSessionRecord } from '@/auth/session'
+import { SessionManager } from '@/auth/SessionManager'
+import type { DrizzleTx } from '@/database/repository/drizzle/executor'
+import { DatabaseError } from '@/error/DatabaseError'
+import { ErrorCode, IpcChannel, type SetupAdminParams } from '@/interface/CoreInterface'
+import { CoreUtil } from '@/util/CoreUtil'
+
+export class SetupAdminHandler extends CoreBaseHandler<IpcChannel.AUTH_SETUP_ADMIN> {
+  constructor() {
+    super(IpcChannel.AUTH_SETUP_ADMIN)
+  }
+
+  async handler(params: SetupAdminParams) {
+    const passwordHash = await hashPassword(params.password)
+    const userId = CoreUtil.getUuid()
+
+    const user = await this.repos.db.transaction(async (tx) => {
+      // 트랜잭션 스코프 advisory lock — 커밋/롤백 시 자동 해제, 동시 시드 직렬화
+      await (tx as DrizzleTx).execute(sql`SELECT pg_advisory_xact_lock(${FIRST_ADMIN_LOCK_KEY})`)
+      const existing = await this.repos.users.count(tx)
+      if (existing > 0) {
+        throw new DatabaseError(ErrorCode.OPERATION_FAILED_ERROR, '이미 관리자 계정이 존재합니다.', null)
+      }
+      return this.repos.users.create(
+        {
+          userId,
+          userSn: normalizeHandle(params.userSn),
+          passwordHash,
+          userName: params.userName,
+          userEmail: params.userEmail ? normalizeHandle(params.userEmail) : null,
+          userRole: 'admin'
+        },
+        tx
+      )
+    })
+
+    const session = createSessionRecord({ user_id: user.user_id, user_sn: user.user_sn }, false, Date.now())
+    SessionManager.getInstance().save(session)
+    return { data: toSafeUser(user), error: null }
+  }
+}
+```
+
+> `this.repos.db` is the `DatabaseAdapter`; `transaction(fn)` passes a drizzle `tx` typed as `unknown` at the adapter boundary. Cast it to `DrizzleTx` (the real pg transaction type from `executor.ts`, which exposes `.execute()` for raw SQL — the same `.execute(sql\`...\`)` API `PostgresAdapter` uses elsewhere). The `tx` is also passed to `repos.users.count(tx)` / `create(data, tx)`, which accept `RepoExecutor` (= `unknown`) — matching Phase 2's executor pattern. `pg_advisory_xact_lock` auto-releases on commit/rollback.
+
+- [ ] **Step 8: `LogoutHandler`**
+
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { SessionManager } from '@/auth/SessionManager'
+import { IpcChannel } from '@/interface/CoreInterface'
+
+export class LogoutHandler extends CoreBaseHandler<IpcChannel.AUTH_LOGOUT> {
+  constructor() {
+    super(IpcChannel.AUTH_LOGOUT)
+  }
+
+  async handler() {
+    SessionManager.getInstance().clear()
+    return { data: true, error: null }
+  }
+}
+```
+
+- [ ] **Step 9: `SessionStatusHandler`** (bootstrap re-verify)
+
+```ts
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { toSafeUser } from '@/auth/safeUser'
+import { isExpired } from '@/auth/session'
+import { SessionManager } from '@/auth/SessionManager'
+import { IpcChannel } from '@/interface/CoreInterface'
+
+export class SessionStatusHandler extends CoreBaseHandler<IpcChannel.AUTH_SESSION_STATUS> {
+  constructor() {
+    super(IpcChannel.AUTH_SESSION_STATUS)
+  }
+
+  async handler() {
+    const mgr = SessionManager.getInstance()
+    const session = mgr.load()
+    if (!session || isExpired(session, Date.now())) {
+      mgr.clear()
+      return { data: { authenticated: false, user: null }, error: null }
+    }
+    // 사용자 존재 + 활성 재검증
+    const user = await this.repos.users.findById(session.userId)
+    if (!user || user.user_status === 'inactive') {
+      mgr.clear()
+      return { data: { authenticated: false, user: null }, error: null }
+    }
+    return { data: { authenticated: true, user: toSafeUser(user) }, error: null }
+  }
+}
+```
+
+> `SessionStatusHandler` reads `this.repos` — but bootstrap may run before connect (no RepositoryContainer). `this.repos` throws if uninitialized. The renderer must only call `AUTH_SESSION_STATUS` **after** `WORKSPACE_STATUS` reports `connected: true` (see Task 9). The handler still guards: if `repos` would throw, that surfaces as an IPC error and the renderer treats it as unauthenticated.
+
+- [ ] **Step 10: Rework `ConnectWorkspaceHandler`** (remove auto-admin; report `needsSetup`)
+
+Replace the block at lines 79-101 (the `let user = await userRepo.findByDbRole(...)` lookup, the `isFirstLogin` auto-create `if` block, and the old `{ connected, user, isFirstLogin }` return) with:
+```ts
+    // Phase 3: 연결 시 자동 admin 생성 제거. users 비어있으면 setup 필요.
+    const userCount = await userRepo.count()
+
+    return {
+      data: {
+        connected: true,
+        needsSetup: userCount === 0
+      },
+      error: null
+    }
+```
+**Remove the `import { CoreUtil } from '@/util/CoreUtil'` line** — its only use in this file was the removed auto-create block (`CoreUtil.getUuid()`). The repository instantiations (`new DrizzleXRepository(db)`) do not use it. Keep everything from `adapter.connect(...)` through `container.initialize(...)` unchanged.
+
+- [ ] **Step 11: Update `WorkspaceStatusHandler`** (full rewrite to the new response shape)
+
+Read its current content first. It returns a `WorkspaceStatusResponse` (which changed in Task 6 to `{ connected, needsSetup }`). Update it to return `{ connected, needsSetup }`:
+- `connected` = `RepositoryContainer.getInstance().isInitialized`.
+- `needsSetup` = when connected, `await this.repos.users.count() === 0`; when not connected, `false`.
+Example body:
+```ts
+  async handler() {
+    const container = RepositoryContainer.getInstance()
+    if (!container.isInitialized) {
+      return { data: { connected: false, needsSetup: false }, error: null }
+    }
+    const count = await container.users.count()
+    return { data: { connected: true, needsSetup: count === 0 }, error: null }
+  }
+```
+(Adjust imports to match the file's existing style — read it first.)
+
+- [ ] **Step 12: Register the new handlers in `auth/index.ts`**
+
+`src/main/handler/auth/index.ts` re-exports handler classes (initHandler instantiates every exported class). It currently exports `CreateMemberHandler`, `DeleteUserHandler`, `ListUsersHandler`, `UpdateUserHandler`. Add the four new ones:
+```ts
+export { LoginHandler } from './LoginHandler'
+export { LogoutHandler } from './LogoutHandler'
+export { SessionStatusHandler } from './SessionStatusHandler'
+export { SetupAdminHandler } from './SetupAdminHandler'
+```
+Verify (PowerShell): `Select-String -Path src/main/handler/auth/index.ts -Pattern 'LoginHandler|SetupAdminHandler|LogoutHandler|SessionStatusHandler' | Measure-Object | Select-Object -ExpandProperty Count` → expect `4`.
+
+- [ ] **Step 13: Typecheck the whole main process**
+
+Run: `pnpm typecheck:node`
+Expected: **no errors**. Then confirm no dead references remain (PowerShell): `Select-String -Path src/main -Pattern 'findByDbRole|createRole|dropRole' | Where-Object { $_.Path -notmatch '\.test\.' } | Measure-Object | Select-Object -ExpandProperty Count` → must be `0`.
+
+- [ ] **Step 14: Lint + commit**
+
+Run: `pnpm exec biome check src/main/handler/auth src/main/handler/workspace src/main/core/auth src/main/core/database/adapter`
+```bash
+git add src/main/handler/auth src/main/handler/workspace/ConnectWorkspaceHandler.ts src/main/handler/workspace/WorkspaceStatusHandler.ts src/main/core/auth/safeUser.ts src/main/core/database/adapter/PostgresAdapter.ts src/main/core/database/adapter/DatabaseAdapter.ts electron.vite.config.ts tsconfig.node.json
+git commit -m "feat: 로그인/셋업/로그아웃/세션 핸들러 + 연결 시 needsSetup, ROLE 생성 제거"
+```
+(The `git add src/main/handler/auth` covers the modified `CreateMemberHandler`, `DeleteUserHandler`, `UpdateUserHandler`, `ListUsersHandler`, `index.ts` and the four new handler files.)
+
+---
+
+## Task 8: DB integration tests (auth)
+
+**Files:**
+- Create: `src/main/core/auth/auth.integration.test.ts`
+
+- [ ] **Step 1: Write the integration tests**
+
+```ts
+// src/main/core/auth/auth.integration.test.ts
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PostgresAdapter } from '../database/adapter/PostgresAdapter'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from '../database/__testutils__/pgTestDb'
+import { DrizzleUserRepository } from '../database/repository/drizzle/DrizzleUserRepository'
+import { hashPassword, verifyPassword } from './password'
+import { normalizeHandle } from './normalize'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('auth integration', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+    await adapter.runMigrations(resolve(process.cwd(), 'drizzle'))
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  })
+
+  it('auth migration created user_sn / user_password_hash / user_status', async () => {
+    const repo = new DrizzleUserRepository(adapter.getConnection())
+    expect(await repo.count()).toBe(0)
+  })
+
+  it('create + findBySn round-trips with normalized handle and verifiable password', async () => {
+    const repo = new DrizzleUserRepository(adapter.getConnection())
+    const passwordHash = await hashPassword('s3cret')
+    await repo.create({
+      userId: randomUUID(),
+      userSn: normalizeHandle('  AdminUser '),
+      passwordHash,
+      userName: 'Admin',
+      userRole: 'admin'
+    })
+    const found = await repo.findBySn('adminuser')
+    expect(found).not.toBeNull()
+    expect(found?.user_role).toBe('admin')
+    expect(await verifyPassword('s3cret', found!.user_password_hash)).toBe(true)
+    expect(await verifyPassword('wrong', found!.user_password_hash)).toBe(false)
+  })
+
+  it('user_sn UNIQUE prevents duplicates', async () => {
+    const repo = new DrizzleUserRepository(adapter.getConnection())
+    const passwordHash = await hashPassword('x')
+    const sn = normalizeHandle('dupe')
+    await repo.create({ userId: randomUUID(), userSn: sn, passwordHash, userRole: 'member' })
+    await expect(repo.create({ userId: randomUUID(), userSn: sn, passwordHash, userRole: 'member' })).rejects.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run (DB-gated)**
+
+Run (PowerShell, requires `pnpm docker:up` + fresh DB — the harness creates throwaway DBs so no manual reset needed here):
+```powershell
+$env:RUN_DB_TESTS='1'; pnpm test -- src/main/core/auth/auth.integration.test.ts
+```
+Expected: PASS (3 tests). If Docker is unavailable, the suite SKIPS (acceptable locally; CI runs it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/core/auth/auth.integration.test.ts
+git commit -m "test: 인증 마이그레이션/리포지토리 통합 테스트 (DB-gated)"
+```
+
+---
+
+## Task 9: Renderer — auth store session layer
+
+**Files:**
+- Modify: `src/renderer/src/types/auth.ts`, `src/renderer/src/stores/auth.ts`
+
+- [ ] **Step 1: Extend `AuthState` (renderer types)**
+
+In `types/auth.ts`, add to `AuthState`:
+```ts
+  isAuthenticated: boolean
+  needsSetup: boolean
+  setAuthenticated: (v: boolean) => void
+  setNeedsSetup: (v: boolean) => void
+  logout: () => Promise<void>
+```
+(Keep all existing fields. `User` already comes from `@/interface/CoreInterface`, now aliased to `SafeUser`.)
+
+- [ ] **Step 2: Update the store**
+
+In `stores/auth.ts`:
+- Add `isAuthenticated: false` and `needsSetup: false` to the initial state.
+- Add setters `setAuthenticated`, `setNeedsSetup`.
+- Add `logout`:
+```ts
+      logout: async () => {
+        try {
+          await window.callApi(IpcChannel.AUTH_LOGOUT)
+        } finally {
+          set({ user: null, isAuthenticated: false })
+        }
+      },
+```
+- In `disconnect` and `reset`, also clear `isAuthenticated: false` and `needsSetup: false`.
+- Rewrite `bootstrap` to sync connection **and** session:
+```ts
+      bootstrap: async () => {
+        try {
+          const status = await window.callApi(IpcChannel.WORKSPACE_STATUS)
+          const connectedInMain = status?.data?.connected === true
+          const needsSetup = status?.data?.needsSetup === true
+
+          if (!connectedInMain) {
+            set({ user: null, isConnected: false, isAuthenticated: false, needsSetup: false, currentWorkspace: null })
+            return
+          }
+
+          // 연결됨 → 세션 재검증
+          const session = await window.callApi(IpcChannel.AUTH_SESSION_STATUS)
+          const authed = session?.data?.authenticated === true
+          set({
+            isConnected: true,
+            needsSetup,
+            isAuthenticated: authed,
+            user: authed ? (session?.data?.user ?? null) : null
+          })
+        } catch (error) {
+          console.error('[auth.bootstrap] failed to sync with main', error)
+          set({ user: null, isConnected: false, isAuthenticated: false, needsSetup: false, currentWorkspace: null })
+        } finally {
+          set({ isBootstrapped: true })
+        }
+      }
+```
+- Update `partialize` to also persist `isAuthenticated` and `needsSetup`.
+- **Delete the `onRehydrateStorage` option entirely** from the persist config. The current code (`onRehydrateStorage: () => (state) => { if (state?.isConnected && !state.user) state.disconnect() }`) races with the new session bootstrap. `bootstrap()` runs on app mount and is now the single source of truth: it calls `WORKSPACE_STATUS` and, if connected, `AUTH_SESSION_STATUS`, then sets `isConnected`/`isAuthenticated`/`user` — reconciling any stale persisted state. So `onRehydrateStorage` is removed, not replaced.
+
+- [ ] **Step 3: Typecheck (web) + commit**
+
+Run: `pnpm typecheck:web`
+Expected: errors remain only in routes/pages (Tasks 10-12). Store + types compile.
+```bash
+git add src/renderer/src/types/auth.ts src/renderer/src/stores/auth.ts
+git commit -m "feat: 인증 스토어에 세션 레이어(isAuthenticated/needsSetup) + bootstrap 재검증"
+```
+
+---
+
+## Task 10: Renderer — routes + guard rework
+
+**Files:**
+- Modify: `src/renderer/src/routers/routes.tsx`, `src/renderer/src/routers/routerContext.ts`
+
+- [ ] **Step 1: Extend `RouterContext` and the place that builds it**
+
+`routerContext.ts` defines its own explicit `auth` interface (currently `{ isConnected, user, disconnect }`). Replace it with the new shape:
+```ts
+import type { User } from '@/interface/CoreInterface'
+
+export interface RouterContext {
+  auth: {
+    isConnected: boolean
+    isAuthenticated: boolean
+    needsSetup: boolean
+    user: User | null
+    disconnect: () => void
+  }
+}
+```
+Then find where this context is constructed and passed to the router (search: `Select-String -Path src/renderer/src -Pattern 'context=\{\{|RouterProvider|InnerApp'`). Wherever the `auth` context object is built from the store (e.g. in `main.tsx`/`App`), add `isAuthenticated` and `needsSetup` from `useAuthStore` so the guards in Steps 2-4 can read them. Verify with `pnpm typecheck:web` after editing.
+
+- [ ] **Step 2: Rework `authenticatedRoute.beforeLoad`**
+
+In `routes.tsx`, replace the `authenticatedRoute` `beforeLoad`:
+```ts
+  beforeLoad: ({ context }) => {
+    const { isConnected, isAuthenticated, needsSetup } = context.auth
+    if (!isConnected) {
+      throw redirect({ to: '/workspace' })
+    }
+    if (!isAuthenticated) {
+      throw redirect({ to: needsSetup ? '/setup' : '/login' })
+    }
+  },
+```
+
+- [ ] **Step 3: Add `/login` and `/setup` routes (connected-but-unauthenticated)**
+
+```ts
+export const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  beforeLoad: ({ context }) => {
+    const { isConnected, isAuthenticated, needsSetup } = context.auth
+    if (!isConnected) throw redirect({ to: '/workspace' })
+    if (isAuthenticated) throw redirect({ to: '/' })
+    if (needsSetup) throw redirect({ to: '/setup' })
+  },
+  component: lazyRoute(() => import('@/components/pages/LoginPage'))
+})
+
+export const setupRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/setup',
+  beforeLoad: ({ context }) => {
+    const { isConnected, isAuthenticated, needsSetup } = context.auth
+    if (!isConnected) throw redirect({ to: '/workspace' })
+    if (isAuthenticated) throw redirect({ to: '/' })
+    if (!needsSetup) throw redirect({ to: '/login' })
+  },
+  component: lazyRoute(() => import('@/components/pages/AdminSetupPage'))
+})
+```
+
+- [ ] **Step 4: Update `workspaceRoute` guard + route tree**
+
+`workspaceRoute.beforeLoad`: redirect to `/` only when `isConnected && isAuthenticated`:
+```ts
+  beforeLoad: ({ context }) => {
+    const { isConnected, isAuthenticated } = context.auth
+    if (isConnected && isAuthenticated) {
+      throw redirect({ to: '/' })
+    }
+  },
+```
+Add `loginRoute` and `setupRoute` to the `routeTree` `rootRoute.addChildren([...])` array (siblings of `workspaceRoute`):
+```ts
+export const routeTree = rootRoute.addChildren([
+  authenticatedRoute.addChildren([ /* ...unchanged... */ ]),
+  workspaceRoute,
+  loginRoute,
+  setupRoute
+])
+```
+
+- [ ] **Step 5: Typecheck (web)**
+
+Run: `pnpm typecheck:web`
+Expected: errors only about the not-yet-created `LoginPage`/`AdminSetupPage` (Task 11). Route wiring compiles otherwise.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/routers/routes.tsx src/renderer/src/routers/routerContext.ts
+git commit -m "feat: /login·/setup 라우트 + 연결·인증 기반 가드 재구성"
+```
+
+---
+
+## Task 11: Renderer — AuthLayout + LoginPage + AdminSetupPage (split brand panel)
+
+**Files:**
+- Create: `src/renderer/src/components/templates/AuthLayout.tsx`, `src/renderer/src/components/pages/LoginPage.tsx`, `src/renderer/src/components/pages/AdminSetupPage.tsx`
+
+The split brand-panel layout (direction **B**) is the app's UX baseline. Use existing atoms (`Button`, `Input`, `Label`, `Card`) and design tokens (`bg-background`, `text-foreground`, `bg-primary`, `text-primary-foreground`, `text-muted-foreground`, `border`). Use `useIpcHandler` (see `WorkspacePage`) and `sonner` `toast` for errors.
+
+- [ ] **Step 1: `AuthLayout` (shared shell)**
+
+```tsx
+// src/renderer/src/components/templates/AuthLayout.tsx
+import type { ReactNode } from 'react'
+
+// 좌측 브랜드 패널 + 우측 폼. 인증 화면(로그인/셋업)의 공통 셸이자 앱 UX 기준 레이아웃.
+export function AuthLayout({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
+  return (
+    <div className='flex min-h-screen'>
+      {/* Brand panel */}
+      <div className='hidden md:flex md:w-1/2 flex-col justify-between bg-zinc-900 p-10 text-zinc-50'>
+        <div className='flex size-9 items-center justify-center rounded-lg bg-zinc-50 font-bold text-zinc-900'>H</div>
+        <div className='space-y-2'>
+          <div className='text-2xl font-bold'>Hydra</div>
+          <p className='text-sm leading-relaxed text-zinc-400'>가볍고 빠른 이슈·프로젝트 관리</p>
+        </div>
+        <div className='text-xs text-zinc-600'>v3 workspace</div>
+      </div>
+      {/* Form panel */}
+      <div className='flex w-full items-center justify-center bg-background p-6 md:w-1/2'>
+        <div className='w-full max-w-sm space-y-6'>
+          <div className='space-y-1'>
+            <h1 className='text-xl font-bold text-foreground'>{title}</h1>
+            <p className='text-sm text-muted-foreground'>{subtitle}</p>
+          </div>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: `LoginPage`**
+
+```tsx
+// src/renderer/src/components/pages/LoginPage.tsx
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/atoms/Button'
+import { Input } from '@/components/atoms/Input'
+import { Label } from '@/components/atoms/Label'
+import { AuthLayout } from '@/components/templates/AuthLayout'
+import { useIpcHandler } from '@/hooks/use-ipc'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { useAuthStore } from '@/stores/auth'
+
+export default function LoginPage() {
+  const navigate = useNavigate()
+  const login = useIpcHandler(IpcChannel.AUTH_LOGIN)
+  const { setUser, setAuthenticated } = useAuthStore()
+  const [userSn, setUserSn] = useState('')
+  const [password, setPassword] = useState('')
+  const [rememberMe, setRememberMe] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    try {
+      const result = await login({ userSn, password, rememberMe })
+      if (result.data) {
+        setUser(result.data)
+        setAuthenticated(true)
+        navigate({ to: '/' })
+      } else {
+        toast.error(result.error?.message ?? '로그인에 실패했습니다.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout title='로그인' subtitle='계정으로 계속'>
+      <form className='space-y-4' onSubmit={handleSubmit}>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userSn'>아이디</Label>
+          <Input id='userSn' value={userSn} onChange={(e) => setUserSn(e.target.value)} autoFocus />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='password'>비밀번호</Label>
+          <Input id='password' type='password' value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <label className='flex items-center gap-2 text-sm text-muted-foreground'>
+          <input type='checkbox' checked={rememberMe} onChange={(e) => setRememberMe(e.target.checked)} />
+          로그인 유지 (30일)
+        </label>
+        <Button type='submit' className='w-full' disabled={submitting || !userSn || !password}>
+          {submitting ? '로그인 중...' : '로그인'}
+        </Button>
+      </form>
+    </AuthLayout>
+  )
+}
+```
+
+- [ ] **Step 3: `AdminSetupPage`**
+
+```tsx
+// src/renderer/src/components/pages/AdminSetupPage.tsx
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/atoms/Button'
+import { Input } from '@/components/atoms/Input'
+import { Label } from '@/components/atoms/Label'
+import { AuthLayout } from '@/components/templates/AuthLayout'
+import { useIpcHandler } from '@/hooks/use-ipc'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { useAuthStore } from '@/stores/auth'
+
+export default function AdminSetupPage() {
+  const navigate = useNavigate()
+  const setupAdmin = useIpcHandler(IpcChannel.AUTH_SETUP_ADMIN)
+  const { setUser, setAuthenticated, setNeedsSetup } = useAuthStore()
+  const [form, setForm] = useState({ userSn: '', userName: '', userEmail: '', password: '', confirm: '' })
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (form.password !== form.confirm) {
+      toast.error('비밀번호가 일치하지 않습니다.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const result = await setupAdmin({
+        userSn: form.userSn,
+        userName: form.userName,
+        userEmail: form.userEmail || undefined,
+        password: form.password
+      })
+      if (result.data) {
+        setUser(result.data)
+        setAuthenticated(true)
+        setNeedsSetup(false)
+        navigate({ to: '/' })
+      } else {
+        toast.error(result.error?.message ?? '관리자 설정에 실패했습니다.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout title='관리자 계정 만들기' subtitle='이 워크스페이스의 첫 관리자 계정을 설정하세요'>
+      <form className='space-y-4' onSubmit={handleSubmit}>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userSn'>아이디</Label>
+          <Input id='userSn' value={form.userSn} onChange={(e) => setForm({ ...form, userSn: e.target.value })} autoFocus />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userName'>이름</Label>
+          <Input id='userName' value={form.userName} onChange={(e) => setForm({ ...form, userName: e.target.value })} />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userEmail'>이메일 (선택)</Label>
+          <Input id='userEmail' type='email' value={form.userEmail} onChange={(e) => setForm({ ...form, userEmail: e.target.value })} />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='password'>비밀번호</Label>
+          <Input id='password' type='password' value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='confirm'>비밀번호 확인</Label>
+          <Input id='confirm' type='password' value={form.confirm} onChange={(e) => setForm({ ...form, confirm: e.target.value })} />
+        </div>
+        <Button type='submit' className='w-full' disabled={submitting || !form.userSn || !form.userName || !form.password}>
+          {submitting ? '설정 중...' : '관리자 계정 만들기'}
+        </Button>
+      </form>
+    </AuthLayout>
+  )
+}
+```
+
+- [ ] **Step 4: Wire i18n (app convention)**
+
+The app uses `react-i18next` with per-namespace files (e.g. `WorkspacePage` uses `useTranslation('workspace')`, `MembersPage` uses `useTranslation('member')`). The hardcoded Korean strings in the page code above are shown for structural clarity — replace them with translation keys following the existing pattern:
+1. Read `src/renderer/src/locales/index.ts` and an existing namespace file (e.g. the `workspace` namespace) to learn the exact file layout and language set (ko/en).
+2. Add an `auth` namespace mirroring that layout, with keys for: login title/subtitle/userId/password/rememberMe/submit/submitting, and setup title/subtitle/userId/name/email/password/confirm/submit/submitting/passwordMismatch, plus error fallbacks (`loginFailed`, `setupFailed`).
+3. In `LoginPage`/`AdminSetupPage`, add `const { t } = useTranslation('auth')` and replace each literal string with `t('login.title')` etc. Register the namespace in `locales/index.ts` the same way the others are registered.
+
+(If introducing a full namespace is disproportionate for the team's current i18n coverage, at minimum route the strings through the existing `common` namespace where keys already exist; do NOT leave a mix of `t()` and stray literals in these baseline screens.)
+
+- [ ] **Step 5: Typecheck (web) + lint**
+
+Run: `pnpm typecheck:web` (no errors) and `pnpm exec biome check src/renderer/src/components/pages/LoginPage.tsx src/renderer/src/components/pages/AdminSetupPage.tsx src/renderer/src/components/templates/AuthLayout.tsx`.
+> Verified during research: `useIpcHandler(channel)` returns a callable `(request?) => Promise<IpcResponse>` whose result is `{ data, error }` — matches the usage above. `Button` accepts native `disabled`; `Label` accepts `htmlFor`; `Input` accepts `id`/`type`/`value`/`onChange`. If any atom's real API differs, follow it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/components/templates/AuthLayout.tsx src/renderer/src/components/pages/LoginPage.tsx src/renderer/src/components/pages/AdminSetupPage.tsx src/renderer/src/locales
+git commit -m "feat: 분할 패널 로그인/관리자 셋업 화면 + i18n (앱 UX 기준 레이아웃)"
+```
+
+---
+
+## Task 12: Renderer — WorkspacePage connect flow
+
+**Files:**
+- Modify: `src/renderer/src/components/pages/WorkspacePage.tsx` (handleConnect, lines 64-88)
+
+- [ ] **Step 1: Route to /setup or /login after connect**
+
+Replace `handleConnect`'s success block — connect no longer returns a user; it returns `needsSetup`:
+```tsx
+  const handleConnect = async (ws: WorkspaceConfig) => {
+    setConnecting(true)
+    try {
+      const result = await connectWorkspace({
+        host: ws.host,
+        port: ws.port,
+        dbName: ws.dbName,
+        username: ws.username,
+        password,
+        sslCertPath: ws.sslCertPath
+      })
+      if (result.data) {
+        setConnected(true)
+        setCurrentWorkspace(ws)
+        setNeedsSetup(result.data.needsSetup)
+        toast.success(t('toast.connected'))
+        navigate({ to: result.data.needsSetup ? '/setup' : '/login' })
+      } else {
+        toast.error(result.error?.message ?? tc('toast.error'))
+      }
+    } finally {
+      setConnecting(false)
+      setPassword('')
+      setShowPassword(false)
+      setSelectedWs(null)
+    }
+  }
+```
+Update the destructure on line 21 to pull `setNeedsSetup` and drop `setUser`:
+```tsx
+  const { setConnected, setCurrentWorkspace, setNeedsSetup } = useAuthStore()
+```
+(`tc('toast.error')` — if that i18n key doesn't exist, use a literal Korean string `'연결에 실패했습니다.'`.)
+
+- [ ] **Step 2: Typecheck (web) + lint + commit**
+
+Run: `pnpm typecheck:web` (no errors), `pnpm exec biome check src/renderer/src/components/pages/WorkspacePage.tsx`
+```bash
+git add src/renderer/src/components/pages/WorkspacePage.tsx
+git commit -m "feat: 연결 후 needsSetup 따라 /setup·/login 으로 라우팅 (자동 로그인 제거)"
+```
+
+---
+
+## Task 13: Renderer — MembersPage member-creation update
+
+**Files:**
+- Modify: `src/renderer/src/components/pages/MembersPage.tsx`
+
+`MembersPage` still builds and sends the old `CreateMemberParams` (`dbRoleName`/`dbPassword`) via `AUTH_CREATE_MEMBER`. Task 6 changed that payload to `{ userSn, userName, userEmail, initialPassword, userRole }`, so the member-creation UI must change or it breaks at typecheck/runtime.
+
+- [ ] **Step 1: Remove the DB-role machinery, add `userSn`, rename password**
+
+In `MembersPage.tsx`:
+- Delete the `generateDbRoleName` function (currently lines 16-22).
+- In the add-member form state: delete `const [dbRoleName, setDbRoleName] = useState('')`; rename `dbPassword` → `initialPassword` (`const [initialPassword, setInitialPassword] = useState('')`); add `const [userSn, setUserSn] = useState('')`.
+- Delete the `useEffect` that auto-generates `dbRoleName` from `userName` (currently lines 71-73).
+- In `resetAddForm`, remove `setDbRoleName('')`; replace `setDbPassword('')` with `setInitialPassword('')`; add `setUserSn('')`.
+
+- [ ] **Step 2: Update validation + the IPC call in `handleAddMember`**
+
+Replace the validation + `window.callApi(IpcChannel.AUTH_CREATE_MEMBER, ...)` block so it validates `userSn` and sends the new params:
+```tsx
+    if (!userSn.trim()) {
+      toast.error(t('validation.enterUserSn'))
+      return
+    }
+    if (!userName.trim()) {
+      toast.error(t('validation.enterName'))
+      return
+    }
+    if (!userEmail.trim()) {
+      toast.error(t('validation.enterEmail'))
+      return
+    }
+    if (!initialPassword.trim()) {
+      toast.error(t('validation.enterPassword'))
+      return
+    }
+
+    setIsSubmitting(true)
+    const result = await window.callApi(IpcChannel.AUTH_CREATE_MEMBER, {
+      userSn: userSn.trim(),
+      userName: userName.trim(),
+      userEmail: userEmail.trim(),
+      initialPassword: initialPassword.trim(),
+      userRole
+    })
+    setIsSubmitting(false)
+```
+(Add the `member.validation.enterUserSn` i18n key alongside the existing member-namespace validation keys.)
+
+- [ ] **Step 3: Update the Add Member dialog form fields**
+
+In the add-member `Dialog`:
+- Add a `userSn` input as the first field (before name):
+```tsx
+            <div className='grid gap-2'>
+              <Label htmlFor='userSn'>{t('label.userSn')}</Label>
+              <Input id='userSn' placeholder={t('placeholder.userSn')} value={userSn} onChange={(e) => setUserSn(e.target.value)} />
+            </div>
+```
+- **Delete the entire `dbRoleName` field block** (the `<div>` containing `Label htmlFor='dbRoleName'`, its `Input`, and the `help.dbRole` `<p>` — currently lines 277-286).
+- Rename the password field: `htmlFor='dbPassword'` → `htmlFor='initialPassword'`, `id='dbPassword'` → `id='initialPassword'`, `value={dbPassword}` → `value={initialPassword}`, `onChange={... setDbPassword ...}` → `setInitialPassword`. Keep the `t('label.password')`/`t('placeholder.password')` keys (or rename to `label.initialPassword` if you add the key).
+- Add `member.label.userSn` / `member.placeholder.userSn` i18n keys.
+
+- [ ] **Step 4: Typecheck (web) + lint + commit**
+
+Run: `pnpm typecheck:web` (no errors), `pnpm exec biome check src/renderer/src/components/pages/MembersPage.tsx`
+```bash
+git add src/renderer/src/components/pages/MembersPage.tsx src/renderer/src/locales
+git commit -m "feat: MembersPage 멤버 생성 — user_sn + 초기 비밀번호 (DB ROLE 입력 제거)"
+```
+
+---
+
+## Task 14: Full verification
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `pnpm typecheck`
+Expected: main + renderer both pass.
+
+- [ ] **Step 2: Strict lint (CI parity)**
+
+Run: `pnpm lint:ci`
+Expected: **0 errors** (warnings OK). Fix any formatter mismatch: `pnpm exec biome check --write <file>` then commit.
+
+- [ ] **Step 3: Full test suite + DB integration**
+
+Run (PowerShell, requires `pnpm docker:up`):
+```powershell
+$env:RUN_DB_TESTS='1'; pnpm test
+```
+Expected: all suites pass — Phase 1/2 integration + Phase 3 unit (password/normalize/session) + Phase 3 auth integration.
+
+- [ ] **Step 4: Manual dev smoke (fresh DB)**
+
+```powershell
+pnpm docker:down
+docker volume rm hydra_hydra_data
+pnpm docker:up
+pnpm dev
+```
+Confirm: connect to workspace (enter DB password) → empty DB routes to **관리자 계정 만들기** (split-panel) → create admin → lands in app. Relaunch app → session restores (stays logged in). Log out (if wired) / clear session → routes to **로그인**. Wrong password → generic error. Create a member (admin) → log in as that member with the initial password.
+
+- [ ] **Step 5: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "chore: Phase 3 인증 재설계 최종 정리"
+```
+(Only if fixups were needed; otherwise skip. Remember: stage specific paths, not `-A`, if CRLF noise is present — re-check `git status` first.)
+
+---
+
+## Notes / Risks
+
+- **`ADD COLUMN ... NOT NULL` needs an empty `users` table.** Pre-release; dev resets the volume. The throwaway-DB integration harness always starts fresh. Production-data migration is explicitly out of scope (design §2).
+- **`pg_advisory_xact_lock` over `pg_advisory_lock`:** transaction-scoped avoids the pooled-connection footgun (acquire and release could otherwise land on different pooled connections). Drizzle's `transaction()` runs on a single connection, so the lock is held across the count+insert and auto-released on commit/rollback.
+- **`SessionStatus` before connect:** the renderer only calls it after `WORKSPACE_STATUS` reports connected; the handler's `this.repos` access would otherwise throw and is treated as unauthenticated.
+- **Password hash isolation:** every auth IPC response returns `SafeUser` via `toSafeUser`; `user_password_hash` never crosses the IPC boundary.
+- **`@/auth` alias:** added to both `electron.vite.config.ts` (runtime) and `tsconfig.node.json` (typecheck) — both are required or builds/typecheck diverge.
+- **MySQL adapter, `user_db_role` drop, forced password reset, password self-service** remain out of scope (Phases 4-5+).
+
+---
+
+## Self-Review
+
+**Spec coverage (design §1-§9):**
+- §2.1 clean schema NOT NULL: Task 4. ✅
+- §2.2 username identifier + normalization: Tasks 2, 5, 7. ✅
+- §2.3 no forced change / §2.4 session TTL: Task 2 (`SESSION_TTL_MS`). ✅
+- §2.5 deprecate `user_db_role`, remove createRole/dropRole: Tasks 5, 7. ✅
+- §2.6 split-panel UI: Task 11. ✅
+- §3.1 password/normalize/session: Tasks 1-3. ✅
+- §3.2 columns + migration: Task 4. ✅
+- §3.3 repository (findBySn/count/create): Task 5. ✅
+- §3.4 connect→migrate→advisory-lock→state: Tasks 7 (connect needsSetup; advisory xact lock in SetupAdmin). ✅
+- §3.5 IPC handlers + member/delete rework: Tasks 6, 7. ✅
+- §3.6 renderer store/routes/pages: Tasks 9-13 (store 9, routes/guard 10, login/setup pages 11, WorkspacePage connect 12, MembersPage onboarding 13). ✅
+- §4 data flow / §5 error handling (generic auth error, setup race): Task 7. ✅
+- §5.6 member onboarding (admin sets initial password, no ROLE): Task 7 (handler) + Task 13 (UI). ✅
+- §6 security: parameterized only + remove raw-SQL createRole/dropRole (Task 7 Step 3); **no hash leak** — `SafeUser` on every auth IPC response incl. `UpdateUserHandler`/`ListUsersHandler` (Task 7 Step 5); generic auth errors (Task 7 Step 6). ✅
+- §7 testing (unit + DB-gated integration): Tasks 1-3, 8. ✅
+
+**Placeholder scan:** Code shown for every code step. The research-backed reviews resolved earlier guardrail notes: `useIpcHandler` signature, `Button`/`Label`/`Input` props confirmed (Task 11 Step 5). The remaining "adjust to the real layout" notes (locale-file structure in Task 11 Step 4 / Task 13; the exact line ranges in MembersPage) are deliberate — they point at files the implementer reads and edits, with concrete target shapes given.
+
+**Type consistency:** `SafeUser = Omit<UserRecord,'user_password_hash'>` defined in Task 5, used in Tasks 6/7/9. `CreateUserData` (userSn/passwordHash) consistent between Task 5 (interface), Task 5 (impl), Task 7 (handlers). `WorkspaceStatusResponse {connected,needsSetup}` consistent across Task 6 (type), Task 7 (connect/status handlers), Task 9 (bootstrap), Task 12 (WorkspacePage). `createSessionRecord`/`isExpired`/`SESSION_TTL_MS` names match across Tasks 2, 7, 8. `normalizeHandle` consistent across Tasks 2, 5, 7, 8. `toSafeUser`/`FIRST_ADMIN_LOCK_KEY` from `@/auth/safeUser`; `DrizzleTx` from `executor.ts` used for the advisory-lock cast (Task 7 Step 7). `CreateMemberParams` (userSn/initialPassword) consistent across Task 6 (type) ↔ Task 7 Step 4 (handler) ↔ Task 13 (MembersPage). Channel names `AUTH_LOGIN/LOGOUT/SETUP_ADMIN/SESSION_STATUS` consistent (Task 6 enum ↔ Task 7 handlers ↔ Tasks 9-13 renderer).
+
+**Adversarial-review pass:** This plan was checked by a 4-lens review workflow against the real codebase; its findings (routerContext explicit type, `UpdateUser`/`ListUsers` hash-stripping, MembersPage breakage, `@/auth` alias ordering, `onRehydrateStorage`, `DrizzleTx` cast, `LoginHandler` import) are folded in above.
+
+---
+
+## Execution Handoff
+
+(Filled in after presenting to the user.)

--- a/docs/superpowers/plans/2026-06-10-phase3-auth-redesign.md
+++ b/docs/superpowers/plans/2026-06-10-phase3-auth-redesign.md
@@ -1040,6 +1040,10 @@ git commit -m "feat: 로그인/셋업/로그아웃/세션 핸들러 + 연결 시
 **Files:**
 - Create: `src/main/core/auth/auth.integration.test.ts`
 
+- [ ] **Step 0: Fix Phase 1/2 test fixtures for the new NOT NULL columns**
+
+`transaction.atomicity.test.ts` and `repository/drizzle/readAfterWrite.test.ts` insert `users` rows directly (`db.insert(schema.users).values({ user_id, user_name, user_role })`). Since Task 4 made `user_sn`/`user_password_hash` NOT NULL, add them to each insert: `user_sn: userId` (the row's existing unique `userId`) and `user_password_hash: 'test-hash'`. (Three inserts total: one in `transaction.atomicity.test.ts`, two in `readAfterWrite.test.ts`.) Without this, `pnpm typecheck:node` and the DB tests fail. Commit with the auth tests below or separately. **This was already applied during execution as a Task 5 follow-up; verify it's present before relying on a green typecheck.**
+
 - [ ] **Step 1: Write the integration tests**
 
 ```ts

--- a/docs/superpowers/specs/2026-06-10-phase3-auth-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-10-phase3-auth-redesign-design.md
@@ -1,0 +1,112 @@
+# Phase 3 — Authentication Redesign — Design Spec
+
+**Status:** Approved in brainstorming 2026-06-10. Input to the Phase 3 implementation plan.
+
+**Parent spec:** `docs/superpowers/specs/2026-06-06-mysql-support-and-auth-redesign-design.md`
+(§5 Authentication, §6.1 `users` table, §6.2 type rules, §8 migration, §9 security, §11 testing, §12 phasing item 3). This document records the **Phase-3-specific decisions** made in brainstorming and resolves the parent spec's open questions for this phase. Where this document and the parent disagree, **this document wins for Phase 3**.
+
+---
+
+## 1. Summary
+
+Replace Hydra's "DB connection = authentication" model with a real per-user local login layered on top of the shared workspace connection. A member opens a workspace, enters the shared DB service-account password (as today), the app connects + migrates, then the member authenticates with a personal **username + password** against the `users` table. Admins onboard members with an initial password. No PostgreSQL ROLE is created per user anymore. **PostgreSQL-only** this phase (MySQL adapter is Phase 4).
+
+This phase also establishes the app's **UX baseline**: the auth screens (login + admin setup) use a split brand-panel layout that becomes the visual reference for all future UI.
+
+## 2. Locked Decisions (brainstorming 2026-06-10)
+
+1. **Pre-release → clean schema.** No deployed user data to preserve. New `users` columns are created **NOT NULL / UNIQUE from the start** — no nullable→backfill→constrain multi-step migration, no forced-reset-of-existing-users flow. (Supersedes parent §8.2 for this phase.)
+2. **Login identifier = separate username** (`user_sn`), distinct from email. Normalized (trim + lowercase) at both insert and lookup. `user_email` kept for display/contact, also normalized.
+3. **No forced password change on first login.** Members log in with the admin-set initial password directly. (Forced-change + `must_reset` marker deferred to a later phase.)
+4. **Session TTL:** default **1 day**; "remember me" extends to **30 days**.
+5. **`user_db_role` is deprecated, not dropped.** Keep the column; stop reading/writing it. Actual `DROP` is Phase 5 (parent §8.3).
+6. **Auth UI direction = split brand panel** (left dark brand panel + right form). This is the app's new UX standard; login and admin-setup share the layout.
+7. **PostgreSQL-only.** No `schema.mysql.ts`, no MySQL adapter, no `dbms` config work — Phase 4.
+
+## 3. Architecture
+
+Three concerns, isolated:
+
+- **Auth core (main, pure/unit-testable):** password hashing, identifier normalization, session record encode/decode + TTL. No DB, no Electron beyond `safeStorage` for session persistence.
+- **Auth data + flow (main):** schema columns + migration, repository methods (`findBySn`, create-with-hash, `countUsers`), IPC handlers (login / setup-admin / logout / session bootstrap), advisory-lock-guarded connect→migrate→seed sequence.
+- **Auth UI (renderer):** `LoginPage`, `AdminSetupPage`, auth-store session layer, route guard requiring connected **AND** authenticated.
+
+### 3.1 Auth core modules (`src/main/core/auth/`)
+- `password.ts` — `hashPassword(plain): Promise<string>` and `verifyPassword(plain, encoded): Promise<boolean>`.
+  - Algorithm: Node `crypto.scrypt`, params `N=2^15 (32768), r=8, p=1`. Memory ≈ `128·N·r ≈ 33.5 MiB`, which **exceeds** Node's default `maxmem` of 32 MiB and would throw — so an explicit `maxmem` (e.g. `64 * 1024 * 1024`) is **required**, not optional. Per-user random salt ≥16 bytes.
+  - Storage format (self-describing, lets params evolve): `scrypt$N=32768,r=8,p=1$<saltB64>$<hashB64>`.
+  - `verifyPassword` parses params from the stored string and uses `crypto.timingSafeEqual`.
+- `normalize.ts` — `normalizeHandle(value): string` = `value.trim().toLowerCase()`. Applied to `user_sn` and `user_email` at every insert and every lookup.
+- `session.ts` — encode/decode an opaque session record `{ userId, userSn, issuedAt, expiresAt }`; `createSession(user, rememberMe)`, `isExpired(session)`. Persisted via Electron `safeStorage` (reuse the `WorkspaceManager` safeStorage pattern). TTL: 1 day default, 30 days when `rememberMe`.
+
+### 3.2 Data model — `users` (migration `0002`; current history is `0000` tables + `0001` indexes)
+| Column | Change |
+|--------|--------|
+| `user_sn varchar(255)` | **ADD** UNIQUE NOT NULL — normalized login handle |
+| `user_password_hash varchar(255)` | **ADD** NOT NULL — scrypt encoded string |
+| `user_status varchar(20)` default `'active'` | **ADD** — `active` / `inactive` |
+| `user_db_role` | keep, deprecated (no read/write) |
+| `user_email`, `user_name`, `user_role`, `user_created_at`, `user_updated_at` | keep |
+
+Schema edit in `schema.ts` (PK stays `user_id` uuid). Generate migration via `pnpm db:generate`. Because the dev DB is pre-release, applying against a fresh DB is sufficient; no in-place backfill. Add an index on `user_sn` is unnecessary (UNIQUE already creates one).
+
+### 3.3 Repository (`UserRepository` / `DrizzleUserRepository`)
+- `findBySn(userSn): Promise<UserRecord | null>` — lookup by normalized `user_sn`.
+- `countUsers(): Promise<number>` — for empty-DB detection (first-admin).
+- `create(...)` extended to persist `user_sn`, `user_password_hash`, `user_status`. `createMember` path no longer touches `user_db_role`.
+- All writes keep the Phase 2 read-after-write pattern; no `.returning()`.
+
+### 3.4 Connect → migrate → seed sequence (`ConnectWorkspaceHandler`)
+1. Connect with shared service account (unchanged; password entered per connect, never in invite).
+2. `runMigrations()` (Phase 1) — now also applies the auth-column migration.
+3. **Advisory lock** around migrate + first-admin detection so concurrent members/instances against the same shared account don't double-seed: `pg_advisory_lock(<const key>)` … `pg_advisory_unlock`. (MySQL `GET_LOCK` is Phase 4.)
+4. Report DB state to the renderer: `needsSetup` (users table empty) vs `ready` (has users). The renderer routes to setup vs login accordingly.
+
+### 3.5 IPC handlers
+- `auth/LoginHandler` — input `{ userSn, password, rememberMe }`; normalize, `findBySn`, `verifyPassword`, check `user_status==='active'`; on success create + persist session, return the user.
+- `auth/SetupAdminHandler` — only valid when `countUsers()===0` (re-checked under advisory lock); creates the first `admin` user with hashed password; creates session.
+- `auth/LogoutHandler` — clears the persisted session.
+- `auth/SessionStatusHandler` (bootstrap) — read persisted session; if expired → unauthenticated; else re-verify the user row still exists and `user_status==='active'`; return `{ authenticated, user }`.
+- `CreateMemberHandler` — **remove `createRole` call**; insert `users` row with `user_sn` + hashed initial password + `user_role`. `DeleteUserHandler` — stop calling `dropRole`; respect/possibly set `user_status`. Remove now-dead `createRole`/`dropRole` from `PostgresAdapter` (and the `DatabaseAdapter` interface) — they were the only string-interpolated raw SQL (parent §9).
+
+### 3.6 Renderer
+- `auth` store gains a session/`currentUser` layer on top of `isConnected`. `bootstrap()` (existing) extends to: sync connection (existing `WORKSPACE_STATUS`) **then** call `SessionStatus`; expose `isAuthenticated`. Route guard = `isConnected && isAuthenticated`.
+- Routes: `/login` and `/setup` (public-within-connected). After connect, renderer reads `needsSetup`/`ready` and navigates to `/setup` or `/login`; on auth success → app.
+- `LoginPage` + `AdminSetupPage`: **split brand panel** layout (left dark brand panel with Hydra wordmark + tagline; right form). shadcn/Tailwind tokens, dark-mode aware, Pretendard. These set the UX baseline; built with care (frontend-design at implementation time).
+- The existing `WorkspacePage`/connect UI stays for step 1–2 (workspace pick + DB password); login/setup layer on after connection.
+
+## 4. Data Flow
+
+```
+Workspace pick / invite ─▶ DB service password ─▶ connect()
+   ─▶ runMigrations()  ──(pg_advisory_lock)──▶ detect state
+        ├─ users empty ─▶ /setup  ─▶ SetupAdmin ─▶ session ─▶ app
+        └─ users exist ─▶ /login  ─▶ Login      ─▶ session ─▶ app
+App mount ─▶ bootstrap(): connection status + SessionStatus(re-verify exists+active) ─▶ guard
+```
+
+## 5. Error Handling
+- Wrong password / unknown `user_sn` → single generic "invalid credentials" (no user enumeration). `inactive` user → same generic message (don't reveal status).
+- `SetupAdmin` when users already exist → rejected (race lost under lock) → renderer falls back to `/login`.
+- scrypt failure / malformed stored hash → treated as auth failure, logged server-side.
+- Session decode failure / expiry / user-missing / inactive on bootstrap → unauthenticated, route to `/login`.
+- DB/connection errors keep the existing `DatabaseError` wrapping.
+
+## 6. Security
+- Parameterized Drizzle only; remove the last string-interpolated raw SQL (`createRole`/`dropRole`).
+- scrypt with explicit stored params; `timingSafeEqual`; salt ≥16 bytes.
+- Generic auth errors (no enumeration). `user_status='inactive'` honored on next bootstrap / sensitive op (documented limitation: in-flight session persists until relaunch/re-verify — parent §5.4).
+- Backups now contain password hashes (accepted; at-rest encryption out of scope). Least-privilege service-account grant documented (parent §5.7) — doc-only this phase.
+
+## 7. Testing
+- **Unit (no DB):** password hash round-trip + wrong-password rejection + param parsing; `normalizeHandle`; session create/expiry; `user_status` invalidation logic.
+- **Integration (DB-gated, `RUN_DB_TESTS=1`):** auth migration applies on fresh DB + idempotent; `SetupAdmin` seeds first admin then is rejected on second call; concurrent-setup advisory lock (two parallel setups → exactly one admin); `Login` success / wrong-password / inactive; `findBySn` normalization (mixed-case login matches).
+- **Renderer:** guard redirects (unauthenticated → /login; empty DB → /setup); bootstrap re-verify path.
+
+## 8. Out of Scope (later phases)
+- MySQL adapter / `schema.mysql.ts` / `dbms` config (Phase 4).
+- Drop `user_db_role`, remove ROLE remnants, finalize docs (Phase 5).
+- Forced first-login password change, password reset/self-service, at-rest secret encryption.
+
+## 9. Open Questions
+- None blocking. (Advisory-lock key constant, exact brand-panel copy, and token-level visual polish are implementation details resolved in the plan / at build time.)

--- a/drizzle/0002_oval_edwin_jarvis.sql
+++ b/drizzle/0002_oval_edwin_jarvis.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "users" ADD COLUMN "user_sn" varchar(255) NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "user_password_hash" varchar(255) NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "user_status" varchar(20) DEFAULT 'active';--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_user_sn_unique" UNIQUE("user_sn");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1310 @@
+{
+  "id": "e90f48b0-459c-4e3f-bbb2-dac99808e3a2",
+  "prevId": "471ef7af-a292-49af-82dd-4b087ba6d66f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_content": {
+          "name": "comment_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_created_by": {
+          "name": "comment_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_updated_by": {
+          "name": "comment_updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_created_at": {
+          "name": "comment_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_issue_id": {
+          "name": "idx_comments_issue_id",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_issue_id_issues_issue_id_fk": {
+          "name": "comments_issue_id_issues_issue_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "file_updated_at": {
+          "name": "file_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_config": {
+          "name": "integration_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_enabled": {
+          "name": "integration_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "integration_created_at": {
+          "name": "integration_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "integration_updated_at": {
+          "name": "integration_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "invite_code_id": {
+          "name": "invite_code_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_name": {
+          "name": "db_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_relations": {
+      "name": "issue_relations",
+      "schema": "",
+      "columns": {
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_issue_id": {
+          "name": "target_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_created_at": {
+          "name": "relation_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_relations_source": {
+          "name": "idx_issue_relations_source",
+          "columns": [
+            {
+              "expression": "source_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_relations_target": {
+          "name": "idx_issue_relations_target",
+          "columns": [
+            {
+              "expression": "target_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_relations_source_issue_id_issues_issue_id_fk": {
+          "name": "issue_relations_source_issue_id_issues_issue_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_relations_target_issue_id_issues_issue_id_fk": {
+          "name": "issue_relations_target_issue_id_issues_issue_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "target_issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_desc": {
+          "name": "issue_desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_status": {
+          "name": "issue_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_priority": {
+          "name": "issue_priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_category": {
+          "name": "issue_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_created_by": {
+          "name": "issue_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_modified_by": {
+          "name": "issue_modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_assigned_to": {
+          "name": "issue_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_milestone_id": {
+          "name": "issue_milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_created_at": {
+          "name": "issue_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "issue_updated_at": {
+          "name": "issue_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issues_project_id": {
+          "name": "idx_issues_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_assigned_to": {
+          "name": "idx_issues_assigned_to",
+          "columns": [
+            {
+              "expression": "issue_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_milestone_id": {
+          "name": "idx_issues_milestone_id",
+          "columns": [
+            {
+              "expression": "issue_milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_project_id_fk": {
+          "name": "issues_project_id_projects_project_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_issue_milestone_id_milestones_milestone_id_fk": {
+          "name": "issues_issue_milestone_id_milestones_milestone_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "issue_milestone_id"
+          ],
+          "columnsTo": [
+            "milestone_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_files_link": {
+      "name": "issues_files_link",
+      "schema": "",
+      "columns": {
+        "issue_file_link_id": {
+          "name": "issue_file_link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_issues_files_link_issue": {
+          "name": "idx_issues_files_link_issue",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_files_link_file": {
+          "name": "idx_issues_files_link_file",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_files_link_issue_id_issues_issue_id_fk": {
+          "name": "issues_files_link_issue_id_issues_issue_id_fk",
+          "tableFrom": "issues_files_link",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_files_link_file_id_files_file_id_fk": {
+          "name": "issues_files_link_file_id_files_file_id_fk",
+          "tableFrom": "issues_files_link",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "file_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_labels_link": {
+      "name": "issues_labels_link",
+      "schema": "",
+      "columns": {
+        "issue_label_link_id": {
+          "name": "issue_label_link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_issues_labels_link_issue": {
+          "name": "idx_issues_labels_link_issue",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_labels_link_label": {
+          "name": "idx_issues_labels_link_label",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_labels_link_issue_id_issues_issue_id_fk": {
+          "name": "issues_labels_link_issue_id_issues_issue_id_fk",
+          "tableFrom": "issues_labels_link",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_labels_link_label_id_labels_label_id_fk": {
+          "name": "issues_labels_link_label_id_labels_label_id_fk",
+          "tableFrom": "issues_labels_link",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "label_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_color": {
+          "name": "label_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_created_at": {
+          "name": "label_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_title": {
+          "name": "milestone_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_desc": {
+          "name": "milestone_desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_due_date": {
+          "name": "milestone_due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_status": {
+          "name": "milestone_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "milestone_created_at": {
+          "name": "milestone_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "milestone_updated_at": {
+          "name": "milestone_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_milestones_project_id": {
+          "name": "idx_milestones_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestones_project_id_projects_project_id_fk": {
+          "name": "milestones_project_id_projects_project_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_title": {
+          "name": "notification_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_message": {
+          "name": "notification_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_read": {
+          "name": "notification_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "notification_link": {
+          "name": "notification_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_created_at": {
+          "name": "notification_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_user_id_fk": {
+          "name": "notifications_user_id_users_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_desc": {
+          "name": "project_desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_created_by": {
+          "name": "project_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_modified_by": {
+          "name": "project_modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_start_date": {
+          "name": "project_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_end_date": {
+          "name": "project_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_project_key_unique": {
+          "name": "projects_project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_title": {
+          "name": "task_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_completed": {
+          "name": "task_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "task_order": {
+          "name": "task_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "task_created_by": {
+          "name": "task_created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_created_at": {
+          "name": "task_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "task_updated_at": {
+          "name": "task_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tasks_issue_id": {
+          "name": "idx_tasks_issue_id",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_issue_id_issues_issue_id_fk": {
+          "name": "tasks_issue_id_issues_issue_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "issue_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_sn": {
+          "name": "user_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_password_hash": {
+          "name": "user_password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_status": {
+          "name": "user_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_db_role": {
+          "name": "user_db_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_avatar_path": {
+          "name": "user_avatar_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "user_created_at": {
+          "name": "user_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_updated_at": {
+          "name": "user_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_sn_unique": {
+          "name": "users_user_sn_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_sn"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_projects_link": {
+      "name": "users_projects_link",
+      "schema": "",
+      "columns": {
+        "user_project_link_id": {
+          "name": "user_project_link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_projects_link_user": {
+          "name": "idx_users_projects_link_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_projects_link_project": {
+          "name": "idx_users_projects_link_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_projects_link_user_id_users_user_id_fk": {
+          "name": "users_projects_link_user_id_users_user_id_fk",
+          "tableFrom": "users_projects_link",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_projects_link_project_id_projects_project_id_fk": {
+          "name": "users_projects_link_project_id_projects_project_id_fk",
+          "tableFrom": "users_projects_link",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781013595255,
       "tag": "0001_big_havok",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781027624724,
+      "tag": "0002_oval_edwin_jarvis",
+      "breakpoints": true
     }
   ]
 }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
     resolve: {
       alias: {
+        '@/auth': resolve('src/main/core/auth'),
         '@/base': resolve('src/main/core/base'),
         '@/constant': resolve('src/main/core/constant'),
         '@/database': resolve('src/main/core/database'),

--- a/src/main/core/auth/SessionManager.ts
+++ b/src/main/core/auth/SessionManager.ts
@@ -1,0 +1,50 @@
+// 세션 레코드를 safeStorage로 암호화해 userData/session.json 에 영속화 (WorkspaceManager 패턴).
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { app, safeStorage } from 'electron'
+import type { SessionRecord } from './session'
+
+export class SessionManager {
+  private static instance: SessionManager | null = null
+  private storePath: string
+
+  private constructor() {
+    this.storePath = join(app.getPath('userData'), 'session.json')
+  }
+
+  static getInstance(): SessionManager {
+    if (!SessionManager.instance) {
+      SessionManager.instance = new SessionManager()
+    }
+    return SessionManager.instance
+  }
+
+  load(): SessionRecord | null {
+    if (!existsSync(this.storePath)) return null
+    try {
+      const raw = readFileSync(this.storePath)
+      const json = safeStorage.isEncryptionAvailable() ? safeStorage.decryptString(raw) : raw.toString('utf-8')
+      return JSON.parse(json) as SessionRecord
+    } catch {
+      return null
+    }
+  }
+
+  save(session: SessionRecord): void {
+    try {
+      const json = JSON.stringify(session)
+      if (safeStorage.isEncryptionAvailable()) {
+        writeFileSync(this.storePath, safeStorage.encryptString(json))
+      } else {
+        writeFileSync(this.storePath, json, 'utf-8')
+      }
+    } catch (error) {
+      console.warn('[SessionManager] failed to persist session:', error)
+    }
+  }
+
+  clear(): void {
+    if (existsSync(this.storePath)) rmSync(this.storePath)
+  }
+}

--- a/src/main/core/auth/auth.integration.test.ts
+++ b/src/main/core/auth/auth.integration.test.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from '../database/__testutils__/pgTestDb'
+import { PostgresAdapter } from '../database/adapter/PostgresAdapter'
+import { DrizzleUserRepository } from '../database/repository/drizzle/DrizzleUserRepository'
+import { normalizeHandle } from './normalize'
+import { hashPassword, verifyPassword } from './password'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('auth integration', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+    await adapter.runMigrations(resolve(process.cwd(), 'drizzle'))
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  })
+
+  it('auth migration created user_sn / user_password_hash / user_status', async () => {
+    const repo = new DrizzleUserRepository(adapter.getConnection())
+    expect(await repo.count()).toBe(0)
+  })
+
+  it('create + findBySn round-trips with normalized handle and verifiable password', async () => {
+    const repo = new DrizzleUserRepository(adapter.getConnection())
+    const passwordHash = await hashPassword('s3cret')
+    await repo.create({
+      userId: randomUUID(),
+      userSn: normalizeHandle('  AdminUser '),
+      passwordHash,
+      userName: 'Admin',
+      userRole: 'admin'
+    })
+    const found = await repo.findBySn('adminuser')
+    expect(found).not.toBeNull()
+    expect(found?.user_role).toBe('admin')
+    expect(await verifyPassword('s3cret', found!.user_password_hash)).toBe(true)
+    expect(await verifyPassword('wrong', found!.user_password_hash)).toBe(false)
+  })
+
+  it('user_sn UNIQUE prevents duplicates', async () => {
+    const repo = new DrizzleUserRepository(adapter.getConnection())
+    const passwordHash = await hashPassword('x')
+    const sn = normalizeHandle('dupe')
+    await repo.create({ userId: randomUUID(), userSn: sn, passwordHash, userRole: 'member' })
+    await expect(repo.create({ userId: randomUUID(), userSn: sn, passwordHash, userRole: 'member' })).rejects.toThrow()
+  })
+})

--- a/src/main/core/auth/normalize.test.ts
+++ b/src/main/core/auth/normalize.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeHandle } from './normalize'
+
+describe('normalizeHandle', () => {
+  it('trims and lowercases', () => {
+    expect(normalizeHandle('  JuJoyCode ')).toBe('jujoycode')
+    expect(normalizeHandle('A@B.COM')).toBe('a@b.com')
+  })
+})

--- a/src/main/core/auth/normalize.ts
+++ b/src/main/core/auth/normalize.ts
@@ -1,0 +1,5 @@
+// src/main/core/auth/normalize.ts
+// 로그인 핸들/이메일 정규화 — insert 와 lookup 양쪽에서 동일하게 적용한다.
+export function normalizeHandle(value: string): string {
+  return value.trim().toLowerCase()
+}

--- a/src/main/core/auth/password.test.ts
+++ b/src/main/core/auth/password.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { hashPassword, verifyPassword } from './password'
+
+describe('password hashing', () => {
+  it('produces a self-describing scrypt string', async () => {
+    const encoded = await hashPassword('correct horse battery staple')
+    expect(encoded).toMatch(/^scrypt\$N=32768,r=8,p=1\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+$/)
+  })
+
+  it('verifies the correct password', async () => {
+    const encoded = await hashPassword('hunter2')
+    expect(await verifyPassword('hunter2', encoded)).toBe(true)
+  })
+
+  it('rejects a wrong password', async () => {
+    const encoded = await hashPassword('hunter2')
+    expect(await verifyPassword('hunter3', encoded)).toBe(false)
+  })
+
+  it('uses a random salt (two hashes of same input differ)', async () => {
+    const a = await hashPassword('same')
+    const b = await hashPassword('same')
+    expect(a).not.toBe(b)
+    expect(await verifyPassword('same', a)).toBe(true)
+    expect(await verifyPassword('same', b)).toBe(true)
+  })
+
+  it('returns false on a malformed stored hash instead of throwing', async () => {
+    expect(await verifyPassword('x', 'not-a-valid-hash')).toBe(false)
+  })
+})

--- a/src/main/core/auth/password.ts
+++ b/src/main/core/auth/password.ts
@@ -1,0 +1,45 @@
+// scrypt 비밀번호 해싱. 파라미터를 해시 문자열에 함께 저장해 향후 진화 가능.
+// 형식: scrypt$N=32768,r=8,p=1$<saltB64>$<hashB64>
+
+import { randomBytes, type ScryptOptions, scrypt as scryptCb, timingSafeEqual } from 'node:crypto'
+
+const N = 32768 // 2^15
+const R = 8
+const P = 1
+const KEYLEN = 64
+// 메모리 ≈ 128*N*r ≈ 33.5MiB > Node 기본 maxmem(32MiB) → 명시적 maxmem 필수
+const MAXMEM = 64 * 1024 * 1024
+
+/** promisify 대신 직접 래핑 — options 오버로드를 명확히 사용하기 위함 */
+function scrypt(password: string | Buffer, salt: Buffer, keylen: number, options: ScryptOptions): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scryptCb(password, salt, keylen, options, (err, derived) => {
+      if (err) reject(err)
+      else resolve(derived)
+    })
+  })
+}
+
+export async function hashPassword(plain: string): Promise<string> {
+  const salt = randomBytes(16)
+  const derived = await scrypt(plain, salt, KEYLEN, { N, r: R, p: P, maxmem: MAXMEM })
+  return `scrypt$N=${N},r=${R},p=${P}$${salt.toString('base64')}$${derived.toString('base64')}`
+}
+
+export async function verifyPassword(plain: string, encoded: string): Promise<boolean> {
+  try {
+    const parts = encoded.split('$')
+    if (parts.length !== 4 || parts[0] !== 'scrypt') return false
+    const params = Object.fromEntries(parts[1].split(',').map((kv) => kv.split('=')))
+    const n = Number(params.N)
+    const r = Number(params.r)
+    const p = Number(params.p)
+    if (!n || !r || !p) return false
+    const salt = Buffer.from(parts[2], 'base64')
+    const expected = Buffer.from(parts[3], 'base64')
+    const derived = await scrypt(plain, salt, expected.length, { N: n, r, p, maxmem: MAXMEM })
+    return derived.length === expected.length && timingSafeEqual(derived, expected)
+  } catch {
+    return false
+  }
+}

--- a/src/main/core/auth/safeUser.ts
+++ b/src/main/core/auth/safeUser.ts
@@ -1,0 +1,10 @@
+import type { SafeUser, UserRecord } from '@/database/repository/interfaces/UserRepository'
+
+// 비밀번호 해시를 제거해 렌더러로 안전하게 보낼 형태로 변환
+export function toSafeUser(user: UserRecord): SafeUser {
+  const { user_password_hash, ...safe } = user
+  return safe
+}
+
+// 첫 관리자 시드 임계구역을 보호하는 advisory lock 키 (트랜잭션 스코프)
+export const FIRST_ADMIN_LOCK_KEY = 481975

--- a/src/main/core/auth/session.test.ts
+++ b/src/main/core/auth/session.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { createSessionRecord, isExpired, SESSION_TTL_MS } from './session'
+
+const user = { user_id: 'u1', user_sn: 'admin' }
+const NOW = 1_700_000_000_000
+
+describe('session record', () => {
+  it('default TTL is 1 day', () => {
+    const s = createSessionRecord(user, false, NOW)
+    expect(s.expiresAt - s.issuedAt).toBe(SESSION_TTL_MS.default)
+    expect(SESSION_TTL_MS.default).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('remember-me TTL is 30 days', () => {
+    const s = createSessionRecord(user, true, NOW)
+    expect(s.expiresAt - s.issuedAt).toBe(SESSION_TTL_MS.remember)
+    expect(SESSION_TTL_MS.remember).toBe(30 * 24 * 60 * 60 * 1000)
+  })
+
+  it('carries userId + userSn', () => {
+    const s = createSessionRecord(user, false, NOW)
+    expect(s.userId).toBe('u1')
+    expect(s.userSn).toBe('admin')
+  })
+
+  it('isExpired compares against now', () => {
+    const s = createSessionRecord(user, false, NOW)
+    expect(isExpired(s, NOW + 1000)).toBe(false)
+    expect(isExpired(s, s.expiresAt + 1)).toBe(true)
+  })
+})

--- a/src/main/core/auth/session.ts
+++ b/src/main/core/auth/session.ts
@@ -1,0 +1,25 @@
+// src/main/core/auth/session.ts
+// 세션 레코드(순수 로직). 영속화는 SessionManager가 담당한다.
+
+export interface SessionRecord {
+  userId: string
+  userSn: string
+  issuedAt: number
+  expiresAt: number
+}
+
+const DAY = 24 * 60 * 60 * 1000
+export const SESSION_TTL_MS = { default: DAY, remember: 30 * DAY } as const
+
+export function createSessionRecord(
+  user: { user_id: string; user_sn: string },
+  rememberMe: boolean,
+  now: number
+): SessionRecord {
+  const ttl = rememberMe ? SESSION_TTL_MS.remember : SESSION_TTL_MS.default
+  return { userId: user.user_id, userSn: user.user_sn, issuedAt: now, expiresAt: now + ttl }
+}
+
+export function isExpired(session: SessionRecord, now: number): boolean {
+  return now >= session.expiresAt
+}

--- a/src/main/core/database/adapter/DatabaseAdapter.ts
+++ b/src/main/core/database/adapter/DatabaseAdapter.ts
@@ -14,8 +14,6 @@ export interface DatabaseAdapter {
   disconnect(): Promise<void>
   isConnected(): boolean
   getConnection(): unknown
-  createRole(roleName: string, password: string): Promise<void>
-  dropRole(roleName: string): Promise<void>
   runMigrations(migrationsFolder: string): Promise<void>
   transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T>
 }

--- a/src/main/core/database/adapter/PostgresAdapter.ts
+++ b/src/main/core/database/adapter/PostgresAdapter.ts
@@ -1,7 +1,6 @@
 // PostgreSQL 어댑터 - drizzle-orm + pg Pool 기반 구현
 
 import fs from 'node:fs'
-import { sql } from 'drizzle-orm'
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { migrate } from 'drizzle-orm/node-postgres/migrator'
@@ -124,23 +123,6 @@ export class PostgresAdapter implements DatabaseAdapter {
       throw new Error('Database not connected. Call connect() first.')
     }
     return this.db
-  }
-
-  async createRole(roleName: string, password: string): Promise<void> {
-    if (!this.db) {
-      throw new Error('Database not connected. Call connect() first.')
-    }
-    const escapedRole = roleName.replace(/"/g, '""')
-    const escapedPassword = password.replace(/'/g, "''")
-    await this.db.execute(sql.raw(`CREATE ROLE "${escapedRole}" WITH LOGIN PASSWORD '${escapedPassword}'`))
-  }
-
-  async dropRole(roleName: string): Promise<void> {
-    if (!this.db) {
-      throw new Error('Database not connected. Call connect() first.')
-    }
-    const escapedRole = roleName.replace(/"/g, '""')
-    await this.db.execute(sql.raw(`DROP ROLE IF EXISTS "${escapedRole}"`))
   }
 
   async runMigrations(migrationsFolder: string): Promise<void> {

--- a/src/main/core/database/repository/drizzle/DrizzleUserRepository.ts
+++ b/src/main/core/database/repository/drizzle/DrizzleUserRepository.ts
@@ -2,8 +2,9 @@
 
 import { eq, sql } from 'drizzle-orm'
 import * as schema from '../../schema/drizzle/schema'
+import type { RepoExecutor } from '../interfaces/RepoExecutor'
 import type { CreateUserData, UpdateUserData, UserRecord, UserRepository } from '../interfaces/UserRepository'
-import type { DrizzleDb } from './executor'
+import type { DrizzleDb, DrizzleExecutor } from './executor'
 import { selectById } from './readAfterWrite'
 
 const { users } = schema
@@ -16,8 +17,8 @@ export class DrizzleUserRepository implements UserRepository {
     return (rows[0] as UserRecord) ?? null
   }
 
-  async findByDbRole(dbRole: string): Promise<UserRecord | null> {
-    const rows = await this.db.select().from(users).where(eq(users.user_db_role, dbRole)).limit(1)
+  async findBySn(userSn: string): Promise<UserRecord | null> {
+    const rows = await this.db.select().from(users).where(eq(users.user_sn, userSn)).limit(1)
     return (rows[0] as UserRecord) ?? null
   }
 
@@ -26,28 +27,30 @@ export class DrizzleUserRepository implements UserRepository {
     return rows as UserRecord[]
   }
 
-  async create(data: CreateUserData): Promise<UserRecord> {
+  async create(data: CreateUserData, executor: RepoExecutor = this.db): Promise<UserRecord> {
+    const ex = executor as DrizzleExecutor
     const now = new Date()
-    await this.db.insert(users).values({
+    await ex.insert(users).values({
       user_id: data.userId,
-      user_name: data.userName,
-      user_email: data.userEmail,
-      user_db_role: data.userDbRole,
+      user_sn: data.userSn,
+      user_password_hash: data.passwordHash,
+      user_status: data.userStatus ?? 'active',
+      user_name: data.userName ?? null,
+      user_email: data.userEmail ?? null,
       user_role: data.userRole ?? 'member',
       user_avatar_path: data.userAvatarPath ?? null,
       user_created_at: now,
       user_updated_at: now
     })
-    return selectById<UserRecord>(this.db, users, users.user_id, data.userId)
+    return selectById<UserRecord>(ex, users, users.user_id, data.userId)
   }
 
   async update(userId: string, data: UpdateUserData): Promise<UserRecord> {
-    const values: Record<string, unknown> = {
-      user_updated_at: new Date()
-    }
+    const values: Record<string, unknown> = { user_updated_at: new Date() }
     if (data.userName !== undefined) values.user_name = data.userName
     if (data.userEmail !== undefined) values.user_email = data.userEmail
     if (data.userAvatarPath !== undefined) values.user_avatar_path = data.userAvatarPath
+    if (data.userStatus !== undefined) values.user_status = data.userStatus
 
     await this.db.update(users).set(values).where(eq(users.user_id, userId))
     return selectById<UserRecord>(this.db, users, users.user_id, userId)
@@ -58,8 +61,9 @@ export class DrizzleUserRepository implements UserRepository {
     return true
   }
 
-  async count(): Promise<number> {
-    const rows = await this.db.select({ count: sql<number>`count(*)` }).from(users)
+  async count(executor: RepoExecutor = this.db): Promise<number> {
+    const ex = executor as DrizzleExecutor
+    const rows = await ex.select({ count: sql<number>`count(*)` }).from(users)
     return Number(rows[0].count)
   }
 }

--- a/src/main/core/database/repository/drizzle/readAfterWrite.test.ts
+++ b/src/main/core/database/repository/drizzle/readAfterWrite.test.ts
@@ -26,7 +26,15 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('read-after-write (no RETURNING
   it('create() returns the inserted row without RETURNING', async () => {
     const db = adapter.getConnection()
     const userId = randomUUID()
-    await db.insert(schema.users).values({ user_id: userId, user_name: 'tester', user_role: 'admin' })
+    await db
+      .insert(schema.users)
+      .values({
+        user_id: userId,
+        user_sn: userId,
+        user_password_hash: 'test-hash',
+        user_name: 'tester',
+        user_role: 'admin'
+      })
 
     const projectRepo = new DrizzleProjectRepository(db)
     const projectId = randomUUID()
@@ -59,7 +67,15 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('read-after-write (no RETURNING
   it('case-insensitive search matches regardless of case', async () => {
     const db = adapter.getConnection()
     const userId = randomUUID()
-    await db.insert(schema.users).values({ user_id: userId, user_name: 't2', user_role: 'admin' })
+    await db
+      .insert(schema.users)
+      .values({
+        user_id: userId,
+        user_sn: userId,
+        user_password_hash: 'test-hash',
+        user_name: 't2',
+        user_role: 'admin'
+      })
     const projectId = randomUUID()
     await new DrizzleProjectRepository(db).create({
       projectId,

--- a/src/main/core/database/repository/drizzle/readAfterWrite.test.ts
+++ b/src/main/core/database/repository/drizzle/readAfterWrite.test.ts
@@ -26,15 +26,13 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('read-after-write (no RETURNING
   it('create() returns the inserted row without RETURNING', async () => {
     const db = adapter.getConnection()
     const userId = randomUUID()
-    await db
-      .insert(schema.users)
-      .values({
-        user_id: userId,
-        user_sn: userId,
-        user_password_hash: 'test-hash',
-        user_name: 'tester',
-        user_role: 'admin'
-      })
+    await db.insert(schema.users).values({
+      user_id: userId,
+      user_sn: userId,
+      user_password_hash: 'test-hash',
+      user_name: 'tester',
+      user_role: 'admin'
+    })
 
     const projectRepo = new DrizzleProjectRepository(db)
     const projectId = randomUUID()
@@ -67,15 +65,13 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('read-after-write (no RETURNING
   it('case-insensitive search matches regardless of case', async () => {
     const db = adapter.getConnection()
     const userId = randomUUID()
-    await db
-      .insert(schema.users)
-      .values({
-        user_id: userId,
-        user_sn: userId,
-        user_password_hash: 'test-hash',
-        user_name: 't2',
-        user_role: 'admin'
-      })
+    await db.insert(schema.users).values({
+      user_id: userId,
+      user_sn: userId,
+      user_password_hash: 'test-hash',
+      user_name: 't2',
+      user_role: 'admin'
+    })
     const projectId = randomUUID()
     await new DrizzleProjectRepository(db).create({
       projectId,

--- a/src/main/core/database/repository/interfaces/UserRepository.ts
+++ b/src/main/core/database/repository/interfaces/UserRepository.ts
@@ -1,22 +1,10 @@
-// 사용자 리포지토리 인터페이스
-
-export interface CreateUserData {
-  userId: string
-  userName: string
-  userEmail: string
-  userDbRole: string
-  userRole?: 'admin' | 'member'
-  userAvatarPath?: string | null
-}
-
-export interface UpdateUserData {
-  userName?: string
-  userEmail?: string
-  userAvatarPath?: string | null
-}
+import type { RepoExecutor } from './RepoExecutor'
 
 export interface UserRecord {
   user_id: string
+  user_sn: string
+  user_password_hash: string
+  user_status: string | null
   user_name: string | null
   user_email: string | null
   user_db_role: string | null
@@ -26,12 +14,33 @@ export interface UserRecord {
   user_updated_at: Date | null
 }
 
+// 비밀번호 해시를 제외한, 렌더러로 보낼 수 있는 안전한 사용자 형태
+export type SafeUser = Omit<UserRecord, 'user_password_hash'>
+
+export interface CreateUserData {
+  userId: string
+  userSn: string
+  passwordHash: string
+  userName?: string | null
+  userEmail?: string | null
+  userRole?: 'admin' | 'member'
+  userStatus?: string
+  userAvatarPath?: string | null
+}
+
+export interface UpdateUserData {
+  userName?: string
+  userEmail?: string
+  userAvatarPath?: string | null
+  userStatus?: string
+}
+
 export interface UserRepository {
   findById(userId: string): Promise<UserRecord | null>
-  findByDbRole(dbRole: string): Promise<UserRecord | null>
+  findBySn(userSn: string): Promise<UserRecord | null>
   findAll(): Promise<UserRecord[]>
-  create(data: CreateUserData): Promise<UserRecord>
+  create(data: CreateUserData, executor?: RepoExecutor): Promise<UserRecord>
   update(userId: string, data: UpdateUserData): Promise<UserRecord>
   delete(userId: string): Promise<boolean>
-  count(): Promise<number>
+  count(executor?: RepoExecutor): Promise<number>
 }

--- a/src/main/core/database/schema/drizzle/schema.ts
+++ b/src/main/core/database/schema/drizzle/schema.ts
@@ -5,6 +5,9 @@ import { boolean, index, integer, pgTable, text, timestamp, uuid, varchar } from
 // 사용자 테이블
 export const users = pgTable('users', {
   user_id: uuid('user_id').primaryKey(),
+  user_sn: varchar('user_sn', { length: 255 }).notNull().unique(),
+  user_password_hash: varchar('user_password_hash', { length: 255 }).notNull(),
+  user_status: varchar('user_status', { length: 20 }).default('active'),
   user_name: varchar('user_name', { length: 255 }),
   user_email: varchar('user_email', { length: 255 }),
   user_db_role: varchar('user_db_role', { length: 255 }),

--- a/src/main/core/database/transaction.atomicity.test.ts
+++ b/src/main/core/database/transaction.atomicity.test.ts
@@ -28,7 +28,15 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('transaction atomicity', () => 
     const repo = new DrizzleProjectRepository(db)
 
     const userId = randomUUID()
-    await db.insert(schema.users).values({ user_id: userId, user_name: 'tester', user_role: 'admin' })
+    await db
+      .insert(schema.users)
+      .values({
+        user_id: userId,
+        user_sn: userId,
+        user_password_hash: 'test-hash',
+        user_name: 'tester',
+        user_role: 'admin'
+      })
 
     const projectId = randomUUID()
     await expect(

--- a/src/main/core/database/transaction.atomicity.test.ts
+++ b/src/main/core/database/transaction.atomicity.test.ts
@@ -28,15 +28,13 @@ describe.runIf(process.env.RUN_DB_TESTS === '1')('transaction atomicity', () => 
     const repo = new DrizzleProjectRepository(db)
 
     const userId = randomUUID()
-    await db
-      .insert(schema.users)
-      .values({
-        user_id: userId,
-        user_sn: userId,
-        user_password_hash: 'test-hash',
-        user_name: 'tester',
-        user_role: 'admin'
-      })
+    await db.insert(schema.users).values({
+      user_id: userId,
+      user_sn: userId,
+      user_password_hash: 'test-hash',
+      user_name: 'tester',
+      user_role: 'admin'
+    })
 
     const projectId = randomUUID()
     await expect(

--- a/src/main/core/interface/ipc.ts
+++ b/src/main/core/interface/ipc.ts
@@ -8,8 +8,15 @@ import type { MilestoneRecord } from '../database/repository/interfaces/Mileston
 import type { NotificationRecord } from '../database/repository/interfaces/NotificationRepository'
 import type { ProjectRecord } from '../database/repository/interfaces/ProjectRepository'
 import type { TaskRecord } from '../database/repository/interfaces/TaskRepository'
-import type { UserRecord } from '../database/repository/interfaces/UserRepository'
-import type { AuthDeleteUserParams, AuthUpdateUserParams, CreateMemberParams } from './types/auth'
+import type { SafeUser } from '../database/repository/interfaces/UserRepository'
+import type {
+  AuthDeleteUserParams,
+  AuthUpdateUserParams,
+  CreateMemberParams,
+  LoginParams,
+  SessionStatusResponse,
+  SetupAdminParams
+} from './types/auth'
 import type { CreateCommentParams, DeleteCommentParams, ListCommentsParams, UpdateCommentParams } from './types/comment'
 import type { DeleteIntegrationParams, SaveIntegrationParams, TestSlackWebhookParams } from './types/integration'
 import type { InviteApplyParams, InviteCodeInfo, InviteGenerateParams } from './types/invite'
@@ -81,6 +88,10 @@ export enum IpcChannel {
   AUTH_DELETE_USER = 'authDeleteUser',
   AUTH_CREATE_MEMBER = 'authCreateMember',
   AUTH_LIST_USERS = 'authListUsers',
+  AUTH_LOGIN = 'authLogin',
+  AUTH_LOGOUT = 'authLogout',
+  AUTH_SETUP_ADMIN = 'authSetupAdmin',
+  AUTH_SESSION_STATUS = 'authSessionStatus',
 
   // INVITE-
   INVITE_GENERATE = 'inviteGenerate',
@@ -206,15 +217,31 @@ export interface IpcPayloads extends BaseIpcPayloads {
   }
   [IpcChannel.AUTH_UPDATE_USER]: {
     send: AuthUpdateUserParams
-    receive: BaseIpcResponse<UserRecord>
+    receive: BaseIpcResponse<SafeUser>
   }
   [IpcChannel.AUTH_CREATE_MEMBER]: {
     send: CreateMemberParams
-    receive: BaseIpcResponse<UserRecord>
+    receive: BaseIpcResponse<SafeUser>
   }
   [IpcChannel.AUTH_LIST_USERS]: {
     send: undefined
-    receive: BaseIpcResponse<UserRecord[]>
+    receive: BaseIpcResponse<SafeUser[]>
+  }
+  [IpcChannel.AUTH_LOGIN]: {
+    send: LoginParams
+    receive: BaseIpcResponse<SafeUser>
+  }
+  [IpcChannel.AUTH_LOGOUT]: {
+    send: undefined
+    receive: BaseIpcResponse<boolean>
+  }
+  [IpcChannel.AUTH_SETUP_ADMIN]: {
+    send: SetupAdminParams
+    receive: BaseIpcResponse<SafeUser>
+  }
+  [IpcChannel.AUTH_SESSION_STATUS]: {
+    send: undefined
+    receive: BaseIpcResponse<SessionStatusResponse>
   }
 
   // INVITE-

--- a/src/main/core/interface/types/auth.ts
+++ b/src/main/core/interface/types/auth.ts
@@ -1,6 +1,6 @@
-import type { UserRecord } from '../../database/repository/interfaces/UserRepository'
+import type { SafeUser } from '../../database/repository/interfaces/UserRepository'
 
-export type User = UserRecord
+export type User = SafeUser
 
 export interface AuthDeleteUserParams {
   id: string
@@ -13,10 +13,29 @@ export interface AuthUpdateUserParams {
   userAvatarKey?: string | null
 }
 
+// 관리자가 멤버를 만들 때 (ROLE 생성 없음, 초기 비밀번호 설정)
 export interface CreateMemberParams {
+  userSn: string
   userName: string
   userEmail: string
-  dbRoleName: string
-  dbPassword: string
+  initialPassword: string
   userRole?: 'admin' | 'member'
+}
+
+export interface LoginParams {
+  userSn: string
+  password: string
+  rememberMe?: boolean
+}
+
+export interface SetupAdminParams {
+  userSn: string
+  userName: string
+  userEmail?: string
+  password: string
+}
+
+export interface SessionStatusResponse {
+  authenticated: boolean
+  user: SafeUser | null
 }

--- a/src/main/core/interface/types/workspace.ts
+++ b/src/main/core/interface/types/workspace.ts
@@ -1,5 +1,3 @@
-import type { UserRecord } from '../../database/repository/interfaces/UserRepository'
-
 export interface WorkspaceConfig {
   id: string
   name: string
@@ -34,6 +32,5 @@ export interface WorkspaceConnectParams {
 
 export interface WorkspaceStatusResponse {
   connected: boolean
-  user: UserRecord | null
-  isFirstLogin: boolean
+  needsSetup: boolean
 }

--- a/src/main/handler/auth/CreateMemberHandler.ts
+++ b/src/main/handler/auth/CreateMemberHandler.ts
@@ -1,3 +1,6 @@
+import { normalizeHandle } from '@/auth/normalize'
+import { hashPassword } from '@/auth/password'
+import { toSafeUser } from '@/auth/safeUser'
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
 import { type CreateMemberParams, IpcChannel } from '@/interface/CoreInterface'
 import { CoreUtil } from '@/util/CoreUtil'
@@ -8,18 +11,15 @@ export class CreateMemberHandler extends CoreBaseHandler<IpcChannel.AUTH_CREATE_
   }
 
   async handler(params: CreateMemberParams) {
-    // 1. DB 역할 생성
-    await this.repos.db.createRole(params.dbRoleName, params.dbPassword)
-
-    // 2. 사용자 레코드 생성
+    const passwordHash = await hashPassword(params.initialPassword)
     const user = await this.repos.users.create({
       userId: CoreUtil.getUuid(),
+      userSn: normalizeHandle(params.userSn),
+      passwordHash,
       userName: params.userName,
-      userEmail: params.userEmail,
-      userDbRole: params.dbRoleName,
+      userEmail: params.userEmail ? normalizeHandle(params.userEmail) : null,
       userRole: params.userRole ?? 'member'
     })
-
-    return { data: user, error: null }
+    return { data: toSafeUser(user), error: null }
   }
 }

--- a/src/main/handler/auth/DeleteUserHandler.ts
+++ b/src/main/handler/auth/DeleteUserHandler.ts
@@ -1,31 +1,13 @@
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
 import { type AuthDeleteUserParams, IpcChannel } from '@/interface/CoreInterface'
 
-/**
- * 사용자 삭제 기능을 처리하는 핸들러 클래스입니다.
- * @extends CoreBaseHandler
- */
 export class DeleteUserHandler extends CoreBaseHandler<IpcChannel.AUTH_DELETE_USER> {
   constructor() {
     super(IpcChannel.AUTH_DELETE_USER)
   }
 
-  /**
-   * 사용자를 삭제하는 핸들러 메서드
-   * @param {AuthDeleteUserParams} params - 사용자 삭제에 필요한 파라미터
-   * @param {string} params.id - 삭제할 사용자의 ID
-   * @param {boolean} params.shouldSoftDelete - 소프트 삭제 여부
-   */
   async handler(params: AuthDeleteUserParams) {
-    // 1. DB 역할 삭제
-    const user = await this.repos.users.findById(params.id)
-    if (user?.user_db_role) {
-      await this.repos.db.dropRole(user.user_db_role)
-    }
-
-    // 2. 사용자 삭제
     await this.repos.users.delete(params.id)
-
     return { data: null, error: null }
   }
 }

--- a/src/main/handler/auth/ListUsersHandler.ts
+++ b/src/main/handler/auth/ListUsersHandler.ts
@@ -1,3 +1,4 @@
+import { toSafeUser } from '@/auth/safeUser'
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
 import { IpcChannel } from '@/interface/CoreInterface'
 
@@ -8,6 +9,6 @@ export class ListUsersHandler extends CoreBaseHandler<IpcChannel.AUTH_LIST_USERS
 
   async handler() {
     const users = await this.repos.users.findAll()
-    return { data: users, error: null }
+    return { data: users.map(toSafeUser), error: null }
   }
 }

--- a/src/main/handler/auth/LoginHandler.ts
+++ b/src/main/handler/auth/LoginHandler.ts
@@ -17,7 +17,7 @@ export class LoginHandler extends CoreBaseHandler<IpcChannel.AUTH_LOGIN> {
     const user = await this.repos.users.findBySn(sn)
     // 사용자 열거 방지를 위해 미존재/오답/비활성 모두 동일한 일반 오류
     const ok = user ? await verifyPassword(params.password, user.user_password_hash) : false
-    if (!user || !ok || user.user_status === 'inactive') {
+    if (!user || !ok || user.user_status !== 'active') {
       throw new DatabaseError(ErrorCode.AUTH_ERROR, '아이디 또는 비밀번호가 올바르지 않습니다.', null)
     }
     const session = createSessionRecord(

--- a/src/main/handler/auth/LoginHandler.ts
+++ b/src/main/handler/auth/LoginHandler.ts
@@ -1,0 +1,31 @@
+import { normalizeHandle } from '@/auth/normalize'
+import { verifyPassword } from '@/auth/password'
+import { SessionManager } from '@/auth/SessionManager'
+import { toSafeUser } from '@/auth/safeUser'
+import { createSessionRecord } from '@/auth/session'
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { DatabaseError } from '@/error/DatabaseError'
+import { ErrorCode, IpcChannel, type LoginParams } from '@/interface/CoreInterface'
+
+export class LoginHandler extends CoreBaseHandler<IpcChannel.AUTH_LOGIN> {
+  constructor() {
+    super(IpcChannel.AUTH_LOGIN)
+  }
+
+  async handler(params: LoginParams) {
+    const sn = normalizeHandle(params.userSn)
+    const user = await this.repos.users.findBySn(sn)
+    // 사용자 열거 방지를 위해 미존재/오답/비활성 모두 동일한 일반 오류
+    const ok = user ? await verifyPassword(params.password, user.user_password_hash) : false
+    if (!user || !ok || user.user_status === 'inactive') {
+      throw new DatabaseError(ErrorCode.AUTH_ERROR, '아이디 또는 비밀번호가 올바르지 않습니다.', null)
+    }
+    const session = createSessionRecord(
+      { user_id: user.user_id, user_sn: user.user_sn },
+      params.rememberMe ?? false,
+      Date.now()
+    )
+    SessionManager.getInstance().save(session)
+    return { data: toSafeUser(user), error: null }
+  }
+}

--- a/src/main/handler/auth/LogoutHandler.ts
+++ b/src/main/handler/auth/LogoutHandler.ts
@@ -1,0 +1,14 @@
+import { SessionManager } from '@/auth/SessionManager'
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { IpcChannel } from '@/interface/CoreInterface'
+
+export class LogoutHandler extends CoreBaseHandler<IpcChannel.AUTH_LOGOUT> {
+  constructor() {
+    super(IpcChannel.AUTH_LOGOUT)
+  }
+
+  async handler() {
+    SessionManager.getInstance().clear()
+    return { data: true, error: null }
+  }
+}

--- a/src/main/handler/auth/SessionStatusHandler.ts
+++ b/src/main/handler/auth/SessionStatusHandler.ts
@@ -1,0 +1,27 @@
+import { SessionManager } from '@/auth/SessionManager'
+import { toSafeUser } from '@/auth/safeUser'
+import { isExpired } from '@/auth/session'
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { IpcChannel } from '@/interface/CoreInterface'
+
+export class SessionStatusHandler extends CoreBaseHandler<IpcChannel.AUTH_SESSION_STATUS> {
+  constructor() {
+    super(IpcChannel.AUTH_SESSION_STATUS)
+  }
+
+  async handler() {
+    const mgr = SessionManager.getInstance()
+    const session = mgr.load()
+    if (!session || isExpired(session, Date.now())) {
+      mgr.clear()
+      return { data: { authenticated: false, user: null }, error: null }
+    }
+    // 사용자 존재 + 활성 재검증
+    const user = await this.repos.users.findById(session.userId)
+    if (!user || user.user_status === 'inactive') {
+      mgr.clear()
+      return { data: { authenticated: false, user: null }, error: null }
+    }
+    return { data: { authenticated: true, user: toSafeUser(user) }, error: null }
+  }
+}

--- a/src/main/handler/auth/SessionStatusHandler.ts
+++ b/src/main/handler/auth/SessionStatusHandler.ts
@@ -18,7 +18,7 @@ export class SessionStatusHandler extends CoreBaseHandler<IpcChannel.AUTH_SESSIO
     }
     // 사용자 존재 + 활성 재검증
     const user = await this.repos.users.findById(session.userId)
-    if (!user || user.user_status === 'inactive') {
+    if (!user || user.user_status !== 'active') {
       mgr.clear()
       return { data: { authenticated: false, user: null }, error: null }
     }

--- a/src/main/handler/auth/SetupAdminHandler.ts
+++ b/src/main/handler/auth/SetupAdminHandler.ts
@@ -1,0 +1,46 @@
+import { sql } from 'drizzle-orm'
+import { normalizeHandle } from '@/auth/normalize'
+import { hashPassword } from '@/auth/password'
+import { SessionManager } from '@/auth/SessionManager'
+import { FIRST_ADMIN_LOCK_KEY, toSafeUser } from '@/auth/safeUser'
+import { createSessionRecord } from '@/auth/session'
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import type { DrizzleTx } from '@/database/repository/drizzle/executor'
+import { DatabaseError } from '@/error/DatabaseError'
+import { ErrorCode, IpcChannel, type SetupAdminParams } from '@/interface/CoreInterface'
+import { CoreUtil } from '@/util/CoreUtil'
+
+export class SetupAdminHandler extends CoreBaseHandler<IpcChannel.AUTH_SETUP_ADMIN> {
+  constructor() {
+    super(IpcChannel.AUTH_SETUP_ADMIN)
+  }
+
+  async handler(params: SetupAdminParams) {
+    const passwordHash = await hashPassword(params.password)
+    const userId = CoreUtil.getUuid()
+
+    const user = await this.repos.db.transaction(async (tx) => {
+      // 트랜잭션 스코프 advisory lock — 커밋/롤백 시 자동 해제, 동시 시드 직렬화
+      await (tx as DrizzleTx).execute(sql`SELECT pg_advisory_xact_lock(${FIRST_ADMIN_LOCK_KEY})`)
+      const existing = await this.repos.users.count(tx)
+      if (existing > 0) {
+        throw new DatabaseError(ErrorCode.OPERATION_FAILED_ERROR, '이미 관리자 계정이 존재합니다.', null)
+      }
+      return this.repos.users.create(
+        {
+          userId,
+          userSn: normalizeHandle(params.userSn),
+          passwordHash,
+          userName: params.userName,
+          userEmail: params.userEmail ? normalizeHandle(params.userEmail) : null,
+          userRole: 'admin'
+        },
+        tx
+      )
+    })
+
+    const session = createSessionRecord({ user_id: user.user_id, user_sn: user.user_sn }, false, Date.now())
+    SessionManager.getInstance().save(session)
+    return { data: toSafeUser(user), error: null }
+  }
+}

--- a/src/main/handler/auth/UpdateUserHandler.ts
+++ b/src/main/handler/auth/UpdateUserHandler.ts
@@ -1,25 +1,17 @@
+import { toSafeUser } from '@/auth/safeUser'
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
 import { type AuthUpdateUserParams, IpcChannel } from '@/interface/CoreInterface'
 
-/**
- * 사용자 정보를 업데이트하는 핸들러 클래스입니다
- * @extends CoreBaseHandler
- */
 export class UpdateUserHandler extends CoreBaseHandler<IpcChannel.AUTH_UPDATE_USER> {
   constructor() {
     super(IpcChannel.AUTH_UPDATE_USER)
   }
 
-  /**
-   * 사용자 정보를 업데이트합니다
-   */
   async handler(params: AuthUpdateUserParams) {
-    // 사용자 정보 업데이트 (public.users)
     const user = await this.repos.users.update(params.userId, {
       userName: params.userName,
       userAvatarPath: params.userAvatarKey ?? null
     })
-
-    return { data: user, error: null }
+    return { data: toSafeUser(user), error: null }
   }
 }

--- a/src/main/handler/auth/index.ts
+++ b/src/main/handler/auth/index.ts
@@ -1,4 +1,8 @@
 export { CreateMemberHandler } from './CreateMemberHandler'
 export { DeleteUserHandler } from './DeleteUserHandler'
 export { ListUsersHandler } from './ListUsersHandler'
+export { LoginHandler } from './LoginHandler'
+export { LogoutHandler } from './LogoutHandler'
+export { SessionStatusHandler } from './SessionStatusHandler'
+export { SetupAdminHandler } from './SetupAdminHandler'
 export { UpdateUserHandler } from './UpdateUserHandler'

--- a/src/main/handler/workspace/ConnectWorkspaceHandler.ts
+++ b/src/main/handler/workspace/ConnectWorkspaceHandler.ts
@@ -18,7 +18,6 @@ import {
 } from '@/database/repository/drizzle'
 import type * as schema from '@/database/schema/drizzle/schema'
 import { IpcChannel, type WorkspaceConnectParams } from '@/interface/CoreInterface'
-import { CoreUtil } from '@/util/CoreUtil'
 
 export class ConnectWorkspaceHandler extends CoreBaseHandler<IpcChannel.WORKSPACE_CONNECT> {
   constructor() {
@@ -76,25 +75,13 @@ export class ConnectWorkspaceHandler extends CoreBaseHandler<IpcChannel.WORKSPAC
       integrationRepo
     )
 
-    let user = await userRepo.findByDbRole(params.username)
-    const isFirstLogin = !user
-
-    // 첫 연결 시 admin 유저 자동 생성
-    if (isFirstLogin) {
-      user = await userRepo.create({
-        userId: CoreUtil.getUuid(),
-        userName: params.username,
-        userEmail: '',
-        userDbRole: params.username,
-        userRole: 'admin'
-      })
-    }
+    // Phase 3: 연결 시 자동 admin 생성 제거. users 비어있으면 setup 필요.
+    const userCount = await userRepo.count()
 
     return {
       data: {
         connected: true,
-        user,
-        isFirstLogin
+        needsSetup: userCount === 0
       },
       error: null
     }

--- a/src/main/handler/workspace/WorkspaceStatusHandler.ts
+++ b/src/main/handler/workspace/WorkspaceStatusHandler.ts
@@ -9,25 +9,10 @@ export class WorkspaceStatusHandler extends CoreBaseHandler<IpcChannel.WORKSPACE
 
   async handler() {
     const container = RepositoryContainer.getInstance()
-
     if (!container.isInitialized) {
-      return {
-        data: {
-          connected: false,
-          user: null,
-          isFirstLogin: false
-        },
-        error: null
-      }
+      return { data: { connected: false, needsSetup: false }, error: null }
     }
-
-    return {
-      data: {
-        connected: true,
-        user: null,
-        isFirstLogin: false
-      },
-      error: null
-    }
+    const count = await container.users.count()
+    return { data: { connected: true, needsSetup: count === 0 }, error: null }
   }
 }

--- a/src/renderer/src/components/organisms/sidebars/AppSidebar.tsx
+++ b/src/renderer/src/components/organisms/sidebars/AppSidebar.tsx
@@ -28,17 +28,20 @@ import {
   SidebarSeparator,
   useSidebar
 } from '@/organisms/sidebars/Sidebar'
+import { useAuthStore } from '@/stores/auth'
 
 // 알림 뱃지 카운트 (추후 실제 데이터로 교체)
 const NOTIFICATION_COUNT = 0
 
 function WorkspaceHeader() {
   const { currentWorkspace, disconnect } = useAuth()
+  const logout = useAuthStore((s) => s.logout)
   const { state } = useSidebar()
   const navigate = useNavigate()
   const { t } = useTranslation('nav')
 
-  const handleDisconnect = () => {
+  const handleDisconnect = async () => {
+    await logout()
     disconnect()
     navigate({ to: '/workspace' })
   }
@@ -190,12 +193,14 @@ function BottomNavGroup() {
 
 function UserFooter() {
   const { user, disconnect } = useAuth()
+  const logout = useAuthStore((s) => s.logout)
   const { state } = useSidebar()
   const navigate = useNavigate()
   const { theme, setTheme } = useTheme()
   const { t } = useTranslation('nav')
 
-  const handleDisconnect = () => {
+  const handleDisconnect = async () => {
+    await logout()
     disconnect()
     navigate({ to: '/workspace' })
   }

--- a/src/renderer/src/components/pages/AdminSetupPage.tsx
+++ b/src/renderer/src/components/pages/AdminSetupPage.tsx
@@ -1,0 +1,99 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Button } from '@/components/atoms/Button'
+import { Input } from '@/components/atoms/Input'
+import { Label } from '@/components/atoms/Label'
+import { AuthLayout } from '@/components/templates/AuthLayout'
+import { useIpcHandler } from '@/hooks/use-ipc'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { useAuthStore } from '@/stores/auth'
+
+export default function AdminSetupPage() {
+  const { t } = useTranslation('auth')
+  const navigate = useNavigate()
+  const setupAdmin = useIpcHandler(IpcChannel.AUTH_SETUP_ADMIN)
+  const { setUser, setAuthenticated, setNeedsSetup } = useAuthStore()
+  const [form, setForm] = useState({ userSn: '', userName: '', userEmail: '', password: '', confirm: '' })
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (form.password !== form.confirm) {
+      toast.error(t('setup.passwordMismatch'))
+      return
+    }
+    setSubmitting(true)
+    try {
+      const result = await setupAdmin({
+        userSn: form.userSn,
+        userName: form.userName,
+        userEmail: form.userEmail || undefined,
+        password: form.password
+      })
+      if (result.data) {
+        setUser(result.data)
+        setAuthenticated(true)
+        setNeedsSetup(false)
+        navigate({ to: '/' })
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout title={t('setup.title')} subtitle={t('setup.subtitle')}>
+      <form className='space-y-4' onSubmit={handleSubmit}>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userSn'>{t('setup.userSn')}</Label>
+          <Input
+            id='userSn'
+            value={form.userSn}
+            onChange={(e) => setForm({ ...form, userSn: e.target.value })}
+            autoFocus
+          />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userName'>{t('setup.userName')}</Label>
+          <Input id='userName' value={form.userName} onChange={(e) => setForm({ ...form, userName: e.target.value })} />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userEmail'>{t('setup.userEmail')}</Label>
+          <Input
+            id='userEmail'
+            type='email'
+            value={form.userEmail}
+            onChange={(e) => setForm({ ...form, userEmail: e.target.value })}
+          />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='password'>{t('setup.password')}</Label>
+          <Input
+            id='password'
+            type='password'
+            value={form.password}
+            onChange={(e) => setForm({ ...form, password: e.target.value })}
+          />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='confirm'>{t('setup.confirm')}</Label>
+          <Input
+            id='confirm'
+            type='password'
+            value={form.confirm}
+            onChange={(e) => setForm({ ...form, confirm: e.target.value })}
+          />
+        </div>
+        <Button
+          type='submit'
+          className='w-full'
+          disabled={submitting || !form.userSn || !form.userName || !form.password}
+        >
+          {submitting ? t('setup.submitting') : t('setup.submit')}
+        </Button>
+      </form>
+    </AuthLayout>
+  )
+}

--- a/src/renderer/src/components/pages/LoginPage.tsx
+++ b/src/renderer/src/components/pages/LoginPage.tsx
@@ -1,0 +1,58 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/atoms/Button'
+import { Input } from '@/components/atoms/Input'
+import { Label } from '@/components/atoms/Label'
+import { AuthLayout } from '@/components/templates/AuthLayout'
+import { useIpcHandler } from '@/hooks/use-ipc'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { useAuthStore } from '@/stores/auth'
+
+export default function LoginPage() {
+  const { t } = useTranslation('auth')
+  const navigate = useNavigate()
+  const login = useIpcHandler(IpcChannel.AUTH_LOGIN)
+  const { setUser, setAuthenticated } = useAuthStore()
+  const [userSn, setUserSn] = useState('')
+  const [password, setPassword] = useState('')
+  const [rememberMe, setRememberMe] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    try {
+      const result = await login({ userSn, password, rememberMe })
+      if (result.data) {
+        setUser(result.data)
+        setAuthenticated(true)
+        navigate({ to: '/' })
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout title={t('login.title')} subtitle={t('login.subtitle')}>
+      <form className='space-y-4' onSubmit={handleSubmit}>
+        <div className='space-y-1.5'>
+          <Label htmlFor='userSn'>{t('login.userSn')}</Label>
+          <Input id='userSn' value={userSn} onChange={(e) => setUserSn(e.target.value)} autoFocus />
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor='password'>{t('login.password')}</Label>
+          <Input id='password' type='password' value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <label className='flex items-center gap-2 text-sm text-muted-foreground'>
+          <input type='checkbox' checked={rememberMe} onChange={(e) => setRememberMe(e.target.checked)} />
+          {t('login.rememberMe')}
+        </label>
+        <Button type='submit' className='w-full' disabled={submitting || !userSn || !password}>
+          {submitting ? t('login.submitting') : t('login.submit')}
+        </Button>
+      </form>
+    </AuthLayout>
+  )
+}

--- a/src/renderer/src/components/pages/MembersPage.tsx
+++ b/src/renderer/src/components/pages/MembersPage.tsx
@@ -13,14 +13,6 @@ import type { User as UserRecord } from '@/interface/CoreInterface'
 import { IpcChannel } from '@/interface/CoreInterface'
 import { useAuthStore } from '@/stores/auth'
 
-function generateDbRoleName(userName: string): string {
-  const sanitized = userName
-    .toLowerCase()
-    .replace(/\s+/g, '_')
-    .replace(/[^a-z0-9_]/g, '')
-  return `hydra_${sanitized}`
-}
-
 function formatDate(date: Date | string | null): string {
   if (!date) return '-'
   const d = typeof date === 'string' ? new Date(date) : date
@@ -44,10 +36,10 @@ export default function MembersPage() {
   const { currentWorkspace } = useAuthStore()
 
   // Add member form state
+  const [userSn, setUserSn] = useState('')
   const [userName, setUserName] = useState('')
   const [userEmail, setUserEmail] = useState('')
-  const [dbRoleName, setDbRoleName] = useState('')
-  const [dbPassword, setDbPassword] = useState('')
+  const [initialPassword, setInitialPassword] = useState('')
   const [userRole, setUserRole] = useState<'admin' | 'member'>('member')
 
   // Invite state
@@ -67,20 +59,19 @@ export default function MembersPage() {
     loadMembers()
   }, [loadMembers])
 
-  // Auto-generate dbRoleName when userName changes
-  useEffect(() => {
-    setDbRoleName(generateDbRoleName(userName))
-  }, [userName])
-
   const resetAddForm = () => {
+    setUserSn('')
     setUserName('')
     setUserEmail('')
-    setDbRoleName('')
-    setDbPassword('')
+    setInitialPassword('')
     setUserRole('member')
   }
 
   const handleAddMember = async () => {
+    if (!userSn.trim()) {
+      toast.error(t('validation.enterUserSn'))
+      return
+    }
     if (!userName.trim()) {
       toast.error(t('validation.enterName'))
       return
@@ -89,17 +80,17 @@ export default function MembersPage() {
       toast.error(t('validation.enterEmail'))
       return
     }
-    if (!dbPassword.trim()) {
+    if (!initialPassword.trim()) {
       toast.error(t('validation.enterPassword'))
       return
     }
 
     setIsSubmitting(true)
     const result = await window.callApi(IpcChannel.AUTH_CREATE_MEMBER, {
+      userSn: userSn.trim(),
       userName: userName.trim(),
       userEmail: userEmail.trim(),
-      dbRoleName: dbRoleName.trim(),
-      dbPassword: dbPassword.trim(),
+      initialPassword: initialPassword.trim(),
       userRole
     })
     setIsSubmitting(false)
@@ -256,6 +247,15 @@ export default function MembersPage() {
           </DialogHeader>
           <div className='grid gap-4 py-4'>
             <div className='grid gap-2'>
+              <Label htmlFor='userSn'>{t('label.userSn')}</Label>
+              <Input
+                id='userSn'
+                placeholder={t('placeholder.userSn')}
+                value={userSn}
+                onChange={(e) => setUserSn(e.target.value)}
+              />
+            </div>
+            <div className='grid gap-2'>
               <Label htmlFor='userName'>{t('label.name')}</Label>
               <Input
                 id='userName'
@@ -275,23 +275,13 @@ export default function MembersPage() {
               />
             </div>
             <div className='grid gap-2'>
-              <Label htmlFor='dbRoleName'>{t('label.dbRole')}</Label>
+              <Label htmlFor='initialPassword'>{t('label.password')}</Label>
               <Input
-                id='dbRoleName'
-                placeholder={t('placeholder.dbRole')}
-                value={dbRoleName}
-                onChange={(e) => setDbRoleName(e.target.value)}
-              />
-              <p className='text-xs text-muted-foreground'>{t('help.dbRole')}</p>
-            </div>
-            <div className='grid gap-2'>
-              <Label htmlFor='dbPassword'>{t('label.password')}</Label>
-              <Input
-                id='dbPassword'
+                id='initialPassword'
                 type='password'
                 placeholder={t('placeholder.password')}
-                value={dbPassword}
-                onChange={(e) => setDbPassword(e.target.value)}
+                value={initialPassword}
+                onChange={(e) => setInitialPassword(e.target.value)}
               />
             </div>
             <div className='grid gap-2'>

--- a/src/renderer/src/components/pages/WorkspacePage.tsx
+++ b/src/renderer/src/components/pages/WorkspacePage.tsx
@@ -18,7 +18,7 @@ export default function WorkspacePage() {
   const { t } = useTranslation('workspace')
   const { t: tc } = useTranslation('common')
   const navigate = useNavigate()
-  const { setConnected, setCurrentWorkspace, setNeedsSetup } = useAuthStore()
+  const { setConnected, setCurrentWorkspace, setNeedsSetup, setUser, setAuthenticated } = useAuthStore()
   const { workspaces, addWorkspace, removeWorkspace } = useWorkspaceStore()
 
   const saveWorkspace = useIpcHandler(IpcChannel.WORKSPACE_SAVE)
@@ -77,7 +77,19 @@ export default function WorkspacePage() {
         setCurrentWorkspace(ws)
         setNeedsSetup(result.data.needsSetup)
         toast.success(t('toast.connected'))
-        navigate({ to: result.data.needsSetup ? '/setup' : '/login' })
+        if (result.data.needsSetup) {
+          navigate({ to: '/setup' })
+          return
+        }
+        // remember-me: 유효한 세션이 있으면 로그인 건너뜀
+        const session = await window.callApi(IpcChannel.AUTH_SESSION_STATUS)
+        if (session?.data?.authenticated && session.data.user) {
+          setUser(session.data.user)
+          setAuthenticated(true)
+          navigate({ to: '/' })
+        } else {
+          navigate({ to: '/login' })
+        }
       }
     } finally {
       setConnecting(false)

--- a/src/renderer/src/components/pages/WorkspacePage.tsx
+++ b/src/renderer/src/components/pages/WorkspacePage.tsx
@@ -18,7 +18,7 @@ export default function WorkspacePage() {
   const { t } = useTranslation('workspace')
   const { t: tc } = useTranslation('common')
   const navigate = useNavigate()
-  const { setUser, setConnected, setCurrentWorkspace } = useAuthStore()
+  const { setConnected, setCurrentWorkspace, setNeedsSetup } = useAuthStore()
   const { workspaces, addWorkspace, removeWorkspace } = useWorkspaceStore()
 
   const saveWorkspace = useIpcHandler(IpcChannel.WORKSPACE_SAVE)
@@ -74,10 +74,10 @@ export default function WorkspacePage() {
       })
       if (result.data) {
         setConnected(true)
-        setUser(result.data.user)
         setCurrentWorkspace(ws)
+        setNeedsSetup(result.data.needsSetup)
         toast.success(t('toast.connected'))
-        navigate({ to: '/' })
+        navigate({ to: result.data.needsSetup ? '/setup' : '/login' })
       }
     } finally {
       setConnecting(false)

--- a/src/renderer/src/components/templates/AuthLayout.tsx
+++ b/src/renderer/src/components/templates/AuthLayout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+
+// 좌측 브랜드 패널 + 우측 폼. 인증 화면(로그인/셋업)의 공통 셸이자 앱 UX 기준 레이아웃.
+export function AuthLayout({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
+  return (
+    <div className='flex min-h-screen'>
+      {/* Brand panel */}
+      <div className='hidden md:flex md:w-1/2 flex-col justify-between bg-zinc-900 p-10 text-zinc-50'>
+        <div className='flex size-9 items-center justify-center rounded-lg bg-zinc-50 font-bold text-zinc-900'>H</div>
+        <div className='space-y-2'>
+          <div className='text-2xl font-bold'>Hydra</div>
+          <p className='text-sm leading-relaxed text-zinc-400'>가볍고 빠른 이슈·프로젝트 관리</p>
+        </div>
+        <div className='text-xs text-zinc-600'>v3 workspace</div>
+      </div>
+      {/* Form panel */}
+      <div className='flex w-full items-center justify-center bg-background p-6 md:w-1/2'>
+        <div className='w-full max-w-sm space-y-6'>
+          <div className='space-y-1'>
+            <h1 className='text-xl font-bold text-foreground'>{title}</h1>
+            <p className='text-sm text-muted-foreground'>{subtitle}</p>
+          </div>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/locales/en/auth.json
+++ b/src/renderer/src/locales/en/auth.json
@@ -1,0 +1,25 @@
+{
+  "login": {
+    "title": "Sign In",
+    "subtitle": "Continue with your account",
+    "userSn": "Username",
+    "password": "Password",
+    "rememberMe": "Stay signed in (30 days)",
+    "submit": "Sign In",
+    "submitting": "Signing in...",
+    "failed": "Login failed."
+  },
+  "setup": {
+    "title": "Create Admin Account",
+    "subtitle": "Set up the first admin account for this workspace",
+    "userSn": "Username",
+    "userName": "Name",
+    "userEmail": "Email (optional)",
+    "password": "Password",
+    "confirm": "Confirm Password",
+    "submit": "Create Admin Account",
+    "submitting": "Setting up...",
+    "failed": "Admin setup failed.",
+    "passwordMismatch": "Passwords do not match."
+  }
+}

--- a/src/renderer/src/locales/en/member.json
+++ b/src/renderer/src/locales/en/member.json
@@ -11,15 +11,17 @@
   },
   "label": {
     "unknown": "Unknown",
+    "userSn": "Username",
     "name": "Name",
     "email": "Email",
     "dbRole": "Database Role",
-    "password": "Database Password",
+    "password": "Password",
     "role": "Role",
     "inviteCode": "Invite Code",
     "expiration": "Expiration"
   },
   "placeholder": {
+    "userSn": "Login username",
     "name": "John Doe",
     "email": "john@example.com",
     "dbRole": "hydra_johndoe",
@@ -46,8 +48,9 @@
     "generateFailed": "Failed to generate invite code"
   },
   "validation": {
+    "enterUserSn": "Enter a username",
     "enterName": "Please enter a user name",
     "enterEmail": "Please enter an email",
-    "enterPassword": "Please enter a database password"
+    "enterPassword": "Please enter a password"
   }
 }

--- a/src/renderer/src/locales/index.ts
+++ b/src/renderer/src/locales/index.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import en_auth from './en/auth.json'
 import en_common from './en/common.json'
 import en_dashboard from './en/dashboard.json'
 import en_issue from './en/issue.json'
@@ -8,6 +9,7 @@ import en_nav from './en/nav.json'
 import en_project from './en/project.json'
 import en_settings from './en/settings.json'
 import en_workspace from './en/workspace.json'
+import ko_auth from './ko/auth.json'
 import ko_common from './ko/common.json'
 import ko_dashboard from './ko/dashboard.json'
 import ko_issue from './ko/issue.json'
@@ -20,6 +22,7 @@ import ko_workspace from './ko/workspace.json'
 export const defaultNS = 'common'
 export const resources = {
   ko: {
+    auth: ko_auth,
     common: ko_common,
     nav: ko_nav,
     project: ko_project,
@@ -30,6 +33,7 @@ export const resources = {
     settings: ko_settings
   },
   en: {
+    auth: en_auth,
     common: en_common,
     nav: en_nav,
     project: en_project,

--- a/src/renderer/src/locales/ko/auth.json
+++ b/src/renderer/src/locales/ko/auth.json
@@ -1,0 +1,25 @@
+{
+  "login": {
+    "title": "로그인",
+    "subtitle": "계정으로 계속",
+    "userSn": "아이디",
+    "password": "비밀번호",
+    "rememberMe": "로그인 유지 (30일)",
+    "submit": "로그인",
+    "submitting": "로그인 중...",
+    "failed": "로그인에 실패했습니다."
+  },
+  "setup": {
+    "title": "관리자 계정 만들기",
+    "subtitle": "이 워크스페이스의 첫 관리자 계정을 설정하세요",
+    "userSn": "아이디",
+    "userName": "이름",
+    "userEmail": "이메일 (선택)",
+    "password": "비밀번호",
+    "confirm": "비밀번호 확인",
+    "submit": "관리자 계정 만들기",
+    "submitting": "설정 중...",
+    "failed": "관리자 설정에 실패했습니다.",
+    "passwordMismatch": "비밀번호가 일치하지 않습니다."
+  }
+}

--- a/src/renderer/src/locales/ko/member.json
+++ b/src/renderer/src/locales/ko/member.json
@@ -11,15 +11,17 @@
   },
   "label": {
     "unknown": "알 수 없음",
+    "userSn": "아이디",
     "name": "이름",
     "email": "이메일",
     "dbRole": "데이터베이스 역할",
-    "password": "데이터베이스 비밀번호",
+    "password": "비밀번호",
     "role": "역할",
     "inviteCode": "초대 코드",
     "expiration": "만료 기간"
   },
   "placeholder": {
+    "userSn": "로그인 아이디",
     "name": "홍길동",
     "email": "hong@example.com",
     "dbRole": "hydra_honggildong",
@@ -46,8 +48,9 @@
     "generateFailed": "초대 코드 생성에 실패했습니다"
   },
   "validation": {
+    "enterUserSn": "아이디를 입력하세요",
     "enterName": "사용자 이름을 입력해주세요",
     "enterEmail": "이메일을 입력해주세요",
-    "enterPassword": "데이터베이스 비밀번호를 입력해주세요"
+    "enterPassword": "비밀번호를 입력해주세요"
   }
 }

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -9,7 +9,7 @@ import './index.css'
 import './locales'
 
 function InnerApp() {
-  const { user, isConnected, disconnect, isBootstrapped, bootstrap } = useAuthStore()
+  const { user, isConnected, isAuthenticated, needsSetup, disconnect, isBootstrapped, bootstrap } = useAuthStore()
 
   // 앱 진입 시 1회 main 프로세스 상태와 동기화.
   // main이 재시작되어 RepositoryContainer 가 비어있는 경우 persist 된 isConnected 를 초기화한다.
@@ -23,7 +23,12 @@ function InnerApp() {
     return <EmptyPage />
   }
 
-  return <RouterProvider router={router} context={{ auth: { user, isConnected, disconnect } }} />
+  return (
+    <RouterProvider
+      router={router}
+      context={{ auth: { user, isConnected, isAuthenticated, needsSetup, disconnect } }}
+    />
+  )
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/renderer/src/routers/routerContext.ts
+++ b/src/renderer/src/routers/routerContext.ts
@@ -3,6 +3,8 @@ import type { User } from '@/interface/CoreInterface'
 export interface RouterContext {
   auth: {
     isConnected: boolean
+    isAuthenticated: boolean
+    needsSetup: boolean
     user: User | null
     disconnect: () => void
   }

--- a/src/renderer/src/routers/routes.tsx
+++ b/src/renderer/src/routers/routes.tsx
@@ -39,13 +39,12 @@ export const authenticatedRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: '_authenticated',
   beforeLoad: ({ context }) => {
-    const { isConnected, user, disconnect } = context.auth
-    if (isConnected && !user) {
-      disconnect()
-      throw redirect({ to: '/workspace' })
-    }
+    const { isConnected, isAuthenticated, needsSetup } = context.auth
     if (!isConnected) {
       throw redirect({ to: '/workspace' })
+    }
+    if (!isAuthenticated) {
+      throw redirect({ to: needsSetup ? '/setup' : '/login' })
     }
   },
   component: MainLayout
@@ -174,12 +173,38 @@ export const workspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/workspace',
   beforeLoad: ({ context }) => {
-    const { isConnected, user } = context.auth
-    if (isConnected && user) {
+    const { isConnected, isAuthenticated } = context.auth
+    if (isConnected && isAuthenticated) {
       throw redirect({ to: '/' })
     }
   },
   component: lazyRoute(() => import('@/pages/WorkspacePage'))
+})
+
+// Login (public)
+export const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  beforeLoad: ({ context }) => {
+    const { isConnected, isAuthenticated, needsSetup } = context.auth
+    if (!isConnected) throw redirect({ to: '/workspace' })
+    if (isAuthenticated) throw redirect({ to: '/' })
+    if (needsSetup) throw redirect({ to: '/setup' })
+  },
+  component: lazyRoute(() => import('@/components/pages/LoginPage'))
+})
+
+// Admin Setup (public)
+export const setupRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/setup',
+  beforeLoad: ({ context }) => {
+    const { isConnected, isAuthenticated, needsSetup } = context.auth
+    if (!isConnected) throw redirect({ to: '/workspace' })
+    if (isAuthenticated) throw redirect({ to: '/' })
+    if (!needsSetup) throw redirect({ to: '/login' })
+  },
+  component: lazyRoute(() => import('@/components/pages/AdminSetupPage'))
 })
 
 // Route Tree
@@ -206,5 +231,7 @@ export const routeTree = rootRoute.addChildren([
       settingsIntegrationsRoute
     ])
   ]),
-  workspaceRoute
+  workspaceRoute,
+  loginRoute,
+  setupRoute
 ])

--- a/src/renderer/src/stores/auth.ts
+++ b/src/renderer/src/stores/auth.ts
@@ -5,11 +5,13 @@ import type { AuthState, WorkspaceConfig } from '@/types/auth'
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set, get) => ({
+    (set, _get) => ({
       user: null,
       isConnected: false,
       isLoading: false,
       isBootstrapped: false,
+      isAuthenticated: false,
+      needsSetup: false,
       error: null,
       currentWorkspace: null,
 
@@ -17,11 +19,15 @@ export const useAuthStore = create<AuthState>()(
       setConnected: (connected: boolean) => set({ isConnected: connected }),
       setCurrentWorkspace: (ws: WorkspaceConfig | null) => set({ currentWorkspace: ws }),
       setError: (error: Error | null) => set({ error }),
+      setAuthenticated: (v: boolean) => set({ isAuthenticated: v }),
+      setNeedsSetup: (v: boolean) => set({ needsSetup: v }),
 
       disconnect: () =>
         set({
           user: null,
           isConnected: false,
+          isAuthenticated: false,
+          needsSetup: false,
           currentWorkspace: null
         }),
 
@@ -29,35 +35,46 @@ export const useAuthStore = create<AuthState>()(
         set({
           user: null,
           isConnected: false,
+          isAuthenticated: false,
+          needsSetup: false,
           isLoading: false,
           error: null,
           currentWorkspace: null
         }),
 
+      logout: async () => {
+        try {
+          await window.callApi(IpcChannel.AUTH_LOGOUT)
+        } finally {
+          set({ user: null, isAuthenticated: false })
+        }
+      },
+
       // 앱 부팅 시 main 프로세스의 실제 연결 상태와 renderer persist 상태를 동기화한다.
       // main이 재시작되어 RepositoryContainer 가 초기화되지 않은 상태이면 disconnect 처리.
       bootstrap: async () => {
         try {
-          const result = await window.callApi(IpcChannel.WORKSPACE_STATUS)
-          const connectedInMain = result?.data?.connected === true
-          const { isConnected } = get()
+          const status = await window.callApi(IpcChannel.WORKSPACE_STATUS)
+          const connectedInMain = status?.data?.connected === true
+          const needsSetup = status?.data?.needsSetup === true
 
-          if (isConnected && !connectedInMain) {
-            // renderer는 연결된 것으로 알고 있지만 main은 초기화되어 있지 않음 → 상태 정리
-            set({
-              user: null,
-              isConnected: false,
-              currentWorkspace: null
-            })
+          if (!connectedInMain) {
+            set({ user: null, isConnected: false, isAuthenticated: false, needsSetup: false, currentWorkspace: null })
+            return
           }
-        } catch (error) {
-          // IPC 호출 실패 시에도 안전하게 disconnect 상태로 둔다.
-          console.error('[auth.bootstrap] failed to sync with main', error)
+
+          // 연결됨 → 세션 재검증
+          const session = await window.callApi(IpcChannel.AUTH_SESSION_STATUS)
+          const authed = session?.data?.authenticated === true
           set({
-            user: null,
-            isConnected: false,
-            currentWorkspace: null
+            isConnected: true,
+            needsSetup,
+            isAuthenticated: authed,
+            user: authed ? (session?.data?.user ?? null) : null
           })
+        } catch (error) {
+          console.error('[auth.bootstrap] failed to sync with main', error)
+          set({ user: null, isConnected: false, isAuthenticated: false, needsSetup: false, currentWorkspace: null })
         } finally {
           set({ isBootstrapped: true })
         }
@@ -69,13 +86,10 @@ export const useAuthStore = create<AuthState>()(
       partialize: (state) => ({
         user: state.user,
         isConnected: state.isConnected,
+        isAuthenticated: state.isAuthenticated,
+        needsSetup: state.needsSetup,
         currentWorkspace: state.currentWorkspace
-      }),
-      onRehydrateStorage: () => (state) => {
-        if (state?.isConnected && !state.user) {
-          state.disconnect()
-        }
-      }
+      })
     }
   )
 )

--- a/src/renderer/src/types/auth.ts
+++ b/src/renderer/src/types/auth.ts
@@ -15,13 +15,18 @@ export interface AuthState {
   isConnected: boolean
   isLoading: boolean
   isBootstrapped: boolean
+  isAuthenticated: boolean
+  needsSetup: boolean
   error: Error | null
   currentWorkspace: WorkspaceConfig | null
   setUser: (user: User | null) => void
   setConnected: (connected: boolean) => void
   setCurrentWorkspace: (ws: WorkspaceConfig | null) => void
   setError: (error: Error | null) => void
+  setAuthenticated: (v: boolean) => void
+  setNeedsSetup: (v: boolean) => void
   disconnect: () => void
   reset: () => void
+  logout: () => Promise<void>
   bootstrap: () => Promise<void>
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -30,6 +30,7 @@
     "types": ["electron-vite/node"],
     "baseUrl": ".",
     "paths": {
+      "@/auth/*": ["src/main/core/auth/*"],
       "@/base/*": ["src/main/core/base/*"],
       "@/constant/*": ["src/main/core/constant/*"],
       "@/database/*": ["src/main/core/database/*"],


### PR DESCRIPTION
## 개요

멀티 DBMS 로드맵 **Phase 3 (Authentication Redesign)**. "DB 연결 = 인증" 모델을 버리고, 공유 워크스페이스 연결 위에 **개인 로그인(아이디 + scrypt 비밀번호 + 세션)** 레이어를 추가한다. 첫 관리자 셋업 플로우, PostgreSQL ROLE 없는 멤버 온보딩, 분할 패널 인증 UI(앱 UX 기준점) 포함. PostgreSQL 전용(MySQL은 Phase 4).

스펙: `docs/superpowers/specs/2026-06-10-phase3-auth-redesign-design.md`
계획: `docs/superpowers/plans/2026-06-10-phase3-auth-redesign.md`

## 주요 변경

**백엔드**
- scrypt 비밀번호 해싱(자기기술 형식, 명시적 maxmem) + 핸들 정규화 + 세션 레코드/TTL(기본 1일·기억 30일)
- `SessionManager` — safeStorage 기반 세션 영속화
- `users` 인증 컬럼(`user_sn` UNIQUE NOT NULL / `user_password_hash` / `user_status`) + 마이그레이션 0002
- `UserRepository.findBySn`/`count`/executor 지원, `findByDbRole` 제거
- IPC: `AUTH_LOGIN`/`LOGOUT`/`SETUP_ADMIN`/`SESSION_STATUS` + **`SafeUser`로 비밀번호 해시 IPC 노출 차단**
- 로그인/첫관리자셋업(advisory-lock `pg_advisory_xact_lock`로 동시 시드 직렬화)/로그아웃/세션 재검증 핸들러
- `ConnectWorkspaceHandler`: 자동 admin 생성 제거 → `needsSetup` 보고. `createRole`/`dropRole`(유일한 raw SQL) 제거

**렌더러**
- 인증 스토어 세션 레이어(`isAuthenticated`/`needsSetup`) + bootstrap 재검증
- `/login`·`/setup` 라우트 + 연결·인증 기반 가드, `main.tsx` 라우터 컨텍스트 확장
- 분할 패널 `AuthLayout` + `LoginPage` + `AdminSetupPage` (앱 UX 기준 레이아웃) + i18n(ko·en)
- WorkspacePage 연결 후 `needsSetup`/세션(remember-me) 따라 라우팅, MembersPage 온보딩(아이디+초기 비번)

## 검증

- `pnpm typecheck` (main + renderer) ✅
- 단위 테스트(scrypt/정규화/세션) ✅ — 33 passed
- DB 통합 테스트(마이그레이션/리포지토리/정규화) — 로컬 Docker 부재로 **CI에서 검증**(`RUN_DB_TESTS=1`)
- 계획 단계 4-렌즈 적대적 검증 + Task 7 독립 스펙 리뷰(14/14) + 최종 통합·보안 리뷰 통과
- 최종 리뷰 후속 수정: 로그아웃 시 세션 삭제, 연결 후 세션 재사용, status fail-closed

## 범위 밖 (Phase 4-5)

MySQL 어댑터/`schema.mysql.ts`/`dbms` 설정, `user_db_role` 컬럼 DROP, 강제 초기 비번 변경, 비번 자가 재설정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)