### PR TITLE
feat: ActivityLogRepository + 컨테이너 배선 (M3 2/N)

### DIFF
--- a/src/main/core/database/RepositoryContainer.ts
+++ b/src/main/core/database/RepositoryContainer.ts
@@ -1,6 +1,7 @@
 // 리포지토리 컨테이너 - 싱글톤 패턴으로 DB 어댑터와 리포지토리 인스턴스 관리
 
 import type { DatabaseAdapter } from './adapter/DatabaseAdapter'
+import type { ActivityLogRepository } from './repository/interfaces/ActivityLogRepository'
 import type { CommentRepository } from './repository/interfaces/CommentRepository'
 import type { FileRepository } from './repository/interfaces/FileRepository'
 import type { IntegrationRepository } from './repository/interfaces/IntegrationRepository'
@@ -27,6 +28,7 @@ export class RepositoryContainer {
   private _issueRelations: IssueRelationRepository | null = null
   private _notifications: NotificationRepository | null = null
   private _integrations: IntegrationRepository | null = null
+  private _activityLogs: ActivityLogRepository | null = null
 
   private constructor() {}
 
@@ -49,7 +51,8 @@ export class RepositoryContainer {
     tasks: TaskRepository,
     issueRelations: IssueRelationRepository,
     notifications: NotificationRepository,
-    integrations: IntegrationRepository
+    integrations: IntegrationRepository,
+    activityLogs: ActivityLogRepository
   ): void {
     this.adapter = adapter
     this._users = users
@@ -63,6 +66,7 @@ export class RepositoryContainer {
     this._issueRelations = issueRelations
     this._notifications = notifications
     this._integrations = integrations
+    this._activityLogs = activityLogs
   }
 
   async teardown(): Promise<void> {
@@ -81,6 +85,7 @@ export class RepositoryContainer {
     this._issueRelations = null
     this._notifications = null
     this._integrations = null
+    this._activityLogs = null
   }
 
   get db(): DatabaseAdapter {
@@ -165,6 +170,13 @@ export class RepositoryContainer {
       throw new Error('RepositoryContainer is not initialized. Call initialize() first.')
     }
     return this._integrations
+  }
+
+  get activityLogs(): ActivityLogRepository {
+    if (!this._activityLogs) {
+      throw new Error('RepositoryContainer is not initialized. Call initialize() first.')
+    }
+    return this._activityLogs
   }
 
   get isInitialized(): boolean {

--- a/src/main/core/database/repository/drizzle/DrizzleActivityLogRepository.ts
+++ b/src/main/core/database/repository/drizzle/DrizzleActivityLogRepository.ts
@@ -1,0 +1,43 @@
+// Drizzle 기반 활동 로그 리포지토리 구현
+
+import { and, desc, eq } from 'drizzle-orm'
+import * as pgSchema from '../../schema/drizzle/schema'
+import type {
+  ActivityLogRecord,
+  ActivityLogRepository,
+  CreateActivityLogData
+} from '../interfaces/ActivityLogRepository'
+import type { DrizzleDb, DrizzleSchema } from './executor'
+import { selectById } from './readAfterWrite'
+
+export class DrizzleActivityLogRepository implements ActivityLogRepository {
+  constructor(
+    private db: DrizzleDb,
+    private schema: DrizzleSchema = pgSchema
+  ) {}
+
+  async create(data: CreateActivityLogData): Promise<ActivityLogRecord> {
+    const { activityLogs } = this.schema
+    await this.db.insert(activityLogs).values({
+      activity_id: data.activityId,
+      activity_entity_type: data.entityType,
+      activity_entity_id: data.entityId,
+      activity_action: data.action,
+      activity_actor_id: data.actorId ?? null,
+      activity_metadata: data.metadata ?? null,
+      activity_created_at: new Date()
+    })
+    return selectById<ActivityLogRecord>(this.db, activityLogs, activityLogs.activity_id, data.activityId)
+  }
+
+  // 엔티티별 활동을 최신순으로 반환 (타임라인용)
+  async findByEntity(entityType: string, entityId: string): Promise<ActivityLogRecord[]> {
+    const { activityLogs } = this.schema
+    const rows = await this.db
+      .select()
+      .from(activityLogs)
+      .where(and(eq(activityLogs.activity_entity_type, entityType), eq(activityLogs.activity_entity_id, entityId)))
+      .orderBy(desc(activityLogs.activity_created_at))
+    return rows as ActivityLogRecord[]
+  }
+}

--- a/src/main/core/database/repository/drizzle/activityLog.integration.test.ts
+++ b/src/main/core/database/repository/drizzle/activityLog.integration.test.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createTestDatabase, dropTestDatabase, pgTestConfig } from '../../__testutils__/pgTestDb'
+import { PostgresAdapter } from '../../adapter/PostgresAdapter'
+import * as schema from '../../schema/drizzle/schema'
+import { DrizzleActivityLogRepository } from './DrizzleActivityLogRepository'
+
+describe.runIf(process.env.RUN_DB_TESTS === '1')('DrizzleActivityLogRepository', () => {
+  let adapter: PostgresAdapter
+  let dbName: string
+
+  beforeAll(async () => {
+    dbName = await createTestDatabase()
+    adapter = new PostgresAdapter()
+    await adapter.connect({ ...pgTestConfig(), database: dbName })
+    await adapter.runMigrations(resolve(process.cwd(), 'drizzle/pg'))
+  }, 30000)
+
+  afterAll(async () => {
+    await adapter.disconnect()
+    await dropTestDatabase(dbName)
+  }, 30000)
+
+  it('create로 기록하고 findByEntity로 엔티티별 조회한다', async () => {
+    const db = adapter.getConnection()
+    const repo = new DrizzleActivityLogRepository(db)
+
+    const actorId = randomUUID()
+    await db.insert(schema.users).values({
+      user_id: actorId,
+      user_sn: actorId,
+      user_password_hash: 'h',
+      user_role: 'member'
+    })
+
+    const entityId = randomUUID()
+    const created = await repo.create({
+      activityId: randomUUID(),
+      entityType: 'issue',
+      entityId,
+      action: 'status_changed',
+      actorId,
+      metadata: JSON.stringify({ from: 'backlog', to: 'done' })
+    })
+    expect(created.activity_action).toBe('status_changed')
+    expect(created.activity_metadata).toContain('done')
+    expect(created.activity_created_at).not.toBeNull()
+
+    await repo.create({ activityId: randomUUID(), entityType: 'issue', entityId, action: 'assigned', actorId })
+
+    const list = await repo.findByEntity('issue', entityId)
+    expect(list).toHaveLength(2)
+    expect(list.map((a) => a.activity_action).sort()).toEqual(['assigned', 'status_changed'])
+
+    // 다른 엔티티의 활동은 섞이지 않는다
+    expect(await repo.findByEntity('issue', randomUUID())).toEqual([])
+  })
+})

--- a/src/main/core/database/repository/drizzle/index.ts
+++ b/src/main/core/database/repository/drizzle/index.ts
@@ -1,3 +1,4 @@
+export { DrizzleActivityLogRepository } from './DrizzleActivityLogRepository'
 export { DrizzleCommentRepository } from './DrizzleCommentRepository'
 export { DrizzleFileRepository } from './DrizzleFileRepository'
 export { DrizzleIntegrationRepository } from './DrizzleIntegrationRepository'

--- a/src/main/core/database/repository/interfaces/ActivityLogRepository.ts
+++ b/src/main/core/database/repository/interfaces/ActivityLogRepository.ts
@@ -1,0 +1,25 @@
+// 활동 로그 리포지토리 인터페이스
+
+export interface CreateActivityLogData {
+  activityId: string
+  entityType: string
+  entityId: string
+  action: string
+  actorId?: string | null
+  metadata?: string | null
+}
+
+export interface ActivityLogRecord {
+  activity_id: string
+  activity_entity_type: string
+  activity_entity_id: string
+  activity_action: string
+  activity_actor_id: string | null
+  activity_metadata: string | null
+  activity_created_at: Date | null
+}
+
+export interface ActivityLogRepository {
+  create(data: CreateActivityLogData): Promise<ActivityLogRecord>
+  findByEntity(entityType: string, entityId: string): Promise<ActivityLogRecord[]>
+}

--- a/src/main/handler/workspace/ConnectWorkspaceHandler.ts
+++ b/src/main/handler/workspace/ConnectWorkspaceHandler.ts
@@ -3,6 +3,7 @@ import { createAdapter, toMigrationDialect } from '@/database/adapter/createAdap
 import { getMigrationsFolder } from '@/database/migrate/migrationsPath'
 import { RepositoryContainer } from '@/database/RepositoryContainer'
 import {
+  DrizzleActivityLogRepository,
   DrizzleCommentRepository,
   DrizzleFileRepository,
   DrizzleIntegrationRepository,
@@ -79,6 +80,7 @@ export class ConnectWorkspaceHandler extends CoreBaseHandler<IpcChannel.WORKSPAC
     const issueRelationRepo = new DrizzleIssueRelationRepository(db, schemaSet)
     const notificationRepo = new DrizzleNotificationRepository(db, schemaSet)
     const integrationRepo = new DrizzleIntegrationRepository(db, schemaSet)
+    const activityLogRepo = new DrizzleActivityLogRepository(db, schemaSet)
 
     container.initialize(
       adapter,
@@ -92,7 +94,8 @@ export class ConnectWorkspaceHandler extends CoreBaseHandler<IpcChannel.WORKSPAC
       taskRepo,
       issueRelationRepo,
       notificationRepo,
-      integrationRepo
+      integrationRepo,
+      activityLogRepo
     )
 
     // Phase 3: 연결 시 자동 admin 생성 제거. users 비어있으면 setup 필요.


### PR DESCRIPTION
## M3 활동 로그 (2/N) — Repository + 컨테이너 배선

`activity_logs` 스키마(#47) 위에 데이터 접근 계층을 추가합니다.

- **`ActivityLogRepository`** 인터페이스 + **`DrizzleActivityLogRepository`**: `create`, `findByEntity`(엔티티별 최신순)
- **RepositoryContainer 배선**: private field / `initialize` 인자 / `teardown` / getter + drizzle 바렐 export
- **ConnectWorkspaceHandler**: repo 생성(`schemaSet` 주입) + `initialize`에 전달 (PG/MySQL 공용)
- **통합 테스트**: `create` + `findByEntity`(엔티티 격리 검증), `RUN_DB_TESTS` 게이트

### 다음 (M3)
- 자동 기록: 이슈 상태/담당자 변경·댓글 생성 핸들러에서 `repos.activityLogs.create(...)` 호출
- `ACTIVITY_LIST` IPC + IssueDetailPage 타임라인 UI

### 검증
typecheck(node) · lint:ci(0) · test(로컬 pass, 통합 테스트 DB-skip)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_