### PR TITLE
refactor: TasksPage 데이터 패칭을 useQuery/useQueries로 이관 (N+1 정리)

### DIFF
--- a/src/renderer/src/components/pages/TasksPage/TasksPage.tsx
+++ b/src/renderer/src/components/pages/TasksPage/TasksPage.tsx
@@ -1,69 +1,33 @@
 import { useParams } from '@tanstack/react-router'
 import { Plus, Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Button } from '@/atoms/Button'
 import { Checkbox } from '@/atoms/Checkbox'
 import { Input } from '@/atoms/Input'
 import { useAuth } from '@/hooks/use-auth'
-import type { Issue, Task } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
-
-interface IssueWithTasks {
-  issue: Issue
-  tasks: Task[]
-}
+import { useProjectTasks, useTaskMutations } from '@/hooks/use-tasks'
 
 export default function TasksPage() {
   const { projectId } = useParams({ strict: false })
   const { user } = useAuth()
-  const [issuesWithTasks, setIssuesWithTasks] = useState<IssueWithTasks[]>([])
+  const { issuesWithTasks, isLoading } = useProjectTasks(projectId)
+  const { create, update, remove } = useTaskMutations()
   const [newTaskInputs, setNewTaskInputs] = useState<Record<string, string>>({})
-  const [isLoading, setIsLoading] = useState(true)
 
-  const loadData = useCallback(async () => {
-    if (!projectId) return
-    setIsLoading(true)
-
-    const issueResult = await window.callApi(IpcChannel.ISSUE_LIST, { projectId })
-    const issues = Array.isArray(issueResult.data) ? (issueResult.data as Issue[]) : []
-
-    const results: IssueWithTasks[] = []
-    for (const issue of issues) {
-      const taskResult = await window.callApi(IpcChannel.TASK_LIST, { issueId: issue.issue_id })
-      const tasks = Array.isArray(taskResult.data) ? (taskResult.data as Task[]) : []
-      results.push({ issue, tasks })
-    }
-
-    setIssuesWithTasks(results)
-    setIsLoading(false)
-  }, [projectId])
-
-  useEffect(() => {
-    loadData()
-  }, [loadData])
-
-  const handleToggleTask = async (taskId: string, completed: boolean) => {
-    await window.callApi(IpcChannel.TASK_UPDATE, { taskId, taskCompleted: !completed })
-    await loadData()
+  const handleToggleTask = (taskId: string, completed: boolean) => {
+    update.mutate({ taskId, taskCompleted: !completed })
   }
 
-  const handleDeleteTask = async (taskId: string) => {
-    await window.callApi(IpcChannel.TASK_DELETE, { taskId })
-    await loadData()
+  const handleDeleteTask = (taskId: string) => {
+    remove.mutate({ taskId })
   }
 
   const handleAddTask = async (issueId: string) => {
     const title = newTaskInputs[issueId]?.trim()
     if (!title || !user) return
 
-    await window.callApi(IpcChannel.TASK_CREATE, {
-      issueId,
-      taskTitle: title,
-      userId: user.user_id
-    })
-
+    await create.mutateAsync({ issueId, taskTitle: title, userId: user.user_id })
     setNewTaskInputs((prev) => ({ ...prev, [issueId]: '' }))
-    await loadData()
   }
 
   const handleKeyDown = (e: React.KeyboardEvent, issueId: string) => {

--- a/src/renderer/src/hooks/use-tasks.ts
+++ b/src/renderer/src/hooks/use-tasks.ts
@@ -1,0 +1,43 @@
+import { useQueries, useQueryClient } from '@tanstack/react-query'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { invokeApi, useApiMutation, useApiQuery } from './use-api'
+
+/**
+ * 프로젝트의 이슈별 체크리스트(Tasks)를 조회한다.
+ * 이슈 목록은 단일 쿼리, 이슈별 task는 useQueries로 병렬 조회(N+1을 React Query 캐시로 관리).
+ * 이슈 목록 쿼리키는 useProjectIssues와 동일하여 캐시를 공유한다(중복 패칭 없음).
+ */
+export function useProjectTasks(projectId: string | undefined) {
+  const issuesQuery = useApiQuery(
+    queryKeys.issues.byProject(projectId ?? ''),
+    IpcChannel.ISSUE_LIST,
+    { projectId: projectId ?? '' },
+    { enabled: !!projectId }
+  )
+  const issues = issuesQuery.data ?? []
+
+  const taskQueries = useQueries({
+    queries: issues.map((issue) => ({
+      queryKey: queryKeys.tasks.byIssue(issue.issue_id),
+      queryFn: () => invokeApi(IpcChannel.TASK_LIST, { issueId: issue.issue_id })
+    }))
+  })
+
+  const issuesWithTasks = issues.map((issue, i) => ({ issue, tasks: taskQueries[i]?.data ?? [] }))
+  const isLoading = issuesQuery.isLoading || taskQueries.some((q) => q.isLoading)
+
+  return { issuesWithTasks, isLoading }
+}
+
+/** task 생성/수정/삭제 뮤테이션 묶음. 성공 시 모든 task 쿼리를 무효화한다. */
+export function useTaskMutations() {
+  const queryClient = useQueryClient()
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.tasks.all })
+
+  const create = useApiMutation(IpcChannel.TASK_CREATE, { onSuccess: invalidate })
+  const update = useApiMutation(IpcChannel.TASK_UPDATE, { onSuccess: invalidate })
+  const remove = useApiMutation(IpcChannel.TASK_DELETE, { onSuccess: invalidate })
+
+  return { create, update, remove }
+}

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -20,5 +20,9 @@ export const queryKeys = {
     all: ['notifications'] as const,
     list: (userId: string) => ['notifications', 'list', userId] as const,
     unreadCount: (userId: string) => ['notifications', 'unreadCount', userId] as const
+  },
+  tasks: {
+    all: ['tasks'] as const,
+    byIssue: (issueId: string) => ['tasks', 'issue', issueId] as const
   }
 } as const


### PR DESCRIPTION
## 개요

데이터 패칭 통일 리팩토링 2번째 페이지입니다. TasksPage의 수동 패칭 + 이슈별 task 순차 N+1을 React Query로 이관합니다.

## 변경 사항

- `hooks/use-tasks.ts` 추가
  - `useProjectTasks(projectId)` — 이슈 목록(단일 쿼리) + 이슈별 task(`useQueries` 병렬). 이슈 목록 쿼리키는 `useProjectIssues`와 동일하여 캐시 공유(중복 패칭 없음)
  - `useTaskMutations()` — 생성/수정/삭제, 성공 시 task 쿼리 무효화
- `queryKeys.tasks` 추가
- TasksPage: 수동 `useState + useEffect + loadData()` 및 순차 `for` 루프 task 패칭 제거 → 훅 사용

## 영향

- 기존: 이슈 N개에 대해 task를 순차 await(N+1 직렬). 변경: `useQueries`로 병렬 + 캐시
- 변경 후 task 토글/삭제/추가는 캐시 무효화로 갱신(전체 loadData 재호출 제거)

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_