### PR TITLE
test: 전 스토리 자동 스모크 테스트 + 커넥티드 컴포넌트 프로바이더 하니스

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Bridge exposing `window.callApi` for typed IPC communication.
 - **DB naming** (`docs/design/convention-db.md`): snake_case tables (plural), snake_case columns (singular)
 - **Atomic Design**: atoms → molecules → organisms → templates → pages → layouts
 - **Component folder structure**: 각 컴포넌트는 자기 이름의 폴더를 가진다 — `atoms/Skeleton/{ index.ts(barrel: export * from './Skeleton'), Skeleton.tsx, Skeleton.stories.tsx, Skeleton.test.tsx }`. import는 배럴 경유(`@/atoms/Skeleton`)라 폴더화해도 임포터는 안 바뀐다. atoms·molecules·templates·organisms·pages·layouts 전 레이어 전환 완료(평면 컴포넌트 없음); 신규 컴포넌트는 처음부터 이 구조로 생성한다. 스토리는 프레젠테이셔널(atoms/molecules/simple-templates/charts)에만 생성하고, 커넥티드(organisms/pages/layouts)는 폴더 구조만 유지한다. `export default` 컴포넌트의 배럴은 `export { default }`도 함께 재노출한다(lazyRoute 호환).
+- **Testing**: Vitest 2-project(main: node / renderer: jsdom). 렌더러 jsdom 폴리필(ResizeObserver, matchMedia)은 `vitest.setup.ts`. 모든 `*.stories.tsx`는 `src/renderer/src/components/stories.smoke.test.tsx`가 `composeStories`로 자동 스모크 렌더(새 스토리 추가 시 별도 테스트 불필요). 커넥티드 컴포넌트는 `@/test/test-utils`의 `renderWithProviders`(Theme+Query+i18n)로 테스트한다. 자세한 계층은 `docs/adr/0003-*`.
 
 ## V3 Features
 

--- a/src/renderer/src/components/organisms/tabs/DashboardTab/DashboardTab.test.tsx
+++ b/src/renderer/src/components/organisms/tabs/DashboardTab/DashboardTab.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { DashboardTab } from './DashboardTab'
+
+// 커넥티드 organism을 앱 프로바이더(Theme + Query + i18n)로 렌더하는 예시 테스트.
+// renderWithProviders 하니스가 i18n 번역까지 정상 동작함을 검증한다.
+describe('DashboardTab', () => {
+  const props = {
+    issueStats: { total: 10, inProgress: 3, done: 5, blocked: 1, review: 1 },
+    statusData: [
+      { name: 'Done', value: 5, color: 'var(--chart-1)' },
+      { name: 'In Progress', value: 3, color: 'var(--chart-2)' }
+    ],
+    trendData: [
+      { name: 'Mon', created: 2, resolved: 1 },
+      { name: 'Tue', created: 3, resolved: 4 }
+    ]
+  }
+
+  it('통계 카드와 차트가 프로바이더 하니스에서 렌더된다', () => {
+    render(<DashboardTab {...props} />)
+    // i18n 번역 키가 실제 문자열로 치환되어 노출된다(translation 누락 시 'stats.totalIssues' 키 그대로 노출됨)
+    expect(screen.getByText('전체 이슈')).toBeInTheDocument()
+  })
+
+  it('완료율이 issueStats로부터 계산된다', () => {
+    render(<DashboardTab {...props} />)
+    // done(5) / total(10) = 50%
+    expect(screen.getByText('50%')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/stories.smoke.test.tsx
+++ b/src/renderer/src/components/stories.smoke.test.tsx
@@ -1,0 +1,31 @@
+import { composeStories } from '@storybook/react'
+import { cleanup, render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// 모든 *.stories.tsx를 자동 수집해 portable stories로 스모크 렌더한다.
+// 새 스토리를 추가하면 별도 테스트 작성 없이 자동으로 커버된다(렌더 중 throw가 없는지 검증).
+type StoryModule = Parameters<typeof composeStories>[0]
+const storyModules = import.meta.glob<StoryModule>('./**/*.stories.tsx', { eager: true })
+
+afterEach(cleanup)
+
+describe('component stories smoke', () => {
+  const entries = Object.entries(storyModules)
+
+  it('수집된 스토리 모듈이 존재한다', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  for (const [path, mod] of entries) {
+    const composed = composeStories(mod)
+    const relPath = path.replace(/^\.\//, '')
+
+    for (const [name, Story] of Object.entries(composed) as [string, ComponentType][]) {
+      it(`${relPath} → ${name} 렌더`, () => {
+        const { container } = render(<Story />)
+        expect(container).toBeInTheDocument()
+      })
+    }
+  }
+})

--- a/src/renderer/src/test/test-utils.tsx
+++ b/src/renderer/src/test/test-utils.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { type RenderOptions, render } from '@testing-library/react'
+import { ThemeProvider } from 'next-themes'
+import type { ReactElement, ReactNode } from 'react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../locales'
+
+// 테스트마다 캐시가 격리되도록 새 QueryClient를 만든다(재시도 off, 콘솔 에러 억제).
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, gcTime: 0 },
+      mutations: { retry: false }
+    }
+  })
+}
+
+interface ProvidersProps {
+  children: ReactNode
+  queryClient?: QueryClient
+}
+
+/**
+ * 앱과 동일한 프로바이더 스택(Theme + Query + i18n)으로 children을 감싼다.
+ * 커넥티드 컴포넌트(organisms/pages 등)를 테스트할 때 사용한다.
+ * 라우터 훅(useParams/useNavigate)에 의존하는 컴포넌트는 별도 라우터 스텁이 필요하다.
+ */
+export function AppProviders({ children, queryClient = createTestQueryClient() }: ProvidersProps) {
+  return (
+    <ThemeProvider attribute='class' defaultTheme='light' enableSystem={false}>
+      <QueryClientProvider client={queryClient}>
+        <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  )
+}
+
+interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
+  queryClient?: QueryClient
+}
+
+/**
+ * @testing-library/react의 render를 앱 프로바이더로 감싼 커스텀 render.
+ * 사용법: `import { renderWithProviders } from '@/test/test-utils'`
+ */
+export function renderWithProviders(ui: ReactElement, options: CustomRenderOptions = {}) {
+  const { queryClient, ...renderOptions } = options
+  return render(ui, {
+    wrapper: ({ children }) => <AppProviders queryClient={queryClient}>{children}</AppProviders>,
+    ...renderOptions
+  })
+}
+
+// @testing-library/react re-export — 테스트에서 단일 임포트 소스로 사용
+export * from '@testing-library/react'
+export { renderWithProviders as render }

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -53,6 +53,7 @@
       "@/hooks/*": ["src/renderer/src/hooks/*"],
       "@/types/*": ["src/renderer/src/types/*"],
       "@/stores/*": ["src/renderer/src/stores/*"],
+      "@/test/*": ["src/renderer/src/test/*"],
       "@/interface/*": ["src/main/core/interface/*"],
       "@/routers": ["src/renderer/src/routers"],
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ const rendererAliases = {
   '@/hooks': resolve('src/renderer/src/hooks'),
   '@/types': resolve('src/renderer/src/types'),
   '@/stores': resolve('src/renderer/src/stores'),
+  '@/test': resolve('src/renderer/src/test'),
   '@/utils': resolve('src/renderer/src/utils'),
   '@/constants': resolve('src/renderer/src/constants'),
   '@/interface': resolve('src/main/core/interface')
@@ -60,7 +61,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/main/**/*.ts', 'src/renderer/src/**/*.{ts,tsx}'],
-      exclude: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}', '**/index.ts', 'src/renderer/src/**/*.d.ts'],
+      exclude: [
+        '**/*.test.{ts,tsx}',
+        '**/*.stories.{ts,tsx}',
+        '**/index.ts',
+        'src/renderer/src/**/*.d.ts',
+        'src/renderer/src/test/**'
+      ],
       // 회귀 방지 floor. 미테스트 UI 표면이 커서 초기값은 낮다 — 테스트가 늘면 단계적으로 상향(ratchet).
       // CI는 DB 통합 테스트까지 실행하므로 실제 수치는 이 floor보다 높다.
       thresholds: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,27 @@
 // 렌더러(jsdom) 테스트 전역 설정 — jest-dom 매처 등록
 import '@testing-library/jest-dom/vitest'
+
+// jsdom에는 ResizeObserver가 없다 — recharts ResponsiveContainer 등 리사이즈 의존 컴포넌트 렌더용 폴리필
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+}
+
+// jsdom에는 matchMedia가 없다 — next-themes ThemeProvider 등 미디어쿼리 의존 컴포넌트 렌더용 폴리필
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false
+  })) as unknown as typeof window.matchMedia
+}


