### PR TITLE
refactor: React 19 관용구 정리 (forwardRef/Context.Provider/React.FC 제거)

### DIFF
--- a/src/renderer/src/components/atoms/Breadcrumb/Breadcrumb.tsx
+++ b/src/renderer/src/components/atoms/Breadcrumb/Breadcrumb.tsx
@@ -1,20 +1,17 @@
 import { Slot } from '@radix-ui/react-slot'
 import { ChevronRight, MoreHorizontal } from 'lucide-react'
-import * as React from 'react'
+import type * as React from 'react'
 import { cn } from '@/lib/utils'
 
-const Breadcrumb = React.forwardRef<
-  HTMLElement,
-  React.ComponentPropsWithoutRef<'nav'> & {
-    separator?: React.ReactNode
-  }
->(({ ...props }, ref) => <nav ref={ref} aria-label='breadcrumb' {...props} />)
-Breadcrumb.displayName = 'Breadcrumb'
+// React 19: ref를 일반 prop으로 전달(forwardRef 불필요). 나머지 atoms와 동일한 data-slot 패턴.
+function Breadcrumb({ ...props }: React.ComponentProps<'nav'> & { separator?: React.ReactNode }) {
+  return <nav data-slot='breadcrumb' aria-label='breadcrumb' {...props} />
+}
 
-const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWithoutRef<'ol'>>(
-  ({ className, ...props }, ref) => (
+function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
+  return (
     <ol
-      ref={ref}
+      data-slot='breadcrumb-list'
       className={cn(
         'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
         className
@@ -22,32 +19,23 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
       {...props}
     />
   )
-)
-BreadcrumbList.displayName = 'BreadcrumbList'
+}
 
-const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<'li'>>(
-  ({ className, ...props }, ref) => (
-    <li ref={ref} className={cn('inline-flex items-center gap-1.5', className)} {...props} />
-  )
-)
-BreadcrumbItem.displayName = 'BreadcrumbItem'
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot='breadcrumb-item' className={cn('inline-flex items-center gap-1.5', className)} {...props} />
+}
 
-const BreadcrumbLink = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<'a'> & {
-    asChild?: boolean
-  }
->(({ asChild, className, ...props }, ref) => {
+function BreadcrumbLink({ asChild, className, ...props }: React.ComponentProps<'a'> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : 'a'
+  return (
+    <Comp data-slot='breadcrumb-link' className={cn('transition-colors hover:text-foreground', className)} {...props} />
+  )
+}
 
-  return <Comp ref={ref} className={cn('transition-colors hover:text-foreground', className)} {...props} />
-})
-BreadcrumbLink.displayName = 'BreadcrumbLink'
-
-const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<'span'>>(
-  ({ className, ...props }, ref) => (
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
     <span
-      ref={ref}
+      data-slot='breadcrumb-page'
       role='link'
       aria-disabled='true'
       aria-current='page'
@@ -55,21 +43,26 @@ const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWit
       {...props}
     />
   )
-)
-BreadcrumbPage.displayName = 'BreadcrumbPage'
+}
 
 function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<'li'>) {
   return (
-    <li role='presentation' aria-hidden='true' className={cn('[&>svg]:size-3.5', className)} {...props}>
+    <li
+      data-slot='breadcrumb-separator'
+      role='presentation'
+      aria-hidden='true'
+      className={cn('[&>svg]:size-3.5', className)}
+      {...props}
+    >
       {children ?? <ChevronRight />}
     </li>
   )
 }
-BreadcrumbSeparator.displayName = 'BreadcrumbSeparator'
 
 function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
+      data-slot='breadcrumb-ellipsis'
       role='presentation'
       aria-hidden='true'
       className={cn('flex size-9 items-center justify-center', className)}
@@ -80,7 +73,6 @@ function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'
     </span>
   )
 }
