### PR TITLE
ci: Pages 배포 configure-pages(enablement) 추가

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Pages 배포 수정 — configure-pages(enablement)

직전 Deploy Storybook 실행에서 deploy 잡이 `Failed to create deployment (status: 404) ... Ensure GitHub Pages has been enabled`로 실패했습니다 (build/업로드는 성공). 원인은 **Pages 미활성화**.

- build 잡에 `actions/configure-pages@v5` (`enablement: true`) 추가 → 가능하면 Pages 자동 활성화 + base path 설정

### ⚠️ 그래도 안 되면 (계정 정책상 자동 활성화 불가 시)
**Settings → Pages → Source = "GitHub Actions"** 수동 설정 후, 실패한 워크플로를 **Re-run**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_