### PR TITLE
feat: 활동 타임라인 UI + IssueDetailPage (M3 4b/N, 활동로그 완료)

### DIFF
--- a/src/main/core/interface/types/activity.ts
+++ b/src/main/core/interface/types/activity.ts
@@ -1,3 +1,5 @@
+export type { ActivityLogRecord } from '../../database/repository/interfaces/ActivityLogRepository'
+
 export interface ListActivityParams {
   entityType: string
   entityId: string

--- a/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.stories.tsx
+++ b/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ActivityLogRecord } from '@/interface/CoreInterface'
+import { ActivityTimeline } from './ActivityTimeline'
+
+const sample = (over: Partial<ActivityLogRecord>): ActivityLogRecord => ({
+  activity_id: Math.random().toString(36).slice(2),
+  activity_entity_type: 'issue',
+  activity_entity_id: 'i1',
+  activity_action: 'comment_created',
+  activity_actor_id: 'u1',
+  activity_metadata: null,
+  activity_created_at: new Date('2026-06-14T04:00:00Z'),
+  ...over
+})
+
+const meta: Meta<typeof ActivityTimeline> = {
+  title: 'Molecules/ActivityTimeline',
+  component: ActivityTimeline
+}
+export default meta
+type Story = StoryObj<typeof ActivityTimeline>
+
+export const Default: Story = {
+  args: {
+    activities: [
+      sample({
+        activity_action: 'status_changed',
+        activity_metadata: JSON.stringify({ from: 'backlog', to: 'in_progress' })
+      }),
+      sample({ activity_action: 'comment_created' })
+    ]
+  }
+}
+
+export const Loading: Story = { args: { activities: [], isLoading: true } }
+export const Empty: Story = { args: { activities: [] } }

--- a/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.test.tsx
+++ b/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { ActivityLogRecord } from '@/interface/CoreInterface'
+import { ActivityTimeline, describeActivity } from './ActivityTimeline'
+
+const rec = (over: Partial<ActivityLogRecord>): ActivityLogRecord => ({
+  activity_id: 'a',
+  activity_entity_type: 'issue',
+  activity_entity_id: 'i1',
+  activity_action: 'comment_created',
+  activity_actor_id: null,
+  activity_metadata: null,
+  activity_created_at: null,
+  ...over
+})
+
+describe('describeActivity', () => {
+  it('status_changed를 from→to로 표현한다', () => {
+    const text = describeActivity(
+      rec({ activity_action: 'status_changed', activity_metadata: JSON.stringify({ from: 'backlog', to: 'done' }) })
+    )
+    expect(text).toBe('changed status: backlog → done')
+  })
+
+  it('comment_created는 라벨로 표현한다', () => {
+    expect(describeActivity(rec({ activity_action: 'comment_created' }))).toBe('added a comment')
+  })
+
+  it('알 수 없는 action은 원문을 반환한다', () => {
+    expect(describeActivity(rec({ activity_action: 'weird' }))).toBe('weird')
+  })
+})
+
+describe('ActivityTimeline', () => {
+  it('로딩 / 빈 / 목록 상태를 렌더한다', () => {
+    const { container, rerender } = render(<ActivityTimeline activities={[]} isLoading />)
+    expect(container.textContent).toContain('Loading')
+
+    rerender(<ActivityTimeline activities={[]} />)
+    expect(container.textContent).toContain('No activity')
+
+    rerender(<ActivityTimeline activities={[rec({ activity_action: 'comment_created' })]} />)
+    expect(container.textContent).toContain('added a comment')
+  })
+})

