### PR TITLE
perf: 대시보드/내이슈 N+1 제거 + 이슈 캐시 React Query 단일화

### DIFF
--- a/src/main/core/database/repository/drizzle/DrizzleIssueRepository.ts
+++ b/src/main/core/database/repository/drizzle/DrizzleIssueRepository.ts
@@ -1,6 +1,6 @@
 // Drizzle 기반 이슈 리포지토리 구현
 
-import { and, asc, desc, eq, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm'
 import * as pgSchema from '../../schema/drizzle/schema'
 import type {
   CreateIssueData,
@@ -49,6 +49,24 @@ export class DrizzleIssueRepository implements IssueRepository {
   async findByProject(projectId: string): Promise<IssueRecord[]> {
     const { issues } = this.schema
     const rows = await this.db.select().from(issues).where(eq(issues.project_id, projectId))
+    return rows as IssueRecord[]
+  }
+
+  // 담당자에게 할당된 이슈 (전 프로젝트). 단일 쿼리 — N+1 회피.
+  async findByAssignee(userId: string): Promise<IssueRecord[]> {
+    const { issues } = this.schema
+    const rows = await this.db.select().from(issues).where(eq(issues.issue_assigned_to, userId))
+    return rows as IssueRecord[]
+  }
+
+  // 사용자가 속한 프로젝트의 모든 이슈 (대시보드용). 멤버십 서브쿼리로 단일 쿼리 — N+1 회피.
+  async findByUserProjects(userId: string): Promise<IssueRecord[]> {
+    const { issues, usersProjectsLink } = this.schema
+    const memberProjects = this.db
+      .select({ projectId: usersProjectsLink.project_id })
+      .from(usersProjectsLink)
+      .where(eq(usersProjectsLink.user_id, userId))
+    const rows = await this.db.select().from(issues).where(inArray(issues.project_id, memberProjects))
     return rows as IssueRecord[]
   }
 

--- a/src/main/core/database/repository/interfaces/IssueRepository.ts
+++ b/src/main/core/database/repository/interfaces/IssueRepository.ts
@@ -63,6 +63,8 @@ export interface IssueRepository {
   create(data: CreateIssueData): Promise<IssueRecord>
   findById(issueId: string): Promise<IssueRecord | null>
   findByProject(projectId: string): Promise<IssueRecord[]>
+  findByAssignee(userId: string): Promise<IssueRecord[]>
+  findByUserProjects(userId: string): Promise<IssueRecord[]>
   update(issueId: string, data: UpdateIssueData): Promise<IssueRecord>
   delete(issueId: string): Promise<boolean>
   countByProject(projectId: string): Promise<number>

--- a/src/main/core/interface/ipc.ts
+++ b/src/main/core/interface/ipc.ts
@@ -24,7 +24,9 @@ import type {
   CreateIssueParams,
   DeleteIssueParams,
   GetIssueParams,
+  ListAssignedIssuesParams,
   ListIssueParams,
+  ListMemberProjectIssuesParams,
   UpdateIssueParams
 } from './types/issue'
 import type {
@@ -109,6 +111,8 @@ export enum IpcChannel {
   // ISSUE-
   ISSUE_CREATE = 'issueCreate',
   ISSUE_LIST = 'issueList',
+  ISSUE_LIST_ASSIGNED = 'issueListAssigned',
+  ISSUE_LIST_MEMBER_PROJECTS = 'issueListMemberProjects',
   ISSUE_GET = 'issueGet',
   ISSUE_UPDATE = 'issueUpdate',
   ISSUE_DELETE = 'issueDelete',
@@ -284,6 +288,14 @@ export interface IpcPayloads extends BaseIpcPayloads {
   // ISSUE-
   [IpcChannel.ISSUE_LIST]: {
     send: ListIssueParams
+    receive: BaseIpcResponse<IssueRecord[]>
+  }
+  [IpcChannel.ISSUE_LIST_ASSIGNED]: {
+    send: ListAssignedIssuesParams
+    receive: BaseIpcResponse<IssueRecord[]>
+  }
+  [IpcChannel.ISSUE_LIST_MEMBER_PROJECTS]: {
+    send: ListMemberProjectIssuesParams
     receive: BaseIpcResponse<IssueRecord[]>
   }
   [IpcChannel.ISSUE_GET]: {

--- a/src/main/core/interface/types/issue.ts
+++ b/src/main/core/interface/types/issue.ts
@@ -59,3 +59,11 @@ export interface ListIssueParams {
 export interface GetIssueParams {
   issueId: string
 }
+
+export interface ListAssignedIssuesParams {
+  userId: string
+}
+
+export interface ListMemberProjectIssuesParams {
+  userId: string
+}

--- a/src/main/handler/issues/ListAssignedIssuesHandler.ts
+++ b/src/main/handler/issues/ListAssignedIssuesHandler.ts
@@ -1,0 +1,13 @@
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { IpcChannel, type ListAssignedIssuesParams } from '@/interface/CoreInterface'
+
+export class ListAssignedIssuesHandler extends CoreBaseHandler<IpcChannel.ISSUE_LIST_ASSIGNED> {
+  constructor() {
+    super(IpcChannel.ISSUE_LIST_ASSIGNED)
+  }
+
+  async handler(params: ListAssignedIssuesParams) {
+    const issues = await this.repos.issues.findByAssignee(params.userId)
+    return { data: issues, error: null }
+  }
+}

--- a/src/main/handler/issues/ListMemberProjectIssuesHandler.ts
+++ b/src/main/handler/issues/ListMemberProjectIssuesHandler.ts
@@ -1,0 +1,13 @@
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { IpcChannel, type ListMemberProjectIssuesParams } from '@/interface/CoreInterface'
+
+export class ListMemberProjectIssuesHandler extends CoreBaseHandler<IpcChannel.ISSUE_LIST_MEMBER_PROJECTS> {
+  constructor() {
+    super(IpcChannel.ISSUE_LIST_MEMBER_PROJECTS)
+  }
+
+  async handler(params: ListMemberProjectIssuesParams) {
+    const issues = await this.repos.issues.findByUserProjects(params.userId)
+    return { data: issues, error: null }
+  }
+}

--- a/src/main/handler/issues/index.ts
+++ b/src/main/handler/issues/index.ts
@@ -1,5 +1,7 @@
 export { CreateIssueHandler } from './CreateIssueHandler'
 export { DeleteIssueHandler } from './DeleteIssueHandler'
 export { GetIssueHandler } from './GetIssueHandler'
+export { ListAssignedIssuesHandler } from './ListAssignedIssuesHandler'
 export { ListIssueHandler } from './ListIssueHandler'
+export { ListMemberProjectIssuesHandler } from './ListMemberProjectIssuesHandler'
 export { UpdateIssueHandler } from './UpdateIssueHandler'

--- a/src/renderer/src/components/organisms/dialogs/CreateIssueDialog.tsx
+++ b/src/renderer/src/components/organisms/dialogs/CreateIssueDialog.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { ChevronDown, ChevronsUp, ChevronUp, CircleDot, TriangleAlert, User2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,9 +11,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/atoms/Textarea'
 import { useProjectMembers } from '@/hooks/use-members'
 import { useProject } from '@/hooks/use-project'
-import type { Issue as IssueRecord, Project } from '@/interface/CoreInterface'
+import type { Project } from '@/interface/CoreInterface'
 import { IpcChannel } from '@/interface/CoreInterface'
-import { useIssueStore } from '@/stores/issue'
+import { queryKeys } from '@/lib/queryKeys'
 import type { IssuePriority } from '@/types/issue'
 
 interface CreateIssueDialogProps {
@@ -27,9 +28,8 @@ export function CreateIssueDialog({ open, onOpenChange, userId }: CreateIssueDia
   // 프로젝트 상태 관리
   const { projects } = useProject()
 
-  // 이슈 store — 생성 성공 시 캐시된 리스트 갱신
-  const issues = useIssueStore((state) => state.issues)
-  const setIssues = useIssueStore((state) => state.setIssues)
+  // 생성 성공 시 이슈 쿼리 캐시를 무효화해 목록을 갱신한다(React Query 단일 출처).
+  const queryClient = useQueryClient()
 
   // 이슈 생성 폼 상태 관리
   const [selectedProject, setSelectedProject] = useState<string>('')
@@ -97,10 +97,8 @@ export function CreateIssueDialog({ open, onOpenChange, userId }: CreateIssueDia
         return
       }
 
-      // 캐시된 이슈 리스트에 신규 이슈 prepend (있을 때만)
-      if (result.data && issues) {
-        setIssues([result.data as IssueRecord, ...issues])
-      }
+      // 이슈 쿼리 캐시 무효화 → IssuePage/MyIssues/Home이 자동 갱신
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.all })
 
       toast.success(t('toast.created'))
       onOpenChange(false)

--- a/src/renderer/src/components/pages/HomePage.tsx
+++ b/src/renderer/src/components/pages/HomePage.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TrendDataPoint } from '@/atoms/charts/AreaTrendChart'
 import type { StatusData } from '@/atoms/charts/StatusDonutChart'
 import { useAuth } from '@/hooks/use-auth'
-import type { Issue, Project } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
+import { useDashboardIssues } from '@/hooks/use-issues'
 import { getCssVar } from '@/lib/statusTokens'
 import { HomePageTemplate } from '@/templates/HomePageTemplate'
 
@@ -19,79 +18,58 @@ const getStatusColors = () => ({
 export default function HomePage() {
   const { user } = useAuth()
   const { t } = useTranslation('dashboard')
-  const [issueStats, setIssueStats] = useState({
-    total: 0,
-    inProgress: 0,
-    done: 0,
-    review: 0,
-    blocked: 0
-  })
-  const [statusData, setStatusData] = useState<StatusData[]>([])
-  const [trendData, setTrendData] = useState<TrendDataPoint[]>([])
 
-  useEffect(() => {
-    if (!user) return
+  // 사용자가 속한 프로젝트의 모든 이슈를 단일 쿼리로 조회 (N+1 제거)
+  const { data: allIssues = [] } = useDashboardIssues(user?.user_id)
 
-    const loadData = async () => {
-      const projectResult = await window.callApi(IpcChannel.PROJECT_LIST, { userId: user.user_id })
-      const projects = Array.isArray(projectResult.data) ? (projectResult.data as Project[]) : []
+  const { issueStats, statusData, trendData } = useMemo(() => {
+    const statusCount = { open: 0, in_progress: 0, done: 0, review: 0, blocked: 0 }
+    for (const issue of allIssues) {
+      const status = issue.issue_status || 'open'
+      if (status in statusCount) statusCount[status as keyof typeof statusCount]++
+    }
 
-      const allIssues: Issue[] = []
-      for (const project of projects) {
-        const issueResult = await window.callApi(IpcChannel.ISSUE_LIST, { projectId: project.project_id })
-        const projectIssues = Array.isArray(issueResult.data) ? (issueResult.data as Issue[]) : []
-        allIssues.push(...projectIssues)
-      }
+    const statusColors = getStatusColors()
+    const status: StatusData[] = [
+      { name: t('status.inProgress'), value: statusCount.in_progress, color: statusColors.in_progress },
+      { name: t('status.done'), value: statusCount.done, color: statusColors.done },
+      { name: t('status.blocked'), value: statusCount.blocked, color: statusColors.blocked },
+      { name: t('status.review'), value: statusCount.review, color: statusColors.review }
+    ]
 
-      // 상태별 집계
-      const statusCount = { open: 0, in_progress: 0, done: 0, review: 0, blocked: 0 }
-      for (const issue of allIssues) {
-        const status = issue.issue_status || 'open'
-        if (status in statusCount) statusCount[status as keyof typeof statusCount]++
-      }
+    const now = new Date()
+    const months: TrendDataPoint[] = []
+    for (let i = 5; i >= 0; i--) {
+      const date = new Date(now.getFullYear(), now.getMonth() - i, 1)
+      const monthName = date.toLocaleString('ko', { month: 'short' })
+      const monthStart = date.getTime()
+      const monthEnd = new Date(date.getFullYear(), date.getMonth() + 1, 0).getTime()
 
-      setIssueStats({
+      const created = allIssues.filter((issue) => {
+        const ts = new Date(issue.issue_created_at || 0).getTime()
+        return ts >= monthStart && ts <= monthEnd
+      }).length
+
+      const resolved = allIssues.filter((issue) => {
+        const ts = new Date(issue.issue_updated_at || 0).getTime()
+        return issue.issue_status === 'done' && ts >= monthStart && ts <= monthEnd
+      }).length
+
+      months.push({ name: monthName, created, resolved })
+    }
+
+    return {
+      issueStats: {
         total: allIssues.length,
         inProgress: statusCount.in_progress,
         done: statusCount.done,
         review: statusCount.review,
         blocked: statusCount.blocked
-      })
-
-      const statusColors = getStatusColors()
-      setStatusData([
-        { name: t('status.inProgress'), value: statusCount.in_progress, color: statusColors.in_progress },
-        { name: t('status.done'), value: statusCount.done, color: statusColors.done },
-        { name: t('status.blocked'), value: statusCount.blocked, color: statusColors.blocked },
-        { name: t('status.review'), value: statusCount.review, color: statusColors.review }
-      ])
-
-      // 추이 데이터 (최근 6개월)
-      const now = new Date()
-      const months: TrendDataPoint[] = []
-      for (let i = 5; i >= 0; i--) {
-        const date = new Date(now.getFullYear(), now.getMonth() - i, 1)
-        const monthName = date.toLocaleString('ko', { month: 'short' })
-        const monthStart = date.getTime()
-        const monthEnd = new Date(date.getFullYear(), date.getMonth() + 1, 0).getTime()
-
-        const created = allIssues.filter((issue) => {
-          const t = new Date(issue.issue_created_at || 0).getTime()
-          return t >= monthStart && t <= monthEnd
-        }).length
-
-        const resolved = allIssues.filter((issue) => {
-          const t = new Date(issue.issue_updated_at || 0).getTime()
-          return issue.issue_status === 'done' && t >= monthStart && t <= monthEnd
-        }).length
-
-        months.push({ name: monthName, created, resolved })
-      }
-      setTrendData(months)
+      },
+      statusData: status,
+      trendData: months
     }
-
-    loadData()
-  }, [user])
+  }, [allIssues, t])
 
   if (!user) return null
 

--- a/src/renderer/src/hooks/use-issues.ts
+++ b/src/renderer/src/hooks/use-issues.ts
@@ -1,10 +1,7 @@
-import { useQuery } from '@tanstack/react-query'
-import type { Issue as IssueRecord, Project } from '@/interface/CoreInterface'
 import { IpcChannel } from '@/interface/CoreInterface'
 import { mapIssueRecordToIssue } from '@/lib/mapIssue'
 import { queryKeys } from '@/lib/queryKeys'
-import type { Issue } from '@/types/issue'
-import { invokeApi, useApiQuery } from './use-api'
+import { useApiQuery } from './use-api'
 
 /** 프로젝트의 이슈 목록 (IssueTable 입력 형태로 매핑). */
 export function useProjectIssues(projectId: string | undefined) {
@@ -19,19 +16,29 @@ export function useProjectIssues(projectId: string | undefined) {
   )
 }
 
-/** 현재 사용자에게 할당된 이슈 (전 프로젝트 횡단). */
+/** 현재 사용자에게 할당된 이슈 (전 프로젝트, 단일 쿼리). */
 export function useMyIssues(userId: string | undefined) {
-  return useQuery<Issue[], Error>({
-    queryKey: queryKeys.issues.mine(userId ?? ''),
-    enabled: !!userId,
-    queryFn: async () => {
-      const projects = await invokeApi(IpcChannel.PROJECT_LIST, { userId: userId as string })
-      const records: IssueRecord[] = []
-      for (const project of projects as Project[]) {
-        const issues = await invokeApi(IpcChannel.ISSUE_LIST, { projectId: project.project_id, assignedTo: userId })
-        records.push(...issues)
-      }
-      return records.map(mapIssueRecordToIssue)
+  return useApiQuery(
+    queryKeys.issues.mine(userId ?? ''),
+    IpcChannel.ISSUE_LIST_ASSIGNED,
+    { userId: userId ?? '' },
+    {
+      enabled: !!userId,
+      select: (records) => records.map(mapIssueRecordToIssue)
     }
-  })
+  )
+}
+
+/** 대시보드용 — 사용자가 속한 프로젝트의 모든 이슈(원본 레코드, 단일 쿼리). */
+export function useDashboardIssues(userId: string | undefined) {
+  return useApiQuery(
+    queryKeys.issues.dashboard(userId ?? ''),
+    IpcChannel.ISSUE_LIST_MEMBER_PROJECTS,
+    {
+      userId: userId ?? ''
+    },
+    {
+      enabled: !!userId
+    }
+  )
 }

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -6,7 +6,8 @@ export const queryKeys = {
   issues: {
     all: ['issues'] as const,
     byProject: (projectId: string) => ['issues', 'project', projectId] as const,
-    mine: (userId: string) => ['issues', 'mine', userId] as const
+    mine: (userId: string) => ['issues', 'mine', userId] as const,
+    dashboard: (userId: string) => ['issues', 'dashboard', userId] as const
   },
   projects: {
     all: ['projects'] as const,

--- a/src/renderer/src/stores/issue.ts
+++ b/src/renderer/src/stores/issue.ts
@@ -1,23 +1,19 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
-import type { Issue as IssueRecord } from '@/interface/CoreInterface'
 import type { IssueStoreState } from '@/types/issue'
 
 export const useIssueStore = create<IssueStoreState>()(
   persist(
     (set) => ({
-      issues: null,
       selectedIssueId: null,
       isLoading: false,
       error: null,
 
-      setIssues: (issues: IssueRecord[] | null) => set({ issues }),
       setSelectedIssueId: (issueId: string | null) => set({ selectedIssueId: issueId }),
       setLoading: (loading: boolean) => set({ isLoading: loading }),
       setError: (error: Error | null) => set({ error }),
       reset: () =>
         set({
-          issues: null,
           selectedIssueId: null,
           isLoading: false,
           error: null
@@ -26,7 +22,7 @@ export const useIssueStore = create<IssueStoreState>()(
     {
       name: 'hydra-issue-storage',
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ issues: state.issues, selectedIssueId: state.selectedIssueId }),
+      partialize: (state) => ({ selectedIssueId: state.selectedIssueId }),
       skipHydration: false
     }
   )

--- a/src/renderer/src/types/issue.ts
+++ b/src/renderer/src/types/issue.ts
@@ -1,4 +1,4 @@
-import type { IssueCategory, IssuePriority, Issue as IssueRecord } from '@/interface/CoreInterface'
+import type { IssueCategory, IssuePriority } from '@/interface/CoreInterface'
 import type { IssueState } from '@/molecules/issues/IssueBadge'
 
 /**
@@ -53,11 +53,9 @@ export interface IssueTableMeta {
 }
 
 export interface IssueStoreState {
-  issues: IssueRecord[] | null
   selectedIssueId: string | null
   isLoading: boolean
   error: Error | null
-  setIssues: (issues: IssueRecord[] | null) => void
   setSelectedIssueId: (issueId: string | null) => void
   setLoading: (loading: boolean) => void
   setError: (error: Error | null) => void


### PR DESCRIPTION
## 개요

리뷰에서 지적된 **N+1 쿼리**와 **캐시 이중화**를 해소합니다.

## N+1 제거 (백엔드 단일 쿼리)
HomePage·MyIssues가 `PROJECT_LIST` 후 프로젝트마다 `ISSUE_LIST`를 반복 호출하던 N+1을 제거:
- `IssueRepository.findByAssignee(userId)` — 담당 이슈를 전 프로젝트에서 1쿼리
- `IssueRepository.findByUserProjects(userId)` — 멤버십 서브쿼리(`inArray`)로 1쿼리
- 신규 채널 `ISSUE_LIST_ASSIGNED` / `ISSUE_LIST_MEMBER_PROJECTS` + 핸들러 2개

## 캐시 단일화 (React Query)
- `useMyIssues`는 단일 쿼리로 재작성, 대시보드용 `useDashboardIssues` 신설
- **HomePage**: `useEffect`/`useState` 데이터 로딩 → `useDashboardIssues` + `useMemo` 파생
- **CreateIssueDialog**: Zustand `issue-store` prepend 제거 → `queryClient.invalidateQueries(issues)` (생성 시 IssuePage/MyIssues/Home 자동 갱신)
- issue 스토어에서 미사용 `issues`/`setIssues` 제거 → **이슈 목록의 단일 출처는 React Query**

## 검증
typecheck(node+web) · lint:ci(0 error) · test(48 passed) · build 통과.

## 참고
신규 단일 쿼리 메서드(findByAssignee/findByUserProjects)는 테스트 미커버 — M2 테스트 아키텍처에서 리포지토리 통합 테스트로 커버 예정.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_