### PR TITLE
ci: Storybook GitHub Pages 배포 CD

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,58 @@
+name: Deploy Storybook
+
+# main에 머지될 때 Storybook을 빌드해 GitHub Pages에 배포한다.
+# 선행: 저장소 Settings → Pages → Source = "GitHub Actions"
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 동시 배포 1건만 (진행 중인 것은 취소하지 않고 대기 — 배포 일관성)
+concurrency:
+  group: storybook-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm build-storybook
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: storybook-static
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Storybook → GitHub Pages CD

`build-storybook` 산출물을 GitHub Pages에 자동 배포하는 워크플로(`.github/workflows/storybook.yml`).

- **트리거**: `main` push(머지 시) + 수동(`workflow_dispatch`)
- **build 잡**: install → `pnpm build-storybook` → `upload-pages-artifact`(`storybook-static`)
- **deploy 잡**: `deploy-pages` → `github-pages` environment
- `permissions: pages:write, id-token:write` + `concurrency`로 배포 직렬화
- setup(pnpm10/node22/frozen-lockfile)은 기존 CI와 동일

머지되면 `https://jujoycode.github.io/hydra/`에 Storybook이 게시됩니다.

### ⚠️ 수동 선행 조건 (필수)
저장소 **Settings → Pages → Build and deployment → Source = "GitHub Actions"** 로 설정해야 배포가 동작합니다 (이 설정은 코드/도구로 못 켜서 직접 해주셔야 합니다).

### 참고
GH Pages 프로젝트 서브경로(`/hydra/`)에서 에셋이 404나면 후속으로 Storybook vite `base`를 조정하겠습니다(최신 Storybook은 상대경로라 대개 그대로 동작).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_