### PR DESCRIPTION
## 개요

"각 스토리에 vitest가 있는지 확인하고 모든 컴포넌트를 테스트할 수 있게 준비" 요청에 대응합니다.

기존엔 스토리 33개 중 단 4개만 테스트가 있었습니다. 스토리마다 테스트 파일을 일일이 만드는 대신, **모든 스토리를 자동 수집해 스모크 렌더하는 단일 테스트**와 **커넥티드 컴포넌트용 프로바이더 하니스**를 도입했습니다.

## 변경 사항

### 1. 전 스토리 자동 스모크 테스트
- `src/renderer/src/components/stories.smoke.test.tsx`: `import.meta.glob`로 모든 `*.stories.tsx`를 수집 → `composeStories`로 각 스토리를 렌더해 throw가 없는지 검증 (현재 **64건** 자동 커버)
- 새 스토리를 추가하면 별도 테스트 작성 없이 자동으로 포함됨

### 2. jsdom 폴리필 (`vitest.setup.ts`)
- `ResizeObserver` (recharts `ResponsiveContainer`)
- `window.matchMedia` (next-themes `ThemeProvider`)

### 3. 커넥티드 컴포넌트 테스트 하니스 (`@/test/test-utils`)
- `renderWithProviders` — 앱과 동일한 Theme + Query + i18n 프로바이더로 래핑
- `@testing-library/react` re-export로 단일 임포트 소스 제공
- `@/test/*` 별칭 추가 (`tsconfig.web.json`, `vitest.config.ts`), 커버리지에서 test 인프라 제외
- `DashboardTab.test.tsx` — 하니스(i18n 번역 + 계산 로직) 동작 검증용 예시

### 결과
- 테스트 **69 → 135건** (모두 통과)

## 검증

- `pnpm typecheck` ✅
- `pnpm lint:ci` ✅ (warning만, error 없음)
- `pnpm test` ✅ (135 passed / 25 skipped)
- `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_