--- a/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.tsx
+++ b/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.tsx
@@ -1,0 +1,55 @@
+import type { ActivityLogRecord } from '@/interface/CoreInterface'
+
+const ACTION_LABEL: Record<string, string> = {
+  status_changed: 'changed status',
+  assigned: 'changed assignee',
+  comment_created: 'added a comment'
+}
+
+function parseMeta(raw: string | null): Record<string, unknown> | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+/** 활동 1건을 사람이 읽을 문장으로 변환한다. */
+export function describeActivity(activity: ActivityLogRecord): string {
+  const meta = parseMeta(activity.activity_metadata)
+  if ((activity.activity_action === 'status_changed' || activity.activity_action === 'assigned') && meta) {
+    const label = ACTION_LABEL[activity.activity_action]
+    return `${label}: ${meta.from ?? '—'} → ${meta.to ?? '—'}`
+  }
+  return ACTION_LABEL[activity.activity_action] ?? activity.activity_action
+}
+
+interface ActivityTimelineProps {
+  activities: ActivityLogRecord[]
+  isLoading?: boolean
+}
+
+export function ActivityTimeline({ activities, isLoading = false }: ActivityTimelineProps) {
+  if (isLoading) {
+    return <p className='text-sm text-muted-foreground'>Loading activity…</p>
+  }
+  if (activities.length === 0) {
+    return <p className='text-sm text-muted-foreground'>No activity yet</p>
+  }
+  return (
+    <ul className='space-y-3'>
+      {activities.map((activity) => (
+        <li key={activity.activity_id} className='flex items-start gap-2 text-sm'>
+          <span className='mt-1.5 h-2 w-2 shrink-0 rounded-full bg-muted-foreground/40' />
+          <div className='flex flex-col'>
+            <span>{describeActivity(activity)}</span>
+            <span className='text-xs text-muted-foreground'>
+              {activity.activity_created_at ? new Date(activity.activity_created_at).toLocaleString() : ''}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/renderer/src/components/molecules/ActivityTimeline/index.ts
+++ b/src/renderer/src/components/molecules/ActivityTimeline/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityTimeline'

--- a/src/renderer/src/components/pages/IssueDetailPage.tsx
+++ b/src/renderer/src/components/pages/IssueDetailPage.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/atoms/Input'
 import { Label } from '@/components/atoms/Label'
 import { RichTextEditor } from '@/components/atoms/RichTextEditor'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/atoms/Select'
+import { useActivityLog } from '@/hooks/use-activity'
 import { useAuth } from '@/hooks/use-auth'
 import type {
   Comment as CommentRecord,
@@ -17,6 +18,7 @@ import type {
   User as UserRecord
 } from '@/interface/CoreInterface'
 import { IpcChannel } from '@/interface/CoreInterface'
+import { ActivityTimeline } from '@/molecules/ActivityTimeline'
 
 const STATUS_OPTIONS = [
   { value: 'open', label: 'Open' },
@@ -52,6 +54,7 @@ export default function IssueDetailPage() {
   const { projectId, issueId } = useParams({ strict: false })
   const { user } = useAuth()
   const navigate = useNavigate()
+  const { data: activities = [], isLoading: activityLoading } = useActivityLog('issue', issueId)
   const [issue, setIssue] = useState<IssueRecord | null>(null)
   const [members, setMembers] = useState<UserRecord[]>([])
   const [files, setFiles] = useState<FileRecord[]>([])
@@ -329,6 +332,12 @@ export default function IssueDetailPage() {
                 ))}
               </div>
             )}
+          </div>
+
+          {/* Activity timeline */}
+          <div className='mb-6'>
+            <Label className='mb-2 block'>Activity</Label>
+            <ActivityTimeline activities={activities} isLoading={activityLoading} />
           </div>
 
           {/* Comments */}


### PR DESCRIPTION
## M3 활동 로그 (4b/N) — 타임라인 UI (활동 로그 완료)

자동 기록(#50)된 활동을 `IssueDetailPage`에 타임라인으로 표시합니다.

- **`molecules/ActivityTimeline`** (컴포넌트 폴더 구조: `index.ts` barrel + 컴포넌트 + 스토리 + 테스트)
  - `describeActivity`: `status_changed`(from→to) / `assigned`(from→to) / `comment_created` 사람 친화 문장
  - 로딩 / 빈 / 목록 상태, 프레젠테이셔널(데이터 패칭은 페이지가 담당)
- **`types/activity`**: `ActivityLogRecord` 배럴 재노출(렌더러용)
- **IssueDetailPage**: `useActivityLog('issue', issueId)` → "Activity" 섹션 렌더 (Comments 위)

### 검증
typecheck(node+web) · lint:ci(0) · test 68(+4) · build-storybook 성공

### 🎉 M3 활동 로그 완료
스키마(#47) → repo+배선(#49) → 자동기록(#50) → 조회 IPC/훅(#51) → **타임라인 UI(이 PR)**.

### 후속 폴리시(메모)
- in-page 상태변경/댓글 후 타임라인 자동 갱신(queryKeys.activity 무효화) — 현재는 로드 시점 정확, 액션 후 갱신은 follow-up
- actor UUID → 사용자 이름 표시
- **다음 M3: 칸반 보드**


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_