### PR TITLE
feat: HomePage·ProjectsPage 로딩 스켈레톤 (M1 빈상태 일관성)

### DIFF
--- a/src/renderer/src/components/pages/HomePage.tsx
+++ b/src/renderer/src/components/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TrendDataPoint } from '@/atoms/charts/AreaTrendChart'
 import type { StatusData } from '@/atoms/charts/StatusDonutChart'
+import { Skeleton } from '@/atoms/Skeleton'
 import { useAuth } from '@/hooks/use-auth'
 import { useDashboardIssues } from '@/hooks/use-issues'
 import { getCssVar } from '@/lib/statusTokens'
@@ -20,7 +21,7 @@ export default function HomePage() {
   const { t } = useTranslation('dashboard')
 
   // 사용자가 속한 프로젝트의 모든 이슈를 단일 쿼리로 조회 (N+1 제거)
-  const { data: allIssues = [] } = useDashboardIssues(user?.user_id)
+  const { data: allIssues = [], isLoading } = useDashboardIssues(user?.user_id)
 
   const { issueStats, statusData, trendData } = useMemo(() => {
     const statusCount = { open: 0, in_progress: 0, done: 0, review: 0, blocked: 0 }
@@ -72,6 +73,22 @@ export default function HomePage() {
   }, [allIssues, t])
 
   if (!user) return null
+
+  if (isLoading) {
+    return (
+      <div className='p-6 space-y-6'>
+        <div className='grid grid-cols-2 gap-4 sm:grid-cols-4'>
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} className='h-24 w-full' />
+          ))}
+        </div>
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+          <Skeleton className='h-72 w-full' />
+          <Skeleton className='h-72 w-full' />
+        </div>
+      </div>
+    )
+  }
 
   return <HomePageTemplate user={user} issueStats={issueStats} statusData={statusData} trendData={trendData} />
 }

--- a/src/renderer/src/components/pages/ProjectsPage.tsx
+++ b/src/renderer/src/components/pages/ProjectsPage.tsx
@@ -15,7 +15,7 @@ export default function ProjectsPage() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [, setSelectedProject] = useState<Project | null>(null)
   const { user } = useAuth()
-  const { projects } = useProject()
+  const { projects, isLoading } = useProject()
 
   // Count of projects created by the user
   // const myProjectsCount = projects ? projects.filter((project) => project.project_created_by === user?.id).length : 0
@@ -41,7 +41,7 @@ export default function ProjectsPage() {
       {/* Content area */}
       <div className='flex-1 overflow-auto pt-8'>
         {/* Project table */}
-        <ProjectTable projects={projects ?? []} onSelectProject={setSelectedProject} />
+        <ProjectTable projects={projects ?? []} onSelectProject={setSelectedProject} isLoading={isLoading} />
       </div>
 
       {/* Dialog */}


### PR DESCRIPTION
## M1 — 빈 상태/스켈레톤 일관성

페이지별 로딩/빈상태 처리를 감사한 결과, **HomePage·ProjectsPage만** 로딩 상태가 없었습니다(나머지는 `isLoading`+`TableEmpty` 등으로 이미 처리됨). 두 곳을 보강합니다.

- **ProjectsPage**: `ProjectTable`에 `isLoading` 전달 (컴포넌트는 이미 지원, 페이지가 안 넘기고 있었음) — store의 `isLoading` 사용
- **HomePage**: `useDashboardIssues.isLoading` 동안 스켈레톤 그리드 표시 (기존엔 로딩 중 0값 차트 노출)

데이터소스 마이그레이션 없이 기존 `isLoading` 신호만 연결하는 최소 변경입니다.

## 검증
typecheck(web) · lint · build 통과.

## 참고
ProjectsPage는 아직 Zustand `useProject` 스토어 기반입니다 — 프로젝트 데이터의 React Query 단일화는 이슈 캐시(#38)에 이은 후속 작업으로 남겨둡니다.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_