### PR TITLE
ci: 커버리지 게이트 도입 (M2 5단계, M2 완료)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm lint:ci
 
       - name: Test
-        run: pnpm test
+        run: pnpm test:coverage
         env:
           RUN_DB_TESTS: '1'
           DB_HOST: localhost

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 pnpm-lock.yaml
 dist
 out
+coverage
 .DS_Store
 *.log*
 .env

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,7 +60,15 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/main/**/*.ts', 'src/renderer/src/**/*.{ts,tsx}'],
-      exclude: ['**/*.test.{ts,tsx}', '**/index.ts', 'src/renderer/src/**/*.d.ts']
+      exclude: ['**/*.test.{ts,tsx}', '**/index.ts', 'src/renderer/src/**/*.d.ts'],
+      // 회귀 방지 floor. 미테스트 UI 표면이 커서 초기값은 낮다 — 테스트가 늘면 단계적으로 상향(ratchet).
+      // CI는 DB 통합 테스트까지 실행하므로 실제 수치는 이 floor보다 높다.
+      thresholds: {
+        statements: 8,
+        branches: 5,
+        functions: 5,
+        lines: 8
+      }
     }
   }
 })


### PR DESCRIPTION
## M2 5단계 — 커버리지 게이트 (M2 완료)

- CI `Test` 스텝을 `pnpm test` → **`pnpm test:coverage`**로 전환 (RUN_DB_TESTS 환경 유지 — DB 통합 테스트 계속 실행)
- `vitest` `coverage.thresholds` **floor** 설정: statements 8 / branches 5 / functions 5 / lines 8

### 왜 낮은가
미테스트 UI 컴포넌트 표면이 커서 현재 전체 커버리지가 낮습니다(로컬 ~9%). ADR 0003대로 **"낮게 시작 → 단계적 상향(ratchet)"** 원칙을 따릅니다. 이 floor는 **회귀 방지**가 목적이며, CI는 DB 통합 테스트까지 돌려 실제 수치는 floor보다 높습니다(로컬값이 이미 floor를 상회 → CI 통과 보장).

검증: `pnpm test:coverage` 로컬 통과(exit 0, 임계치 충족) · lint.

### M2 완료
설계(#40) → 하니스(#41) → 백엔드 갭(#42) → flow(#43) → 도메인 훅 UI(#44) → **커버리지 게이트(이 PR)**. 다음은 **M3(활동 로그 → 칸반)**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_