### PR TITLE
feat: KanbanBoard 컴포넌트 (@dnd-kit) — M3 칸반 A/2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@radix-ui/react-avatar": "^1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@electron-toolkit/preload':
         specifier: ^3.0.1
         version: 3.0.2(electron@35.2.2)
@@ -531,6 +534,22 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -6338,6 +6357,24 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 

--- a/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.stories.tsx
+++ b/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Issue } from '@/types/issue'
+import { KanbanBoard } from './KanbanBoard'
+
+const issue = (over: Partial<Issue>): Issue => ({
+  id: Math.random().toString(36).slice(2),
+  type: 'feature',
+  key: 'HYD-1',
+  title: 'Sample issue',
+  created: new Date(),
+  updated: new Date(),
+  reporter: { name: 'user', avatar: '' },
+  assignee: '',
+  state: 'backlog',
+  ...over
+})
+
+const meta: Meta<typeof KanbanBoard> = {
+  title: 'Organisms/KanbanBoard',
+  component: KanbanBoard,
+  args: { onMove: () => {} }
+}
+export default meta
+type Story = StoryObj<typeof KanbanBoard>
+
+export const Default: Story = {
+  args: {
+    issues: [
+      issue({ title: 'Set up CI', state: 'backlog', key: 'H-1' }),
+      issue({ title: 'Build kanban', state: 'in_progress', key: 'H-2' }),
+      issue({ title: 'Review PR', state: 'review', key: 'H-3' }),
+      issue({ title: 'Ship v1', state: 'done', key: 'H-4' }),
+      issue({ title: 'Blocked task', state: 'blocked', key: 'H-5' })
+    ]
+  }
+}
+
+export const Empty: Story = { args: { issues: [] } }

--- a/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.test.tsx
+++ b/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { Issue } from '@/types/issue'
+import { KanbanBoard } from './KanbanBoard'
+
+const issue = (over: Partial<Issue>): Issue => ({
+  id: Math.random().toString(36).slice(2),
+  type: 'feature',
+  key: 'HYD-1',
+  title: 'Sample',
+  created: new Date(),
+  updated: new Date(),
+  reporter: { name: 'user', avatar: '' },
+  assignee: '',
+  state: 'backlog',
+  ...over
+})
+
+describe('KanbanBoard', () => {
+  it('5개 상태 컬럼과 카드를 렌더한다(빈 컬럼 포함)', () => {
+    render(<KanbanBoard issues={[issue({ title: 'Card A', state: 'backlog' })]} onMove={vi.fn()} />)
+    // 컬럼 헤더(라벨)
+    expect(screen.getByText(/대기/)).toBeInTheDocument()
+    expect(screen.getByText(/완료/)).toBeInTheDocument()
+    expect(screen.getByText(/차단/)).toBeInTheDocument()
+    // 카드
+    expect(screen.getByText('Card A')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.tsx
+++ b/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.tsx
@@ -1,0 +1,96 @@
+import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { ISSUE_STATUSES, type IssueStatus } from '@/interface/CoreInterface'
+import { STATUS_LABEL } from '@/lib/statusTokens'
+import { cn } from '@/lib/utils'
+import type { Issue } from '@/types/issue'
+
+interface KanbanBoardProps {
+  issues: Issue[]
+  /** 카드를 다른 상태 컬럼으로 드롭했을 때 호출 */
+  onMove: (issueId: string, newState: IssueStatus) => void
+  onSelectIssue?: (issue: Issue) => void
+}
+
+function KanbanCard({ issue, onSelect }: { issue: Issue; onSelect?: (issue: Issue) => void }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: issue.id })
+  const style = transform ? { transform: `translate(${transform.x}px, ${transform.y}px)` } : undefined
+  return (
+    <button
+      type='button'
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      onClick={() => onSelect?.(issue)}
+      className={cn(
+        'w-full cursor-grab rounded-md border bg-card p-3 text-left text-sm shadow-sm',
+        isDragging && 'opacity-50'
+      )}
+    >
+      <p className='font-medium'>{issue.title}</p>
+      <p className='mt-1 text-xs text-muted-foreground'>{issue.key}</p>
+    </button>
+  )
+}
+
+function KanbanColumn({
+  state,
+  issues,
+  onSelect
+}: {
+  state: IssueStatus
+  issues: Issue[]
+  onSelect?: (issue: Issue) => void
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: state })
+  return (
+    <div className='flex w-64 shrink-0 flex-col gap-2'>
+      <h3 className='px-1 text-sm font-semibold'>
+        {STATUS_LABEL[state]} <span className='text-muted-foreground'>({issues.length})</span>
+      </h3>
+      <div
+        ref={setNodeRef}
+        className={cn('flex min-h-24 flex-col gap-2 rounded-md bg-muted/40 p-2', isOver && 'ring-2 ring-primary/50')}
+      >
+        {issues.map((issue) => (
+          <KanbanCard key={issue.id} issue={issue} onSelect={onSelect} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function KanbanBoard({ issues, onMove, onSelectIssue }: KanbanBoardProps) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const issueId = String(event.active.id)
+    const target = event.over?.id as IssueStatus | undefined
+    if (!target) return
+    const issue = issues.find((i) => i.id === issueId)
+    if (issue && issue.state !== target) onMove(issueId, target)
+  }
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <div className='flex gap-4 overflow-x-auto pb-4'>
+        {ISSUE_STATUSES.map((state) => (
+          <KanbanColumn
+            key={state}
+            state={state}
+            issues={issues.filter((i) => i.state === state)}
+            onSelect={onSelectIssue}
+          />
+        ))}
+      </div>
+    </DndContext>
+  )
+}

--- a/src/renderer/src/components/organisms/KanbanBoard/index.ts
+++ b/src/renderer/src/components/organisms/KanbanBoard/index.ts
@@ -1,0 +1,1 @@
+export * from './KanbanBoard'


### PR DESCRIPTION
## M3 칸반 (A/2) — KanbanBoard 컴포넌트

`@dnd-kit/core` 기반 프레젠테이셔널 칸반 보드.

- **`organisms/KanbanBoard`** (컴포넌트 폴더 구조: index/컴포넌트/스토리/테스트)
  - 상태별 5컬럼(`ISSUE_STATUSES`) + 카드, `STATUS_LABEL` 헤더
  - `useDraggable`(카드) + `useDroppable`(컬럼), `PointerSensor`(거리 5px → 클릭/드래그 양립)
  - 다른 상태 컬럼에 드롭 시 `onMove(issueId, newState)` 콜백, 카드 클릭 `onSelectIssue`
  - 데이터 패칭/뮤테이션은 페이지가 담당(순수 컴포넌트)
- 스토리(Default/Empty) + 렌더 스모크 테스트(컬럼 라벨·카드)
- 의존성 `@dnd-kit/core` 추가

### 검증
typecheck(web) · lint:ci(0) · test pass · build-storybook 성공

### 다음 (B/2)
`IssuePage`에 **테이블 ↔ 칸반 뷰 토글**(localStorage 선호 저장) + `onMove` → `ISSUE_UPDATE`(드롭 시 상태변경 → 활동로그 자동기록과 연동) + 쿼리 무효화.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_