### PR TITLE
refactor: NotificationsPage 데이터 패칭을 useQuery/useMutation으로 이관

### DIFF
--- a/src/renderer/src/components/pages/NotificationsPage/NotificationsPage.tsx
+++ b/src/renderer/src/components/pages/NotificationsPage/NotificationsPage.tsx
@@ -1,10 +1,9 @@
 import { useNavigate } from '@tanstack/react-router'
 import { Bell, CheckCheck, Loader2, MessageSquare, Target, Trash2, UserCheck } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/atoms/Button'
+import { useNotificationMutations, useNotifications } from '@/hooks/use-notifications'
 import type { Notification } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
 import { formatRelativeKorean } from '@/lib/formatDate'
 import { useAuthStore } from '@/stores/auth'
 
@@ -26,32 +25,13 @@ function NotificationIcon({ type }: { type: string }) {
 export default function NotificationsPage() {
   const navigate = useNavigate()
   const { user } = useAuthStore()
-  const [notifications, setNotifications] = useState<Notification[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-
-  const loadNotifications = useCallback(async () => {
-    if (!user) return
-    setIsLoading(true)
-    const result = await window.callApi(IpcChannel.NOTIFICATION_LIST, { userId: user.user_id })
-    if (Array.isArray(result.data)) {
-      setNotifications(result.data)
-    }
-    setIsLoading(false)
-  }, [user])
-
-  useEffect(() => {
-    loadNotifications()
-  }, [loadNotifications])
+  const { data: notifications = [], isLoading } = useNotifications(user?.user_id)
+  const { markRead, markAllRead, remove } = useNotificationMutations(user?.user_id)
 
   const handleClick = async (notification: Notification) => {
     // 읽지 않은 알림이면 읽음 처리
     if (!notification.notification_read) {
-      await window.callApi(IpcChannel.NOTIFICATION_MARK_READ, {
-        notificationId: notification.notification_id
-      })
-      setNotifications((prev) =>
-        prev.map((n) => (n.notification_id === notification.notification_id ? { ...n, notification_read: true } : n))
-      )
+      await markRead.mutateAsync({ notificationId: notification.notification_id })
     }
 
     // 링크가 있으면 이동
@@ -62,19 +42,13 @@ export default function NotificationsPage() {
 
   const handleMarkAllAsRead = async () => {
     if (!user) return
-    const result = await window.callApi(IpcChannel.NOTIFICATION_MARK_ALL_READ, { userId: user.user_id })
-    if (result.data) {
-      setNotifications((prev) => prev.map((n) => ({ ...n, notification_read: true })))
-      toast.success('모든 알림을 읽음 처리했습니다')
-    }
+    await markAllRead.mutateAsync({ userId: user.user_id })
+    toast.success('모든 알림을 읽음 처리했습니다')
   }
 
-  const handleDelete = async (e: React.MouseEvent, notificationId: string) => {
+  const handleDelete = (e: React.MouseEvent, notificationId: string) => {
     e.stopPropagation()
-    const result = await window.callApi(IpcChannel.NOTIFICATION_DELETE, { notificationId })
-    if (result.data) {
-      setNotifications((prev) => prev.filter((n) => n.notification_id !== notificationId))
-    }
+    remove.mutate({ notificationId })
   }
 
   const unreadCount = notifications.filter((n) => !n.notification_read).length

--- a/src/renderer/src/hooks/use-notifications.ts
+++ b/src/renderer/src/hooks/use-notifications.ts
@@ -1,0 +1,33 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { useApiMutation, useApiQuery } from './use-api'
+
+/** 사용자의 알림 목록을 최신순으로 조회한다. */
+export function useNotifications(userId: string | undefined) {
+  return useApiQuery(
+    queryKeys.notifications.list(userId ?? ''),
+    IpcChannel.NOTIFICATION_LIST,
+    { userId: userId ?? '' },
+    { enabled: !!userId }
+  )
+}
+
+/**
+ * 알림 변경(읽음/모두 읽음/삭제) 뮤테이션 묶음.
+ * 성공 시 해당 사용자의 알림 목록·미읽음 카운트 캐시를 무효화한다.
+ */
+export function useNotificationMutations(userId: string | undefined) {
+  const queryClient = useQueryClient()
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.notifications.list(userId ?? '') })
+    queryClient.invalidateQueries({ queryKey: queryKeys.notifications.unreadCount(userId ?? '') })
+  }
+
+  const markRead = useApiMutation(IpcChannel.NOTIFICATION_MARK_READ, { onSuccess: invalidate })
+  const markAllRead = useApiMutation(IpcChannel.NOTIFICATION_MARK_ALL_READ, { onSuccess: invalidate })
+  const remove = useApiMutation(IpcChannel.NOTIFICATION_DELETE, { onSuccess: invalidate })
+
+  return { markRead, markAllRead, remove }
+}

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -15,5 +15,10 @@ export const queryKeys = {
   },
   activity: {
     byEntity: (entityType: string, entityId: string) => ['activity', entityType, entityId] as const
+  },
+  notifications: {
+    all: ['notifications'] as const,
+    list: (userId: string) => ['notifications', 'list', userId] as const,
+    unreadCount: (userId: string) => ['notifications', 'unreadCount', userId] as const
   }
 } as const


### PR DESCRIPTION
## 개요

데이터 패칭 통일 리팩토링의 첫 페이지입니다. NotificationsPage의 수동 `useState + useEffect + window.callApi` 패턴을 ADR 0002의 React Query 기반 패턴으로 이관합니다.

## 변경 사항

- `hooks/use-notifications.ts` 추가
  - `useNotifications(userId)` — 알림 목록 조회(useApiQuery)
  - `useNotificationMutations(userId)` — 읽음/모두읽음/삭제 뮤테이션, 성공 시 목록·미읽음 카운트 캐시 무효화
- `queryKeys.notifications` 추가(list / unreadCount)
- NotificationsPage: 수동 로딩 state·effect·로컬 배열 변형 제거 → 훅 사용

## 영향

- UX 동일(읽음/삭제 즉시 반영은 캐시 무효화 → 재조회로 처리)
- "fetch in useEffect" 안티패턴 제거, 로딩/에러/캐시 일관화

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

> 후속 PR로 TasksPage, 설정 페이지, ProjectDetail/Members/IssueDetail 등 나머지 수동 패칭 페이지를 동일 패턴으로 이관 예정.

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_