-BreadcrumbEllipsis.displayName = 'BreadcrumbEllipsis'
 
 export {
   Breadcrumb,

--- a/src/renderer/src/components/atoms/Tabs/Tabs.tsx
+++ b/src/renderer/src/components/atoms/Tabs/Tabs.tsx
@@ -1,52 +1,49 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs'
-import * as React from 'react'
+import type * as React from 'react'
 import { cn } from '@/lib/utils'
 
-const Tabs = TabsPrimitive.Root
+// React 19: ref를 일반 prop으로 전달(forwardRef 불필요). 나머지 atoms(Dialog 등)와 동일한 data-slot 패턴.
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return <TabsPrimitive.Root data-slot='tabs' className={className} {...props} />
+}
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
-      className
-    )}
-    {...props}
-  />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot='tabs-list'
+      className={cn(
+        'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
-      className
-    )}
-    {...props}
-  />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot='tabs-trigger'
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      className
-    )}
-    {...props}
-  />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot='tabs-content'
+      className={cn(
+        'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/src/renderer/src/components/molecules/InputField/InputField.tsx
+++ b/src/renderer/src/components/molecules/InputField/InputField.tsx
@@ -116,13 +116,14 @@ export function InputField({ id, label, error, children, className, ...props }: 
   const fieldId = id || generatedId
 
   return (
-    <InputFieldContext.Provider value={{ id: fieldId, error }}>
+    // React 19: Context를 직접 Provider로 사용(<Context.Provider> 불필요)
+    <InputFieldContext value={{ id: fieldId, error }}>
       <div className={cn('grid gap-2', className)} {...props}>
         {label && <Label htmlFor={fieldId}>{label}</Label>}
         {children}
         {error && <p className='text-destructive text-sm'>{error}</p>}
       </div>
-    </InputFieldContext.Provider>
+    </InputFieldContext>
   )
 }
 

--- a/src/renderer/src/components/molecules/cards/SettingCard/SettingCard.tsx
+++ b/src/renderer/src/components/molecules/cards/SettingCard/SettingCard.tsx
@@ -9,7 +9,7 @@ interface SettingCardProps {
   className?: string
 }
 
-export const SettingCard: React.FC<SettingCardProps> = ({ title, description, children, footer, className }) => {
+export function SettingCard({ title, description, children, footer, className }: SettingCardProps) {
   return (
     <Card className={className}>
       <CardHeader className='pb-4'>

--- a/src/renderer/src/components/organisms/sidebars/Sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/organisms/sidebars/Sidebar/Sidebar.tsx
@@ -110,7 +110,8 @@ function SidebarProvider({
   )
 
   return (
-    <SidebarContext.Provider value={contextValue}>
+    // React 19: Context를 직접 Provider로 사용(<Context.Provider> 불필요)
+    <SidebarContext value={contextValue}>
       <TooltipProvider delayDuration={0}>
         <div
           data-slot='sidebar-wrapper'
@@ -127,7 +128,7 @@ function SidebarProvider({
           {children}
         </div>
       </TooltipProvider>
-    </SidebarContext.Provider>
+    </SidebarContext>
   )
 }
 


### PR DESCRIPTION
## 개요

프론트엔드 React 19 베스트 프랙티스 점검의 첫 단계입니다. 코드베이스 대부분의 atoms는 이미 React 19 스타일(plain function + `ref` as prop + `data-slot`)인데, 일부 파일만 레거시 패턴이 남아 있어 일관성을 맞춥니다.

## 변경 사항

- **`React.forwardRef` 제거 (2개)**: `Tabs`, `Breadcrumb`
  - React 19에서 `ref`는 일반 prop이므로 `forwardRef` + `React.ElementRef`/`ComponentPropsWithoutRef` 불필요
  - 나머지 atoms(Dialog/Button 등)와 동일한 `data-slot` 패턴으로 통일
- **`<Context.Provider>` → `<Context>` (2개)**: `Sidebar`, `InputField`
  - React 19에서 Context를 직접 Provider로 사용 가능
- **`React.FC` 제거 (1개)**: `SettingCard` → 일반 함수 선언 (코드베이스에 `React.FC` 0개로 정리)

## 영향

동작 변화 없음. 공개 API(export, props) 동일하여 임포터 수정 불필요.

## 검증

- `pnpm typecheck` ✅
- `pnpm lint:ci` ✅
- `pnpm test` ✅ (135 passed / 25 skipped — 스토리 스모크가 Tabs/Breadcrumb 렌더 검증)
- `pnpm build` ✅

> 이후 단계(별도 PR 예정): 표 관련 `any` 타입 축소, 불필요한 `useEffect`/`useMemo` 점검, 데이터 패칭 훅 일관성 등.

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_