### PR TITLE
feat: 자동 업데이트 (update-electron-app) — M4c

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.3",
     "tw-animate-css": "^1.2.5",
+    "update-electron-app": "^3.2.0",
     "uuid": "^13.0.0",
     "zustand": "^5.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       tw-animate-css:
         specifier: ^1.2.5
         version: 1.2.9
+      update-electron-app:
+        specifier: ^3.2.0
+        version: 3.2.0
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -4066,6 +4069,9 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  github-url-to-object@4.0.6:
+    resolution: {integrity: sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4290,6 +4296,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
@@ -5741,6 +5750,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  update-electron-app@3.2.0:
+    resolution: {integrity: sha512-l2e7bzsW+rw70pfyyQeA9E/ofpNY2ZS99XuYxD2qWL4fEy3qMjpqwwgB0me7ESpGogIQE1CM0SaDvKGsK4Jg3Q==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -9827,6 +9839,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-url-to-object@4.0.6:
+    dependencies:
+      is-url: 1.2.4
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -10048,6 +10064,8 @@ snapshots:
   is-stream@1.1.0: {}
 
   is-unicode-supported@0.1.0: {}
+
+  is-url@1.2.4: {}
 
   is-wsl@3.1.1:
     dependencies:
@@ -11528,6 +11546,11 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  update-electron-app@3.2.0:
+    dependencies:
+      github-url-to-object: 4.0.6
+      ms: 2.1.3
 
   use-callback-ref@1.3.3(@types/react@19.1.2)(react@19.1.0):
     dependencies:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { app, BrowserWindow, shell } from 'electron'
+import { UpdateSourceType, updateElectronApp } from 'update-electron-app'
 import { CoreConstant } from '@/constant/CoreConstant'
 import { initHandler } from '@/handler/initHandler'
 import { CoreUtil } from '@/util/CoreUtil'
@@ -49,6 +50,14 @@ function createWindow() {
 app.whenReady().then(() => {
   electronApp.setAppUserModelId('com.electron')
   const startTime = performance.now()
+
+  // 프로덕션(패키징된 앱)에서만 GitHub Releases 기반 자동 업데이트 (macOS/Windows; Linux 미지원)
+  if (app.isPackaged) {
+    updateElectronApp({
+      updateSource: { type: UpdateSourceType.ElectronPublicUpdateService, repo: 'jujoycode/hydra' },
+      updateInterval: '1 hour'
+    })
+  }
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.


### PR DESCRIPTION
## M4c — 자동 업데이트

`update-electron-app`로 GitHub Releases 기반 자동 업데이트를 추가합니다.

- `src/main/index.ts`에서 **`app.isPackaged`일 때만** `updateElectronApp({ updateSource: ElectronPublicUpdateService, repo: 'jujoycode/hydra', updateInterval: '1 hour' })` 호출
- update.electronjs.org(공개 저장소 무료) 경유 → macOS/Windows(Squirrel) 자동 업데이트. dev/Linux는 no-op
- 릴리즈 자동화(#59)가 게시한 인스톨러를 소비하는 구조

### 검증
typecheck(node) · lint:ci(0) · test pass. (실제 업데이트는 패키징·게시된 빌드에서만 동작)

### M4 남은 항목
README 스크린샷(수동 캡처 필요), UI 영문 감사, `v1.0.0` 태그(→ #59 릴리즈 워크플로 첫 실전).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_