### PR TITLE
test: 도메인 훅 렌더러 테스트 (M2 4단계)

### DIFF
--- a/src/renderer/src/__testutils__/queryWrapper.tsx
+++ b/src/renderer/src/__testutils__/queryWrapper.tsx
@@ -1,0 +1,12 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+/** 훅 테스트용 QueryClientProvider 래퍼. 재시도 없음(테스트 결정성). */
+export function createQueryWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}

--- a/src/renderer/src/hooks/use-issues.test.tsx
+++ b/src/renderer/src/hooks/use-issues.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { Issue as IssueRecord } from '@/interface/CoreInterface'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { installMockCallApi } from '../__testutils__/mockCallApi'
+import { createQueryWrapper } from '../__testutils__/queryWrapper'
+import { useMyIssues, useProjectIssues } from './use-issues'
+
+const record = (overrides: Partial<IssueRecord> = {}): IssueRecord =>
+  ({
+    issue_id: 'i1',
+    issue_key: 'HYD-1',
+    issue_title: 't',
+    issue_desc: null,
+    issue_status: 'open',
+    issue_priority: 'high',
+    issue_category: 'bug',
+    issue_created_by: 'u1',
+    issue_assigned_to: 'u2',
+    issue_created_at: new Date(),
+    issue_updated_at: new Date(),
+    ...overrides
+  }) as IssueRecord
+
+describe('useProjectIssues', () => {
+  it('ISSUE_LIST를 projectId로 호출하고 IssueRecord를 Issue로 매핑한다', async () => {
+    const callApi = installMockCallApi({
+      [IpcChannel.ISSUE_LIST]: () => ({ data: [record()], error: null })
+    })
+    const { result } = renderHook(() => useProjectIssues('p1'), { wrapper: createQueryWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(callApi).toHaveBeenCalledWith(IpcChannel.ISSUE_LIST, { projectId: 'p1' })
+    expect(result.current.data?.[0].state).toBe('backlog') // 레거시 open → backlog 매핑
+    expect(result.current.data?.[0].type).toBe('bug')
+  })
+
+  it('projectId가 없으면 쿼리를 실행하지 않는다', () => {
+    const callApi = installMockCallApi()
+    const { result } = renderHook(() => useProjectIssues(undefined), { wrapper: createQueryWrapper() })
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(callApi).not.toHaveBeenCalled()
+  })
+})
+
+describe('useMyIssues', () => {
+  it('ISSUE_LIST_ASSIGNED를 userId로 호출한다', async () => {
+    const callApi = installMockCallApi({
+      [IpcChannel.ISSUE_LIST_ASSIGNED]: () => ({ data: [record({ issue_id: 'mine' })], error: null })
+    })
+    const { result } = renderHook(() => useMyIssues('u2'), { wrapper: createQueryWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(callApi).toHaveBeenCalledWith(IpcChannel.ISSUE_LIST_ASSIGNED, { userId: 'u2' })
+    expect(result.current.data?.[0].id).toBe('mine')
+  })
+})

--- a/src/renderer/src/hooks/use-members.test.tsx
+++ b/src/renderer/src/hooks/use-members.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { installMockCallApi } from '../__testutils__/mockCallApi'
+import { createQueryWrapper } from '../__testutils__/queryWrapper'
+import { useProjectMembers } from './use-members'
+
+describe('useProjectMembers', () => {
+  it('PROJECT_LIST_MEMBERS를 projectId로 호출한다', async () => {
+    const callApi = installMockCallApi({
+      [IpcChannel.PROJECT_LIST_MEMBERS]: () => ({
+        data: [
+          {
+            user_id: 'u1',
+            user_sn: 'u1',
+            user_status: 'active',
+            user_name: 'One',
+            user_email: null,
+            user_avatar_path: null,
+            user_role: 'member',
+            user_created_at: null,
+            user_updated_at: null
+          }
+        ],
+        error: null
+      })
+    })
+    const { result } = renderHook(() => useProjectMembers('p1'), { wrapper: createQueryWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(callApi).toHaveBeenCalledWith(IpcChannel.PROJECT_LIST_MEMBERS, { projectId: 'p1' })
+    expect(result.current.data?.[0].user_id).toBe('u1')
+  })
+
+  it('projectId가 없으면 실행하지 않는다', () => {
+    const callApi = installMockCallApi()
+    const { result } = renderHook(() => useProjectMembers(undefined), { wrapper: createQueryWrapper() })
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(callApi).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## M2 4단계 — 도메인 훅 렌더러 테스트

#41 하니스의 첫 실질 활용. ADR 0002 도메인 훅을 `renderHook` + `QueryClientProvider` + `mockCallApi`로 검증합니다 (jsdom, DB 불필요·항상 실행).

- **useProjectIssues**: `ISSUE_LIST` 호출 + `IssueRecord→Issue` 매핑(레거시 `open→backlog` 포함)
- **useMyIssues**: `ISSUE_LIST_ASSIGNED` 호출
- **useProjectMembers**: `PROJECT_LIST_MEMBERS` 호출
- `projectId/userId` 미지정 시 쿼리 비활성(`enabled:false`) 검증
- `__testutils__/queryWrapper`(retry off) 추가

검증: typecheck(web) · lint:ci(0) · **test 60 passed**(+5) · build 통과.

### M2 남은 단계
5단계 커버리지 게이트(임계치 설정)로 M2 마무리 예정.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_