### PR TITLE
docs: README 현행화 + wiki 문서 신설

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # Hydra
 
-Electron 기반 경량 프로젝트/이슈 관리 데스크톱 앱.
+Electron 기반 경량 프로젝트/이슈 관리 데스크톱 앱. 오프라인 우선, 멀티 워크스페이스, 오픈소스.
+사용자가 **자신의 PostgreSQL 또는 MySQL 8 데이터베이스**를 직접 연결해서 사용합니다.
 
-- **Tech**: Electron + React 19 + TypeScript, Drizzle ORM + PostgreSQL
-- **특징**: 오프라인 우선, 멀티 워크스페이스, 오픈소스
+- **Tech**: Electron + React 19 + TypeScript · shadcn/ui + Tailwind CSS v4 · Zustand v5 · Drizzle ORM (PostgreSQL / MySQL 8) · TanStack Router/Table/Form · Tiptap · Recharts · i18next
+- **특징**: 오프라인 우선, 멀티 워크스페이스, BYO-Database(PostgreSQL·MySQL), 2단계 인증
+
+> 📖 더 깊은 설계/운영 문서는 [`wiki/`](./wiki) 디렉터리(또는 GitHub Wiki)를 참고하세요.
+> 아키텍처 요약은 [`CLAUDE.md`](./CLAUDE.md)에 있습니다.
 
 ## Requirements
 
 - Node.js 20+
 - pnpm 9+
-- Docker Desktop (로컬 PostgreSQL용, 직접 설치된 PG를 써도 무방)
+- 연결할 데이터베이스: PostgreSQL 또는 MySQL 8.0+
+  - 로컬 개발용 PostgreSQL은 `pnpm docker:up`으로 컨테이너 기동 가능 (Docker Desktop 필요)
 
 ## Quick Start
 
@@ -17,18 +22,32 @@ Electron 기반 경량 프로젝트/이슈 관리 데스크톱 앱.
 # 1. 의존성 설치
 pnpm install
 
-# 2. 환경 변수 복사 (필요 시 값 조정)
+# 2. 환경 변수 복사 (drizzle CLI 전용 — 앱 런타임 접속과는 분리)
 cp .env.example .env
 
-# 3. PostgreSQL 컨테이너 기동
+# 3. 로컬 PostgreSQL 컨테이너 기동 (선택)
 pnpm docker:up
 
-# 4. Drizzle 스키마를 DB에 push
+# 4. Drizzle 스키마를 DB에 push (로컬 개발용)
 pnpm db:push
 
 # 5. Electron 앱 개발 모드 실행 (hot reload)
 pnpm hot
 ```
+
+앱을 처음 실행하면 **워크스페이스 연결 화면**이 뜹니다. DB 접속 정보를 입력해 연결하면, 빈 DB인 경우
+**관리자 셋업 화면**으로 이동합니다. 자세한 첫 실행 흐름은 [Getting Started](./wiki/Getting-Started.md)를 참고하세요.
+
+## 인증 모델 (2단계)
+
+Hydra는 "DB 연결 = 인증"이 아니라 **워크스페이스 연결과 앱 로그인을 분리**합니다.
+
+1. **워크스페이스 연결** — 공유 서비스 계정으로 DB에 접속 (host/port/dbName/dbms + 자격증명)
+2. **앱 로그인** — 개인 계정(`user_sn` + scrypt 해시 비밀번호 + 세션)으로 로그인
+
+빈 DB에 처음 연결하면 관리자 셋업 화면이 표시되고, 관리자가 앱 내에서 멤버를 생성합니다(DB ROLE 사용 안 함).
+세션은 Electron safeStorage로 영속화되며 "remember me"로 만료를 연장할 수 있습니다.
+자세한 내용은 [Authentication](./wiki/Authentication.md) 참고.
 
 ## 주요 명령어
 
@@ -37,52 +56,58 @@ pnpm hot
 | `pnpm hot` | 개발 서버 (hot reload) |
 | `pnpm dev` | 개발 서버 (hot reload 없음) |
 | `pnpm build` | 타입체크 + 프로덕션 빌드 |
-| `pnpm typecheck` | 타입체크만 |
+| `pnpm typecheck` | 타입체크 (`:node` / `:web` 분리 가능) |
 | `pnpm lint` | Biome lint + autofix |
 | `pnpm format` | Biome format |
-| `pnpm test` | Vitest (1회 실행) |
-| `pnpm test:watch` | Vitest watch |
-| `pnpm docker:up` / `pnpm docker:down` | PostgreSQL 컨테이너 기동/중지 |
-| `pnpm db:push` | Drizzle 스키마 DB에 반영 |
+| `pnpm test` | Vitest (1회 실행) — `:watch` / `:coverage` |
+| `pnpm docker:up` / `pnpm docker:down` | 로컬 PostgreSQL 컨테이너 기동/중지 |
+| `pnpm db:push` | Drizzle 스키마 DB에 반영 (로컬 개발용) |
+| `pnpm db:generate` / `pnpm db:generate:mysql` | 마이그레이션 파일 생성 (PG / MySQL) |
 | `pnpm db:studio` | Drizzle Studio (DB GUI) |
-| `pnpm db:generate` | 마이그레이션 파일 생성 |
 | `pnpm package` / `pnpm make` | Electron Forge 패키징 / 설치파일 빌드 |
 
-## 트러블슈팅
+## 데이터베이스 (PostgreSQL / MySQL 8)
 
-- **`pnpm db:push`가 "connection refused"**: 컨테이너가 healthy 상태가 될 때까지 수 초 기다린 뒤 재시도 (`docker ps` 로 `(healthy)` 확인 가능).
-- **포트 5432 충돌**: 이미 로컬에 PostgreSQL이 떠 있는 경우. 기존 프로세스를 끄거나 `docker-compose.yml`의 포트를 `'15432:5432'` 등으로 변경 후 `.env`의 `DB_PORT`도 같이 수정.
-- **첫 실행 후 워크스페이스 연결 화면**: DB 접속 정보를 앱 UI에서 입력하면 연결 + 초기 사용자 생성. `.env`는 drizzle CLI 전용이고 앱 런타임 접속과는 분리되어 있습니다.
-
-## MySQL 8 workspace
-
-Hydra can connect to MySQL 8.0+ as well as PostgreSQL. Select the DBMS when adding a workspace.
-
-Runtime service account needs DML only (never `ALL PRIVILEGES`):
+워크스페이스 추가 시 DBMS를 선택합니다. 런타임 서비스 계정은 **DML 권한만** 필요합니다(`ALL PRIVILEGES` 금지).
 
 ```sql
