### PR TITLE
feat: ACTIVITY_LIST IPC + 핸들러 + 도메인 훅 (M3 4a/N)

### DIFF
--- a/src/main/core/interface/CoreInterface.ts
+++ b/src/main/core/interface/CoreInterface.ts
@@ -1,4 +1,5 @@
 export * from './ipc'
+export * from './types/activity'
 export * from './types/auth'
 export * from './types/comment'
 export * from './types/integration'

--- a/src/main/core/interface/ipc.ts
+++ b/src/main/core/interface/ipc.ts
@@ -1,3 +1,4 @@
+import type { ActivityLogRecord } from '../database/repository/interfaces/ActivityLogRepository'
 import type { CommentRecord } from '../database/repository/interfaces/CommentRepository'
 import type { FileRecord } from '../database/repository/interfaces/FileRepository'
 import type { IntegrationRecord } from '../database/repository/interfaces/IntegrationRepository'
@@ -9,6 +10,7 @@ import type { NotificationRecord } from '../database/repository/interfaces/Notif
 import type { ProjectRecord } from '../database/repository/interfaces/ProjectRepository'
 import type { TaskRecord } from '../database/repository/interfaces/TaskRepository'
 import type { SafeUser } from '../database/repository/interfaces/UserRepository'
+import type { ListActivityParams } from './types/activity'
 import type {
   AuthDeleteUserParams,
   AuthUpdateUserParams,
@@ -116,6 +118,9 @@ export enum IpcChannel {
   ISSUE_GET = 'issueGet',
   ISSUE_UPDATE = 'issueUpdate',
   ISSUE_DELETE = 'issueDelete',
+
+  // ACTIVITY-
+  ACTIVITY_LIST = 'activityList',
 
   // ISSUE_RELATION-
   ISSUE_RELATION_CREATE = 'issueRelationCreate',
@@ -297,6 +302,10 @@ export interface IpcPayloads extends BaseIpcPayloads {
   [IpcChannel.ISSUE_LIST_MEMBER_PROJECTS]: {
     send: ListMemberProjectIssuesParams
     receive: BaseIpcResponse<IssueRecord[]>
+  }
+  [IpcChannel.ACTIVITY_LIST]: {
+    send: ListActivityParams
+    receive: BaseIpcResponse<ActivityLogRecord[]>
   }
   [IpcChannel.ISSUE_GET]: {
     send: GetIssueParams

--- a/src/main/core/interface/types/activity.ts
+++ b/src/main/core/interface/types/activity.ts
@@ -1,0 +1,4 @@
+export interface ListActivityParams {
+  entityType: string
+  entityId: string
+}

--- a/src/main/handler/activity/ListActivityHandler.ts
+++ b/src/main/handler/activity/ListActivityHandler.ts
@@ -1,0 +1,13 @@
+import { CoreBaseHandler } from '@/base/CoreBaseHandler'
+import { IpcChannel, type ListActivityParams } from '@/interface/CoreInterface'
+
+export class ListActivityHandler extends CoreBaseHandler<IpcChannel.ACTIVITY_LIST> {
+  constructor() {
+    super(IpcChannel.ACTIVITY_LIST)
+  }
+
+  async handler(params: ListActivityParams) {
+    const activities = await this.repos.activityLogs.findByEntity(params.entityType, params.entityId)
+    return { data: activities, error: null }
+  }
+}

--- a/src/main/handler/activity/index.ts
+++ b/src/main/handler/activity/index.ts
@@ -1,0 +1,1 @@
+export { ListActivityHandler } from './ListActivityHandler'

--- a/src/main/handler/initHandler.ts
+++ b/src/main/handler/initHandler.ts
@@ -2,6 +2,7 @@ import Chalk from 'chalk'
 import { ipcMain } from 'electron/main'
 import { BaseError } from '@/error/BaseError'
 import { type BaseErrorType, ErrorCode } from '@/interface/CoreInterface'
+import * as activityHandlers from './activity'
 import * as authHandlers from './auth'
 import * as commentHandlers from './comments'
 import * as integrationHandlers from './integrations'
@@ -18,6 +19,7 @@ import * as taskHandlers from './tasks'
 import * as workspaceHandlers from './workspace'
 
 const handlerModules = [
+  activityHandlers,
   authHandlers,
   commentHandlers,
   integrationHandlers,

--- a/src/renderer/src/hooks/use-activity.test.tsx
+++ b/src/renderer/src/hooks/use-activity.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { installMockCallApi } from '../__testutils__/mockCallApi'
+import { createQueryWrapper } from '../__testutils__/queryWrapper'
+import { useActivityLog } from './use-activity'
+
+describe('useActivityLog', () => {
+  it('ACTIVITY_LIST를 entityType/entityId로 호출한다', async () => {
+    const callApi = installMockCallApi({
+      [IpcChannel.ACTIVITY_LIST]: () => ({
+        data: [
+          {
+            activity_id: 'a1',
+            activity_entity_type: 'issue',
+            activity_entity_id: 'i1',
+            activity_action: 'status_changed',
+            activity_actor_id: null,
+            activity_metadata: null,
+            activity_created_at: null
+          }
+        ],
+        error: null
+      })
+    })
+    const { result } = renderHook(() => useActivityLog('issue', 'i1'), { wrapper: createQueryWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(callApi).toHaveBeenCalledWith(IpcChannel.ACTIVITY_LIST, { entityType: 'issue', entityId: 'i1' })
+    expect(result.current.data?.[0].activity_action).toBe('status_changed')
+  })
+
+  it('entityId가 없으면 실행하지 않는다', () => {
+    const callApi = installMockCallApi()
+    const { result } = renderHook(() => useActivityLog('issue', undefined), { wrapper: createQueryWrapper() })
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(callApi).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/use-activity.ts
+++ b/src/renderer/src/hooks/use-activity.ts
@@ -1,0 +1,13 @@
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { useApiQuery } from './use-api'
+
+/** 엔티티(예: 이슈)의 활동 로그를 최신순으로 조회한다. */
+export function useActivityLog(entityType: string, entityId: string | undefined) {
+  return useApiQuery(
+    queryKeys.activity.byEntity(entityType, entityId ?? ''),
+    IpcChannel.ACTIVITY_LIST,
+    { entityType, entityId: entityId ?? '' },
+    { enabled: !!entityId }
+  )
+}

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -12,5 +12,8 @@ export const queryKeys = {
   projects: {
     all: ['projects'] as const,
     members: (projectId: string) => ['projects', projectId, 'members'] as const
+  },
+  activity: {
+    byEntity: (entityType: string, entityId: string) => ['activity', entityType, entityId] as const
   }
 } as const


### PR DESCRIPTION
## M3 활동 로그 (4a/N) — ACTIVITY_LIST 데이터 경로

자동 기록(#50)된 활동을 렌더러가 조회할 수 있도록 IPC~훅 경로를 잇습니다.

- **타입**: `types/activity`(`ListActivityParams`) + `CoreInterface` 배럴 export
- **IPC**: `ACTIVITY_LIST` 채널 + payload(`BaseIpcResponse<ActivityLogRecord[]>`)
- **핸들러**: `activity/ListActivityHandler`(→`repos.activityLogs.findByEntity`) + `initHandler` 자동 등록
- **렌더러**: `useActivityLog(entityType, entityId)` 도메인 훅 + `queryKeys.activity` + portable 훅 테스트

### 검증
typecheck(node+web) · lint:ci(0) · test 64 pass(+2 훅 테스트)

### 다음 (4b)
`IssueDetailPage` 타임라인 UI — 컴포넌트 폴더 구조 + Storybook 스토리로 `Timeline` 컴포넌트 작성 후 `useActivityLog` 연결. → 활동 로그 완료 → 칸반.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_