### PR TITLE
ci: 릴리즈 자동화 (태그→3플랫폼 인스톨러) — M4b

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+# vX.Y.Z 태그 push 시 3플랫폼 인스톨러를 빌드해 GitHub Release(draft)에 업로드한다.
+# 게시 전 검토를 위해 draft로 생성 — 확인 후 수동 publish.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build installers (electron-forge make)
+        run: pnpm make
+
+      - name: Upload to GitHub Release (draft)
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            out/make/**/*.dmg
+            out/make/**/*.exe
+            out/make/**/*.nupkg
+            out/make/**/*.deb
+            out/make/**/*.zip
+            out/make/**/RELEASES
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## M4b — 릴리즈 자동화

`vX.Y.Z` 태그 push 시 3플랫폼 인스톨러를 자동 빌드해 GitHub Release(draft)에 올립니다.

- **트리거**: `v*` 태그 push
- **matrix**: `macos-latest`(dmg) · `windows-latest`(exe+nupkg, Squirrel) · `ubuntu-latest`(deb) + 각 zip
- 각 OS에서 `pnpm make`(electron-forge, package.json의 maker-dmg/squirrel/deb/zip 사용) → `softprops/action-gh-release@v2`로 동일 태그 릴리즈에 업로드
- **draft 생성** + `generate_release_notes` → 게시 전 검토 후 수동 publish
- `permissions: contents: write`, `fail-fast: false`

### ⚠️ 검증 한계
크로스플랫폼 빌드라 로컬 검증이 불가합니다. **실제 `v*` 태그 push에서 검증**되며, 태그 전까지는 아무 영향 없습니다(트리거 안 됨). macOS는 미서명(unsigned) dmg입니다(OSS 기본; 코드서명은 인증서 필요 시 후속).

### M4 남은 항목
auto-updater, README 스크린샷, UI 영문 감사, `v1.0.0` 태그(→ 이 워크플로 첫 실전).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_