+-- MySQL 8 예시
 CREATE USER 'hydra_app'@'%' IDENTIFIED BY '<password>';
 GRANT SELECT, INSERT, UPDATE, DELETE ON hydra.* TO 'hydra_app'@'%';
 ```
 
-Schema migrations run automatically at connect. When the schema is already up-to-date,
-Hydra skips the migrator entirely — so a DML-only account works for normal operation.
+스키마 마이그레이션은 연결 시 자동 실행됩니다. 스키마가 최신이면 마이그레이터를 건너뛰므로 DML-only
+계정으로 정상 동작합니다. **첫 연결 및 앱 업그레이드 후**(대기 중인 마이그레이션이 있을 때)는 DDL 권한
+(`CREATE, ALTER, INDEX, REFERENCES`)이 있는 계정으로 한 번 연결해야 합니다. MySQL은 `utf8mb4` charset 필수.
 
-**First connect and after an app upgrade** (when new migrations are pending), you must
-connect once with an account that can run DDL (`CREATE, ALTER, INDEX, REFERENCES`), or
-use an admin account for that single connect. Subsequent connects can use the DML-only
-account above. The database must use the `utf8mb4` charset.
+> MySQL 워크스페이스에는 절대 `drizzle-kit push`를 쓰지 마세요 — 생성된 마이그레이션만 사용합니다
+> (collation은 스키마 custom type이 소유).
 
-> Note: never run `drizzle-kit push` against a MySQL workspace — use the generated
-> migrations only (collation is owned by the schema's custom types).
+멀티 DBMS 아키텍처(어댑터, 듀얼 스키마, 마이그레이션 전략)는 [Database & Multi-DBMS](./wiki/Database-and-Multi-DBMS.md) 참고.
 
-로컬 개발 시 `docker-compose.yml`에 mysql 서비스를 추가하고 `MYSQL_PORT` 환경변수로 호스트 포트를 변경할 수 있습니다 (예: `'3307:3306'`).
+## 주요 기능
+
+이슈/프로젝트 관리, 마일스톤, 라벨, 체크리스트(Tasks), 이슈 간 관계(blocks/is_blocked_by/relates_to),
+스레드 댓글, 인앱 알림, Slack/GitHub 인테그레이션, Tiptap 리치 텍스트 에디터, 다크모드.
+전체 목록은 [Features](./wiki/Features.md) 참고.
 
 ## 프로젝트 구조
 
-- `src/main/` — Electron main process (IPC, DB, workspace)
-- `src/preload/` — window.callApi 브리지
-- `src/renderer/src/` — React 렌더러 (Atomic Design)
+- `src/main/` — Electron main process (IPC 핸들러, DB 어댑터/리포지토리, 워크스페이스)
+- `src/preload/` — `window.callApi` 타입 IPC 브리지
+- `src/renderer/src/` — React 렌더러 (Atomic Design: atoms → molecules → organisms → templates → pages → layouts)
 - `docs/` — 설계/백로그/계획 문서 (`docs/design/`, `docs/project/`, `docs/plans/`)
+- `wiki/` — 사용자/개발자 위키 문서
+- `drizzle/` — 생성된 마이그레이션 (PG: `drizzle/pg`, MySQL: `drizzle/mysql`)
 
-자세한 아키텍처는 `CLAUDE.md`를 참고하세요.
+## 브랜치 모델
+
+- 활성 개발의 기준 브랜치는 **`main`** 입니다.
+- 과거 갈래(`main`의 옛 상태, `ui-v2`, `develop`, `docs`)는 역사 보존을 위해 **`legacy/*`** 네임스페이스로 아카이브되어 있습니다.
+- 작업 브랜치 컨벤션: `feature/*`, `bugfix/*`, `hotfix/*`.
+
+자세한 내용은 [Branching & Releases](./wiki/Branching-and-Releases.md) 참고.
+
+## Contributing
+
+코드 스타일(Biome), 네이밍, DB 컨벤션은 [Contributing](./wiki/Contributing.md)과 [`CLAUDE.md`](./CLAUDE.md)를 참고하세요.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,58 @@
+# Architecture
+
+Hydra는 Electron의 3-프로세스 모델을 따릅니다: **Main**, **Preload**, **Renderer**.
+
+```
+┌─────────────┐   IPC    ┌──────────────┐   contextBridge   ┌──────────────┐
+│  Renderer   │ <──────> │   Preload    │ <───────────────> │     Main     │
+│ (React UI)  │          │ window.callApi│                   │ (IPC/DB/WS)  │
+└─────────────┘          └──────────────┘                   └──────┬───────┘
+                                                                    │
+                                                          ┌─────────▼─────────┐
+                                                          │ PostgreSQL / MySQL │
+                                                          └────────────────────┘
+```
+
+## Main Process (`src/main/`)
+
+DB 접근은 **메인 프로세스에서만** 일어납니다 (렌더러는 IPC로만 접근).
+
+- **IPC 핸들러** (`handler/`): `CoreBaseHandler<C>` 기반 클래스, `this.repos` getter → `RepositoryContainer`
+  - 도메인별: `workspace/`, `auth/`, `projects/`, `issues/`, `milestones/`, `labels/`, `comments/`,
+    `tasks/`, `issueRelations/`, `notifications/`, `integrations/`, `storage/`, `invite/`, `system/`
+- **DB 추상화** (`core/database/`):
+  - `adapter/DatabaseAdapter.ts` — 멀티 DBMS 인터페이스
+  - `adapter/PostgresAdapter.ts` — Drizzle + pg (`wrapPgError()`로 에러 래핑)
+  - `adapter/MySqlAdapter.ts` — Drizzle + mysql2 (`wrapMySqlError()`)
+  - `adapter/createAdapter.ts` — dbms → 어댑터 팩토리 (알 수 없는 값은 `VALIDATION_ERROR`)
+  - `repository/interfaces/` + `repository/drizzle/` — 리포지토리 (스키마 생성자 주입으로 PG/MySQL 공용)
+  - `schema/drizzle/schema.ts` — Drizzle 테이블 정의 (15개 테이블)
+  - `RepositoryContainer.ts` — 싱글톤 DI 컨테이너
+- **워크스페이스** (`core/workspace/WorkspaceManager.ts`): Electron safeStorage로 암호화 설정 저장
+
+## Preload (`src/preload/`)
+
+`window.callApi`를 노출하는 타입 IPC 브리지. 렌더러는 이 통로로만 메인과 통신합니다.
+
+## Renderer (`src/renderer/src/`)
+
+- **라우팅** (`routers/routes.tsx`): TanStack Router (HashHistory)
+  - Public: `/workspace`, `/login`, `/setup`
+  - Authenticated (`MainLayout`): `/`, `/projects`, `/my-issues`, `/notifications`, `/members`
+    - `/projects/$projectId` (`ProjectLayout`): `/issues`, `/issues/$issueId`, `/tasks`, `/settings`
+    - `/settings` (`SettingsLayout`): account, members, notifications, integrations
+- **컴포넌트**: Atomic Design — `atoms/`(shadcn/ui) → `molecules/` → `organisms/` → `templates/` → `pages/` → `layouts/`
+- **상태 관리** (`stores/`, Zustand): `auth.ts`(연결/세션 + `bootstrap()`), `workspace.ts`, `project.ts`, `issue.ts`, `panel.ts`, `sidebar.ts`
+- **리치 텍스트**: Tiptap · **토스트**: sonner · **리사이즈 패널**: react-resizable-panels
+
+## Bootstrap & Auth Guard
+
+메인 프로세스가 hot-reload로 재시작되면 `RepositoryContainer`는 빈 싱글톤이 되지만 렌더러의 persist된
+연결 상태(`isConnected`)는 유지되어 불일치가 생길 수 있습니다. 이를 막기 위해 auth store의
+`bootstrap()`이 앱 마운트 시 `WORKSPACE_STATUS` IPC로 메인의 실제 상태를 조회해 동기화합니다.
+인증 가드는 JWT가 아니라 연결 상태(`isConnected`) + 세션(`isAuthenticated`) 기반입니다.
+
+## Path Aliases
+
+`electron.vite.config.ts`에 정의 — Main(`@/handler`, `@/database`, …), Preload(`@/interface`),
+Renderer(`@/components`, `@/atoms`, `@/stores`, …). `@/interface`는 main/renderer가 공유합니다.

--- a/wiki/Authentication.md
+++ b/wiki/Authentication.md
@@ -1,0 +1,54 @@
+# Authentication
+
+Hydra는 "DB 연결 = 인증"이라는 옛 모델을 버리고, **워크스페이스 연결**과 **앱 로그인**을 분리한
+2단계 인증을 사용합니다. (이 모델은 멀티 DBMS 로드맵 Phase 3에서 도입되었습니다.)
+
+## 1단계 — 워크스페이스 연결
+
+- 공유 **서비스 계정**으로 DB에 접속합니다 (host/port/dbName/dbms + 자격증명).
+- 서비스 계정은 **DML 권한만** 필요합니다. DB ROLE을 사용하지 않습니다.
+- 연결 정보는 Electron safeStorage로 암호화되어 저장됩니다 (`WorkspaceManager`).
+- 빈 DB에 처음 연결하면 핸들러가 `needsSetup`을 보고하여 관리자 셋업 화면으로 분기합니다.
+
+## 2단계 — 앱 로그인
+
+- 개인 계정으로 로그인: `user_sn`(로그인 아이디) + 비밀번호.
+- 비밀번호는 **scrypt**로 해싱되어 저장됩니다 (자기기술 형식, 명시적 maxmem).
+- IPC 채널: `AUTH_LOGIN` / `AUTH_LOGOUT` / `AUTH_SETUP_ADMIN` / `SESSION_STATUS`.
+- 비밀번호 해시는 IPC로 노출되지 않습니다 — 렌더러에는 `SafeUser`만 전달됩니다.
+
+## 첫 관리자 부트스트랩
+
+- 빈 DB의 첫 연결에서 관리자 계정을 생성합니다.
+- 동시 시드를 막기 위해 PostgreSQL `pg_advisory_xact_lock`(MySQL은 `GET_LOCK`)으로 직렬화합니다.
+- 관리자 생성 후에는 앱 내 멤버 관리에서 멤버를 온보딩합니다 (`CreateMemberHandler` — DB ROLE 생성 없이 `users` 행만 삽입).
+
+## 세션
+
+- 세션은 safeStorage로 영속화됩니다 (`SessionManager`).
+- 기본 TTL 1일, "remember me" 선택 시 30일로 연장됩니다.
+- 앱 마운트 시 `bootstrap()`이 세션을 재검증합니다. 상태 조회 실패 시 fail-closed(로그아웃)로 처리합니다.
+- 로그아웃 시 세션 레코드를 삭제합니다.
+
+## 초대 시스템
+
+- 초대 코드는 **자격증명을 포함하지 않는** 비민감 정보(`host/port/dbName/dbms`)를 base64로 인코딩한 값입니다.
+- 초대를 받은 사용자는 같은 워크스페이스에 연결한 뒤, 관리자가 발급한 계정/초기 비밀번호로 로그인합니다.
+
+## 최소 권한 서비스 계정 (GRANT 계약)
+
+런타임 앱은 DDL을 실행하지 않습니다(마이그레이션은 별도 경로). 서비스 계정에는 DML만 부여하세요.
+
+```sql
+-- MySQL 8
+CREATE USER 'hydra_app'@'%' IDENTIFIED BY '<password>';
+GRANT SELECT, INSERT, UPDATE, DELETE ON hydra.* TO 'hydra_app'@'%';
+```
+
+마이그레이션 권한/흐름은 [Database & Multi-DBMS](./Database-and-Multi-DBMS.md)를 참고하세요.
+
+## 알려진 후속 작업 (의도적 미구현)
+
+- 최초 로그인 시 비밀번호 강제 변경 (스펙상 deferred)
+- 사용자 자가 비밀번호 재설정 (관리자 개입 필요)
+- `integrations` 테이블 시크릿 at-rest 암호화 (Non-Goal — Slack 웹훅/GitHub 토큰 평문 저장)

--- a/wiki/Branching-and-Releases.md
+++ b/wiki/Branching-and-Releases.md
@@ -1,0 +1,40 @@
+# Branching & Releases
+
+## 기준 브랜치
+
+활성 개발의 기준 브랜치는 **`main`** 입니다. 멀티 DBMS 지원 + 인증 모델 재설계 작업(`v3`, Phase 1~5,
+PR #27~#31)이 `main`으로 승격되었습니다(PR #32).
+
+## Legacy 아카이브
+
+과거 갈래들은 역사 보존을 위해 **`legacy/*`** 네임스페이스로 아카이브되어 있습니다. 삭제하지 않고
+그대로 보존되므로 언제든 참조할 수 있습니다.
+
+| 아카이브 브랜치 | 원래 브랜치 | 비고 |
+|----------------|------------|------|
+| `legacy/main` | `main`의 옛 상태 (`2b230bb`) | 승격 전 기준선. 현재 `main` 히스토리의 조상이기도 함 |
+| `legacy/ui-v2` | `ui-v2` | 갈라진 옛 UI 작업(v2) |
+| `legacy/develop` | `develop` | 갈라진 옛 개발 라인 |
+| `legacy/docs` | `docs` | 갈라진 옛 문서 라인 |
+
+## 작업 브랜치 컨벤션
+
+- `feature/*` — 신규 기능
+- `bugfix/*` — 버그 수정
+- `hotfix/*` — 긴급 수정
+
+## 정리 대기 항목
+
+다음 브랜치들은 `main`(또는 `legacy/*`)에 내용이 모두 보존되어 있어 삭제 후보입니다. 환경 제약으로
+자동 삭제가 막혀 있어, 저장소 관리자가 GitHub UI 또는 로컬에서 정리합니다.
+
+```bash
+# 이미 main에 머지된 작업 브랜치 + legacy로 아카이브된 원본
+git push origin --delete v3 \
+  feature/mysql-multidbms-phase1 feature/mysql-multidbms-phase2 \
+  feature/mysql-multidbms-phase3 feature/mysql-multidbms-phase4 \
+  feature/phase5-cleanup \
+  ui-v2 develop docs
+```
+
+> `legacy/*`는 보존 대상이므로 삭제하지 않습니다.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,0 +1,45 @@
+# Configuration
+
+## 환경 변수 (`.env`)
+
+`.env`는 **drizzle CLI 전용**입니다 (`pnpm db:push`, `pnpm db:generate`, `pnpm db:studio`).
+**앱 런타임의 DB 접속과는 분리**되어 있습니다 — 런타임 접속 정보는 앱 UI의 워크스페이스 연결 화면에서
+입력하고 safeStorage에 암호화 저장됩니다.
+
+`.env.example`을 복사해서 시작하세요:
+
+```bash
+cp .env.example .env
+```
+
+로컬 개발용 포트 변경 시:
+- PostgreSQL: `docker-compose.yml`의 포트와 `.env`의 `DB_PORT`를 함께 수정 (예: `'15432:5432'`).
+- MySQL: `docker-compose.yml`에 mysql 서비스를 추가하고 `MYSQL_PORT` 등으로 호스트 포트 조정 (예: `'3307:3306'`).
+
+## 워크스페이스 설정
+
+- 워크스페이스 = 하나의 DB 연결. `WorkspaceConfig`에 `dbms`(`postgres`/`mysql`), host, port, dbName,
+  자격증명 등이 담깁니다.
+- safeStorage로 암호화 저장되며, 앱은 여러 워크스페이스를 저장하고 전환할 수 있습니다.
+- DBMS를 바꾸면 폼의 기본 포트/계정이 자동 전환됩니다 (PG 5432 / MySQL 3306).
+
+## 명령어
+
+| 명령어 | 설명 |
+|--------|------|
+| `pnpm install` | 의존성 설치 |
+| `pnpm hot` / `pnpm dev` | 개발 서버 (hot reload 유/무) |
+| `pnpm build` | 타입체크 + 프로덕션 빌드 |
+| `pnpm typecheck` / `:node` / `:web` | 타입체크 (전체 / main / renderer) |
+| `pnpm lint` / `pnpm format` | Biome lint / format |
+| `pnpm test` / `:watch` / `:coverage` | Vitest |
+| `pnpm docker:up` / `pnpm docker:down` | 로컬 PostgreSQL 컨테이너 |
+| `pnpm db:push` | 스키마 DB 반영 (로컬 개발) |
+| `pnpm db:generate` / `pnpm db:generate:mysql` | 마이그레이션 생성 (PG / MySQL) |
+| `pnpm db:studio` | Drizzle Studio (DB GUI) |
+| `pnpm package` / `pnpm make` | Electron Forge 패키징 / 설치파일 |
+
+## 패키징 주의
+
+생성된 마이그레이션(`drizzle/`)은 패키징 빌드의 `extraResource`로 포함됩니다 — 배포된 앱이 연결 시
+마이그레이션을 적용할 수 있도록 하기 위함입니다.

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,53 @@
+# Contributing
+
+## 개발 환경
+
+[Getting Started](./Getting-Started.md)를 따라 설치/실행하세요. 변경 전후로 다음을 통과시키는 것을 권장합니다.
+
+```bash
+pnpm typecheck   # 타입체크 (node + web)
+pnpm lint        # Biome lint
+pnpm test        # Vitest
+pnpm build       # 빌드까지 확인
+```
+
+## 코드 스타일 (Biome)
+
+- 작은따옴표, 세미콜론 없음, 120자 너비, 2-space 들여쓰기, LF.
+- `pnpm lint` / `pnpm format`으로 자동 정리.
+
+## 네이밍
+
+- PascalCase — 컴포넌트/클래스
+- camelCase — 함수/변수
+- UPPER_SNAKE_CASE — 상수
+- `handle` 접두사 — 이벤트 핸들러
+
+## 임포트 순서
+
+외부 라이브러리 → 내부 모듈 → 상수/타입 → 스타일. 타입 전용은 `import type` 사용.
+
+## 언어
+
+- 사용자 노출 텍스트는 영어.
+- 주석은 한국어 또는 영어.
+
+## 아키텍처 규칙
+
+- **DB 접근은 메인 프로세스에서만** (렌더러는 IPC로만).
+- **Atomic Design**: atoms → molecules → organisms → templates → pages → layouts.
+- **One file, one component/feature**.
+- 자세한 구조는 [Architecture](./Architecture.md)와 `CLAUDE.md` 참고.
+
+## DB 컨벤션
+
+- snake_case 테이블(복수형), snake_case 컬럼(단수형). 상세: `docs/design/convention-db.md`.
+- 새 마이그레이션은 `pnpm db:generate`(PG) / `pnpm db:generate:mysql`(MySQL)로 생성.
+  MySQL 워크스페이스에 `drizzle-kit push` 금지.
+- PG/MySQL 양쪽 스키마(`schema.pg.ts` / `schema.mysql.ts`)의 타입 이식 규칙을 지킬 것
+  ([Database & Multi-DBMS](./Database-and-Multi-DBMS.md) 참고).
+
+## 브랜치 / 커밋
+
+- 브랜치: `feature/*`, `bugfix/*`, `hotfix/*` ([Branching & Releases](./Branching-and-Releases.md)).
+- 기준 브랜치는 `main`. `legacy/*`는 보존용이므로 건드리지 않습니다.

--- a/wiki/Database-and-Multi-DBMS.md
+++ b/wiki/Database-and-Multi-DBMS.md
@@ -1,0 +1,63 @@
+# Database & Multi-DBMS
+
+Hydra는 워크스페이스마다 **PostgreSQL** 또는 **MySQL 8.0+**를 선택해 연결할 수 있습니다.
+이 멀티 DBMS 지원은 Phase 1~5에 걸쳐 구현되었습니다.
+
+## 어댑터 계층
+
+- `adapter/DatabaseAdapter.ts` — 공통 인터페이스.
+- `adapter/PostgresAdapter.ts` — Drizzle + `pg`. 에러는 `wrapPgError()`로 `DatabaseError`에 매핑
+  (28P01/28000→AUTH, 3D000→NOT_FOUND, 42501→PERMISSION, ECONNREFUSED/ENOTFOUND/…→NETWORK).
+- `adapter/MySqlAdapter.ts` — Drizzle + `mysql2`. `wrapMySqlError()`가 `DrizzleQueryError`의 cause
+  체인을 언랩해 원본 errno를 매핑. UTC/`utf8mb4`/SSL 풀, READ COMMITTED.
+- `adapter/createAdapter.ts` — `dbms` 값 → 어댑터 팩토리. 알 수 없는 값은 조용히 PG로 폴백하지 않고
+  `VALIDATION_ERROR`로 fail-fast.
+
+## 듀얼 스키마 전략
+
+`schema.mysql.ts`는 `schema.pg.ts`의 단순 복사가 아니라 타입 이식 규칙을 따릅니다.
+
+| 개념 | PostgreSQL | MySQL 8 |
+|------|------------|---------|
+| UUID PK | `uuid` | `char(36)` + `ascii_bin` collation (customType) |
+| 타임스탬프 | `timestamp(3)` | `datetime(3)` |
+| TEXT UNIQUE | `text` + unique | `varchar` (TEXT는 인덱스 길이 제약) |
+
+- PK는 **UUIDv7** 생성(`CoreUtil.getUuid()`)으로 시간 정렬 → InnoDB/PG 인덱스 지역성 향상. 기존 v4 id는 공존.
+- FK/필터 컬럼에 보조 인덱스를 추가했습니다 (MySQL clustered-PK 대비, PG에선 무해).
+
+## 이식 가능한 쿼리 의미
+
+- 단일 리포지토리 셋이 PG/MySQL을 모두 서빙 — 스키마를 생성자 주입으로 받습니다.
+- pg 전용 `ilike` 대신 `lower(col) LIKE lower(?)` 헬퍼 사용 (와일드카드 이스케이프 포함; MySQL 구문
+  호환을 위해 `ESCAPE` 표기를 조정).
+- MySQL은 `RETURNING`을 지원하지 않으므로, 모든 쓰기는 `.returning()`을 제거하고 앱 생성 PK로 재조회
+  (read-after-write)합니다.
+
+## 마이그레이션 전략
+
+- 생성된 마이그레이션은 `drizzle/pg`, `drizzle/mysql`로 분리됩니다 (듀얼 drizzle config).
+- 연결 시 멱등 실행. 스키마가 최신이면 마이그레이터를 **건너뜁니다** → DML-only 계정 지원.
+- 동시 마이그레이션은 락으로 가드: PG `pg_advisory_lock`, MySQL DB-스코프 `GET_LOCK`.
+- 마이그레이션 실패 시 에러에 맥락을 추가해 자격증명 문제와 DDL 권한 문제를 구분합니다.
+
+### DDL vs DML 권한
+
+- **런타임(정상 동작)**: DML만 (`SELECT/INSERT/UPDATE/DELETE`).
+- **첫 연결 / 앱 업그레이드 후**: 대기 중인 마이그레이션 적용을 위해 DDL 권한
+  (`CREATE, ALTER, INDEX, REFERENCES`) 필요 → 해당 1회만 admin/DDL 계정으로 연결.
+
+> MySQL 워크스페이스에는 절대 `drizzle-kit push`를 쓰지 마세요. collation은 스키마 custom type이
+> 소유하므로, 생성된 마이그레이션만 사용해야 합니다.
+
+## 백업 / 롤백 주의
+
+일부 마이그레이션은 **비가역**입니다(예: `user_db_role` 컬럼 드랍 — PG 0004 / MySQL 0001). 비가역
+마이그레이션 SQL에는 첫 줄에 백업 권고 주석이 있습니다. 운영 DB에 적용 전 백업하세요.
+
+## 테이블 (15개)
+
+`users`, `projects`, `users_projects_link`, `milestones`, `issues`, `files`, `issues_files_link`,
+`comments`, `labels`, `issues_labels_link`, `tasks`, `issue_relations`, `notifications`,
+`integrations`, `invite_codes`. 네이밍 규칙은 `docs/design/convention-db.md` 참고
+(snake_case, 테이블 복수형, 컬럼 단수형).

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,0 +1,36 @@
+# Features
+
+## 핵심
+
+- **프로젝트 / 이슈 관리** — CRUD, 목록/상세, 상태·우선순위·담당자, TanStack Table 기반 목록.
+- **마일스톤** — 일정 단위로 이슈를 묶어 관리 (`milestones` 테이블 + CRUD).
+- **라벨** — 색상 포함 다중 라벨. `labels` + `issues_labels_link` 조인, 라벨 부착/필터.
+- **Tasks(체크리스트)** — 이슈별 체크리스트 항목 CRUD.
+- **이슈 관계** — `issue_relations`로 `blocks` / `is_blocked_by` / `relates_to` 표현.
+- **댓글** — 이슈별 스레드 댓글 전체 CRUD.
+- **파일 첨부** — `files` + `issues_files_link`, 업로드/다운로드.
+
+## 협업 & 알림
+
+- **인앱 알림** — `notifications` 테이블 + 읽음 상태 + 미읽음 카운트 배지.
+- **서비스 인테그레이션** — Slack 웹훅(테스트 전송 포함)과 GitHub 토큰을 `integrations` 테이블에 저장,
+  `/settings/integrations`에서 관리.
+  - 후속: 이슈 이벤트의 Slack 전송, GitHub OAuth/양방향 동기화는 백로그 항목.
+
+## 에디터 & UI
+
+- **리치 텍스트 에디터** — Tiptap 기반. 이슈 설명/댓글에서 서식 편집.
+- **다크모드** — next-themes + CSS 변수 기반 토글 (전 컴포넌트 다크모드 감사는 진행 중 항목).
+- **i18n** — i18next + react-i18next (ko/en).
+- **토스트** — sonner. **리사이즈 패널** — react-resizable-panels.
+
+## 데이터/인증 관련
+
+- **멀티 DBMS** — PostgreSQL / MySQL 8 선택 연결. [Database & Multi-DBMS](./Database-and-Multi-DBMS.md) 참고.
+- **2단계 인증** — 워크스페이스 연결 + 개인 로그인. [Authentication](./Authentication.md) 참고.
+- **초대 시스템** — 비민감 워크스페이스 정보 기반 초대 코드.
+
+## 상태 메모
+
+일부 라우트는 아직 placeholder이거나 백로그에 남아 있습니다 (예: 홈 실데이터 연동, 일부 상세 페이지,
+서버사이드 필터링, /my-issues 등). 최신 우선순위는 `docs/project/backlog.md`를 참고하세요.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,45 @@
+# Getting Started
+
+## 사전 준비
+
+- Node.js 20+
+- pnpm 9+
+- 연결할 데이터베이스: PostgreSQL 또는 MySQL 8.0+
+  - 로컬 개발용 PostgreSQL은 `pnpm docker:up`으로 컨테이너를 띄울 수 있습니다 (Docker Desktop 필요).
+
+## 설치 & 실행
+
+```bash
+pnpm install          # 의존성 설치
+cp .env.example .env  # drizzle CLI 전용 환경 변수 (앱 런타임 접속과 분리)
+pnpm docker:up        # (선택) 로컬 PostgreSQL 컨테이너 기동
+pnpm db:push          # (로컬 개발) Drizzle 스키마를 DB에 반영
+pnpm hot              # Electron 앱 개발 모드 (hot reload)
+```
+
+hot reload 없이 실행하려면 `pnpm dev`를 사용합니다.
+
+## 첫 실행 흐름
+
+1. **워크스페이스 연결 화면** — 앱을 처음 켜면 표시됩니다.
+   - DBMS(PostgreSQL/MySQL), host, port, database 이름, 서비스 계정 자격증명을 입력합니다.
+   - DBMS를 바꾸면 기본 포트/계정이 자동으로 전환됩니다 (PG 5432 / MySQL 3306).
+2. **마이그레이션 자동 실행** — 연결 시 스키마 마이그레이션이 자동 적용됩니다.
+   - 스키마가 이미 최신이면 마이그레이터를 건너뜁니다 → DML-only 계정으로도 동작.
+   - 첫 연결 또는 앱 업그레이드 직후엔 DDL 권한 계정으로 한 번 연결해야 합니다([Database & Multi-DBMS](./Database-and-Multi-DBMS.md) 참고).
+3. **관리자 셋업 화면** — 빈 DB라면 첫 관리자 계정을 만드는 화면이 나옵니다.
+   - `user_sn`(로그인 아이디)와 초기 비밀번호를 설정합니다.
+4. **앱 로그인** — 이후부터는 개인 계정으로 로그인합니다. 관리자는 앱 내 멤버 관리에서 멤버를 추가합니다.
+
+## 멤버 초대
+
+초대 코드는 자격증명을 포함하지 않는 비민감 정보(`host/port/dbName/dbms`)를 base64로 인코딩한 값입니다.
+초대를 받은 사용자는 같은 워크스페이스에 연결한 뒤, 관리자가 발급한 계정으로 로그인합니다.
+자세한 내용은 [Authentication](./Authentication.md)을 참고하세요.
+
+## 트러블슈팅
+
+- **`pnpm db:push`가 "connection refused"**: 컨테이너가 healthy가 될 때까지 수 초 기다린 뒤 재시도 (`docker ps`에서 `(healthy)` 확인).
+- **포트 충돌(5432/3306)**: 로컬에 이미 DB가 떠 있는 경우. 기존 프로세스를 끄거나 `docker-compose.yml`의 포트를 변경(예: `'15432:5432'`, `'3307:3306'`)하고 `.env`의 포트도 함께 수정.
+- **연결은 되는데 로그인 화면이 안 뜸**: 빈 DB라면 관리자 셋업 화면이 먼저 나옵니다. 마이그레이션이 적용됐는지(앱 로그/터미널) 확인하세요.
+- **MySQL 마이그레이션 권한 에러**: 첫 연결/업그레이드 시 DDL 권한이 필요합니다. DML-only 계정으로는 대기 중인 마이그레이션을 적용할 수 없습니다.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,30 @@
+# Hydra Wiki
+
+Hydra는 Electron 기반의 경량 프로젝트/이슈 관리 데스크톱 앱입니다. 오프라인 우선이며, 사용자가 자신의
+**PostgreSQL 또는 MySQL 8** 데이터베이스를 직접 연결해 사용하는 멀티 워크스페이스 오픈소스 도구입니다.
+
+## 문서 색인
+
+| 문서 | 내용 |
+|------|------|
+| [Getting Started](./Getting-Started.md) | 설치, 실행, 첫 워크스페이스 연결, 관리자 셋업 |
+| [Architecture](./Architecture.md) | Electron 3-프로세스 모델, IPC, 디렉터리 구조 |
+| [Authentication](./Authentication.md) | 2단계 인증(워크스페이스 연결 + 앱 로그인), 세션, 초대 |
+| [Database & Multi-DBMS](./Database-and-Multi-DBMS.md) | 어댑터, 듀얼 스키마, 마이그레이션, GRANT 계약 |
+| [Configuration](./Configuration.md) | 환경 변수, 워크스페이스 설정, 명령어 |
+| [Features](./Features.md) | 이슈/프로젝트/마일스톤/라벨/Tasks/댓글/알림/인테그레이션 |
+| [Branching & Releases](./Branching-and-Releases.md) | `main` 기준 브랜치, `legacy/*` 아카이브 |
+| [Contributing](./Contributing.md) | 코드 스타일, 네이밍, DB/브랜치 컨벤션 |
+
+## 빠른 링크
+
+- 저장소 루트의 [`README.md`](../README.md) — 한눈에 보는 시작 가이드
+- [`CLAUDE.md`](../CLAUDE.md) — 아키텍처/컨벤션 요약 (AI 어시스턴트 가이드 겸용)
+- `docs/design/` — DB 컨벤션, ERD, UI 설계
+- `docs/project/` — 백로그, 버그, 마일스톤
+
+## 핵심 개념 한 줄 요약
+
+- **BYO-Database**: 앱이 DB를 내장하지 않습니다. 사용자가 PostgreSQL/MySQL을 연결합니다.
+- **2단계 인증**: 워크스페이스(공유 DB 연결) → 앱 로그인(개인 계정).
+- **워크스페이스**: 하나의 DB 연결 = 하나의 워크스페이스. 여러 워크스페이스를 전환할 수 있습니다.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,11 @@
+### Hydra Wiki
+
+- [Home](./Home.md)
+- [Getting Started](./Getting-Started.md)
+- [Architecture](./Architecture.md)
+- [Authentication](./Authentication.md)
+- [Database & Multi-DBMS](./Database-and-Multi-DBMS.md)
+- [Configuration](./Configuration.md)
+- [Features](./Features.md)
+- [Branching & Releases](./Branching-and-Releases.md)
+- [Contributing](./Contributing.md)


### PR DESCRIPTION
## 개요

`v3 → main` 승격(PR #32) 완료 후 프로젝트 문서를 현재 상태에 맞게 새로 정비합니다.

## 변경 내용

### README.md 현행화
- PostgreSQL **+ MySQL 8** 멀티 DBMS 반영 (기존엔 PostgreSQL만 언급)
- **2단계 인증 모델**(워크스페이스 연결 + 앱 로그인) 섹션 추가 — 옛 "연결=초기 사용자 생성" 서술 교체
- V3 기능, 브랜치 모델(`main` 기준 + `legacy/*` 아카이브), wiki 링크 추가

### wiki/ 신설 (9개 + 사이드바)
- `Home`, `Getting-Started`, `Architecture`, `Authentication`,
  `Database-and-Multi-DBMS`, `Configuration`, `Features`,
  `Branching-and-Releases`, `Contributing`, `_Sidebar`
- `wiki/` 디렉터리는 GitHub Wiki로도 게시할 수 있도록 파일명을 위키 페이지 규칙에 맞춰 작성

## 참고

브랜치 정리(머지된 `feature/*`, `v3`, 아카이브된 원본 `ui-v2/develop/docs` 삭제)는 환경 제약으로
자동 수행이 막혀 있어 `wiki/Branching-and-Releases.md`에 정리용 명령을 기록해 두었습니다.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_