### PR TITLE
fix: Storybook Tailwind 플러그인 누락 → 스타일 적용

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+import tailwindcss from '@tailwindcss/vite'
 import type { StorybookConfig } from '@storybook/react-vite'
 
 // 렌더러 '@/' alias (vitest.config.ts와 동일 매핑) — Storybook의 vite가 인식하도록 주입한다.
@@ -30,6 +31,8 @@ const config: StorybookConfig = {
       ...((viteConfig.resolve.alias as Record<string, string>) ?? {}),
       ...rendererAliases
     }
+    // 앱과 동일하게 Tailwind v4 플러그인을 주입해야 index.css의 유틸리티가 생성된다(스타일 누락 방지)
+    viteConfig.plugins = [...(viteConfig.plugins ?? []), tailwindcss()]
     return viteConfig
   }
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
-import tailwindcss from '@tailwindcss/vite'
 import type { StorybookConfig } from '@storybook/react-vite'
+import tailwindcss from '@tailwindcss/vite'
 
 // 렌더러 '@/' alias (vitest.config.ts와 동일 매핑) — Storybook의 vite가 인식하도록 주입한다.
 const rendererAliases: Record<string, string> = {


### PR DESCRIPTION
## Storybook 스타일 누락 수정

배포된 Storybook(및 로컬)에 **스타일이 전혀 적용되지 않던** 문제를 고칩니다.

### 원인
앱은 `electron.vite.config.ts`에서 `@tailwindcss/vite`(Tailwind v4) 플러그인으로 `index.css`의 `@import "tailwindcss"`를 처리합니다. 그런데 **Storybook의 vite(`viteFinal`)에는 이 플러그인이 없어** Tailwind 유틸리티가 전혀 생성되지 않았습니다 → 무스타일.

### 수정
`.storybook/main.ts`의 `viteFinal`에 앱과 동일하게 `tailwindcss()` 플러그인 주입.

### 검증
`build-storybook` 산출 CSS가 **155KB**로 생성되고 Tailwind 유틸리티(`animate-pulse`, `--tw-ring`, `.rounded-full` 등) + 테마 변수 포함 확인. (수정 전엔 사실상 비어 있었음.)

머지되면 Deploy 워크플로가 재배포해 `https://jujoycode.github.io/hydra/` 에 스타일이 적용됩니다.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_