### PR TITLE
feat: 활동 자동 기록 — 이슈 변경·댓글 (M3 3/N)

### DIFF
--- a/src/main/handler/comments/CreateCommentHandler.ts
+++ b/src/main/handler/comments/CreateCommentHandler.ts
@@ -14,6 +14,21 @@ export class CreateCommentHandler extends CoreBaseHandler<IpcChannel.COMMENT_CRE
       commentContent: params.commentContent,
       createdBy: params.userId
     })
+
+    // 활동 로그 기록 — best-effort (실패해도 댓글 생성은 성공시킨다)
+    try {
+      await this.repos.activityLogs.create({
+        activityId: CoreUtil.getUuid(),
+        entityType: 'issue',
+        entityId: params.issueId,
+        action: 'comment_created',
+        actorId: params.userId,
+        metadata: JSON.stringify({ commentId: comment.comment_id })
+      })
+    } catch (error) {
+      console.error('[activity] failed to record comment creation', error)
+    }
+
     return { data: comment, error: null }
   }
 }

--- a/src/main/handler/issues/UpdateIssueHandler.ts
+++ b/src/main/handler/issues/UpdateIssueHandler.ts
@@ -1,5 +1,6 @@
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
 import { IpcChannel, type UpdateIssueParams } from '@/interface/CoreInterface'
+import { CoreUtil } from '@/util/CoreUtil'
 
 export class UpdateIssueHandler extends CoreBaseHandler<IpcChannel.ISSUE_UPDATE> {
   constructor() {
@@ -7,6 +8,9 @@ export class UpdateIssueHandler extends CoreBaseHandler<IpcChannel.ISSUE_UPDATE>
   }
 
   async handler(params: UpdateIssueParams) {
+    // 변경 전 상태(활동 로그 diff용) 확보
+    const before = await this.repos.issues.findById(params.issueId)
+
     // 1. 이슈 업데이트 (public.issues)
     const issue = await this.repos.issues.update(params.issueId, {
       issueTitle: params.issueTitle,
@@ -17,6 +21,32 @@ export class UpdateIssueHandler extends CoreBaseHandler<IpcChannel.ISSUE_UPDATE>
       assignedTo: params.assignedTo,
       modifiedBy: params.userId
     })
+
+    // 2. 활동 로그 기록 — best-effort (실패해도 업데이트는 성공시킨다)
+    try {
+      if (before && before.issue_status !== issue.issue_status) {
+        await this.repos.activityLogs.create({
+          activityId: CoreUtil.getUuid(),
+          entityType: 'issue',
+          entityId: issue.issue_id,
+          action: 'status_changed',
+          actorId: params.userId,
+          metadata: JSON.stringify({ from: before.issue_status, to: issue.issue_status })
+        })
+      }
+      if (before && before.issue_assigned_to !== issue.issue_assigned_to) {
+        await this.repos.activityLogs.create({
+          activityId: CoreUtil.getUuid(),
+          entityType: 'issue',
+          entityId: issue.issue_id,
+          action: 'assigned',
+          actorId: params.userId,
+          metadata: JSON.stringify({ from: before.issue_assigned_to, to: issue.issue_assigned_to })
+        })
+      }
+    } catch (error) {
+      console.error('[activity] failed to record issue update', error)
+    }
 
     return { data: issue, error: null }
   }


### PR DESCRIPTION
## M3 활동 로그 (3/N) — 자동 기록

이슈/댓글 핸들러에서 활동을 자동 기록합니다.

- **UpdateIssueHandler**: 변경 전 `findById`로 비교 → 상태 변경 시 `status_changed`(`{from,to}`), 담당자 변경 시 `assigned`(`{from,to}`) 기록
- **CreateCommentHandler**: `comment_created` 기록(`{commentId}`)
- **모두 best-effort**: 활동 기록을 `try/catch`로 감싸 실패해도 주 작업(이슈 업데이트/댓글 생성)은 성공. 활동 로그는 부차적 데이터라 주 흐름을 막지 않음.
- entityType `issue` + entityId로 기록 → 타임라인이 이슈별 조회(`findByEntity`)

### 다음 (M3 4/N)
`ACTIVITY_LIST` IPC + 도메인 훅 + IssueDetailPage 타임라인 UI(폴더 구조/Storybook 활용).

### 검증
typecheck(node) · lint:ci(0) · test pass. (핸들러 자동기록의 통합 검증은 핸들러 레벨 테스트 도입 시 — 현재 best-effort라 저위험)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_