### PR TITLE
refactor: IntegrationPage 데이터 패칭을 useQuery/useMutation으로 이관

### DIFF
--- a/src/renderer/src/components/pages/settings/IntegrationPage/IntegrationPage.tsx
+++ b/src/renderer/src/components/pages/settings/IntegrationPage/IntegrationPage.tsx
@@ -1,72 +1,49 @@
 import { Github, Send, Slack } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/atoms/Button'
 import { Checkbox } from '@/atoms/Checkbox'
 import { Input } from '@/atoms/Input'
 import { Label } from '@/atoms/Label'
+import { useIntegrationMutations, useIntegrations } from '@/hooks/use-integrations'
 import type { Integration as IntegrationRecord } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
 import { SettingCard } from '@/molecules/cards/SettingCard'
 
-export default function IntegrationPage() {
-  const [isLoading, setIsLoading] = useState(true)
-
-  // Slack state
-  const [slackUrl, setSlackUrl] = useState('')
-  const [slackEnabled, setSlackEnabled] = useState(false)
-  const [isSavingSlack, setIsSavingSlack] = useState(false)
-  const [isTesting, setIsTesting] = useState(false)
-
-  // GitHub state
-  const [githubToken, setGithubToken] = useState('')
-  const [githubRepo, setGithubRepo] = useState('')
-  const [githubEnabled, setGithubEnabled] = useState(false)
-  const [isSavingGithub, setIsSavingGithub] = useState(false)
-
-  useEffect(() => {
-    loadIntegrations()
-  }, [])
-
-  const loadIntegrations = async () => {
-    setIsLoading(true)
-    const result = await window.callApi(IpcChannel.INTEGRATION_LIST)
-    if (Array.isArray(result.data)) {
-      const records = result.data as IntegrationRecord[]
-      const slack = records.find((i) => i.integration_type === 'slack')
-      if (slack) {
-        try {
-          const config = JSON.parse(slack.integration_config)
-          setSlackUrl(config.webhookUrl || '')
-        } catch {}
-        setSlackEnabled(slack.integration_enabled ?? false)
-      }
-      const github = records.find((i) => i.integration_type === 'github')
-      if (github) {
-        try {
-          const config = JSON.parse(github.integration_config)
-          setGithubToken(config.token || '')
-          setGithubRepo(config.repo || '')
-        } catch {}
-        setGithubEnabled(github.integration_enabled ?? false)
-      }
-    }
-    setIsLoading(false)
+function parseConfig(record: IntegrationRecord | undefined): Record<string, string> {
+  if (!record) return {}
+  try {
+    return JSON.parse(record.integration_config)
+  } catch {
+    return {}
   }
+}
+
+// 폼은 로드된 레코드를 초기값으로 받아 마운트 시 1회 초기화한다(useEffect로 서버→폼 동기화하지 않음).
+function IntegrationForm({ records }: { records: IntegrationRecord[] }) {
+  const { save, testSlack } = useIntegrationMutations()
+
+  const slack = records.find((i) => i.integration_type === 'slack')
+  const github = records.find((i) => i.integration_type === 'github')
+  const slackConfig = parseConfig(slack)
+  const githubConfig = parseConfig(github)
+
+  const [slackUrl, setSlackUrl] = useState(slackConfig.webhookUrl ?? '')
+  const [slackEnabled, setSlackEnabled] = useState(slack?.integration_enabled ?? false)
+  const [githubToken, setGithubToken] = useState(githubConfig.token ?? '')
+  const [githubRepo, setGithubRepo] = useState(githubConfig.repo ?? '')
+  const [githubEnabled, setGithubEnabled] = useState(github?.integration_enabled ?? false)
 
   const handleSaveSlack = async () => {
-    setIsSavingSlack(true)
-    const result = await window.callApi(IpcChannel.INTEGRATION_SAVE, {
-      integrationType: 'slack',
-      integrationConfig: JSON.stringify({ webhookUrl: slackUrl }),
-      integrationEnabled: slackEnabled
-    })
-    if (result.error) {
-      toast.error(`Failed: ${result.error.message}`)
-    } else {
+    try {
+      await save.mutateAsync({
+        integrationType: 'slack',
+        integrationConfig: JSON.stringify({ webhookUrl: slackUrl }),
+        integrationEnabled: slackEnabled
+      })
       toast.success('Slack settings saved')
+    } catch {
+      // 에러는 invokeApi가 토스트로 안내한다.
     }
-    setIsSavingSlack(false)
   }
 
   const handleTestSlack = async () => {
@@ -74,37 +51,21 @@ export default function IntegrationPage() {
       toast.error('Enter a webhook URL first')
       return
     }
-    setIsTesting(true)
-    const result = await window.callApi(IpcChannel.INTEGRATION_TEST_SLACK, { webhookUrl: slackUrl })
-    if (result.data) {
-      toast.success('Test message sent to Slack!')
-    } else {
-      toast.error(result.error?.message || 'Failed to send test message')
-    }
-    setIsTesting(false)
+    const ok = await testSlack.mutateAsync({ webhookUrl: slackUrl }).catch(() => false)
+    if (ok) toast.success('Test message sent to Slack!')
   }
 
   const handleSaveGithub = async () => {
-    setIsSavingGithub(true)
-    const result = await window.callApi(IpcChannel.INTEGRATION_SAVE, {
-      integrationType: 'github',
-      integrationConfig: JSON.stringify({ token: githubToken, repo: githubRepo }),
-      integrationEnabled: githubEnabled
-    })
-    if (result.error) {
-      toast.error(`Failed: ${result.error.message}`)
-    } else {
+    try {
+      await save.mutateAsync({
+        integrationType: 'github',
+        integrationConfig: JSON.stringify({ token: githubToken, repo: githubRepo }),
+        integrationEnabled: githubEnabled
+      })
       toast.success('GitHub settings saved')
+    } catch {
+      // 에러는 invokeApi가 토스트로 안내한다.
     }
-    setIsSavingGithub(false)
-  }
-
-  if (isLoading) {
-    return (
-      <div className='w-full p-6'>
-        <p className='text-muted-foreground'>Loading...</p>
-      </div>
-    )
   }
 
   return (
@@ -137,12 +98,17 @@ export default function IntegrationPage() {
           </div>
 
           <div className='flex gap-2'>
-            <Button onClick={handleSaveSlack} disabled={isSavingSlack} size='sm'>
-              {isSavingSlack ? 'Saving...' : 'Save'}
+            <Button onClick={handleSaveSlack} disabled={save.isPending} size='sm'>
+              {save.isPending ? 'Saving...' : 'Save'}
             </Button>
-            <Button onClick={handleTestSlack} disabled={isTesting || !slackUrl.trim()} variant='outline' size='sm'>
+            <Button
+              onClick={handleTestSlack}
+              disabled={testSlack.isPending || !slackUrl.trim()}
+              variant='outline'
+              size='sm'
+            >
               <Send className='size-3 mr-1' />
-              {isTesting ? 'Sending...' : 'Test'}
+              {testSlack.isPending ? 'Sending...' : 'Test'}
             </Button>
           </div>
         </div>
@@ -184,11 +150,25 @@ export default function IntegrationPage() {
             <p className='text-xs text-muted-foreground mt-1'>Format: owner/repo (e.g., jujoycode/hydra)</p>
           </div>
 
-          <Button onClick={handleSaveGithub} disabled={isSavingGithub} size='sm'>
-            {isSavingGithub ? 'Saving...' : 'Save'}
+          <Button onClick={handleSaveGithub} disabled={save.isPending} size='sm'>
+            {save.isPending ? 'Saving...' : 'Save'}
           </Button>
         </div>
       </SettingCard>
     </div>
   )
+}
+
+export default function IntegrationPage() {
+  const { data: records = [], isLoading } = useIntegrations()
+
+  if (isLoading) {
+    return (
+      <div className='w-full p-6'>
+        <p className='text-muted-foreground'>Loading...</p>
+      </div>
+    )
+  }
+
+  return <IntegrationForm records={records} />
 }

--- a/src/renderer/src/hooks/use-integrations.ts
+++ b/src/renderer/src/hooks/use-integrations.ts
@@ -1,0 +1,21 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { useApiMutation, useApiQuery } from './use-api'
+
+/** 워크스페이스의 서비스 인테그레이션(Slack/GitHub) 목록을 조회한다. */
+export function useIntegrations() {
+  return useApiQuery(queryKeys.integrations.all, IpcChannel.INTEGRATION_LIST, undefined)
+}
+
+/** 인테그레이션 저장/슬랙 테스트 뮤테이션. 저장 성공 시 목록 캐시를 무효화한다. */
+export function useIntegrationMutations() {
+  const queryClient = useQueryClient()
+
+  const save = useApiMutation(IpcChannel.INTEGRATION_SAVE, {
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.integrations.all })
+  })
+  const testSlack = useApiMutation(IpcChannel.INTEGRATION_TEST_SLACK)
+
+  return { save, testSlack }
+}

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -24,5 +24,8 @@ export const queryKeys = {
   tasks: {
     all: ['tasks'] as const,
     byIssue: (issueId: string) => ['tasks', 'issue', issueId] as const
+  },
+  integrations: {
+    all: ['integrations'] as const
   }
 } as const


### PR DESCRIPTION
## 개요

데이터 패칭 통일 리팩토링 3번째입니다. IntegrationPage(Slack/GitHub 설정)를 React Query로 이관합니다. 폼 시딩(서버 데이터→폼 초기값) 패턴을 useEffect 없이 처리합니다.

## 변경 사항

- `hooks/use-integrations.ts` 추가
  - `useIntegrations()` — 인테그레이션 목록 조회
  - `useIntegrationMutations()` — 저장/슬랙 테스트, 저장 성공 시 캐시 무효화
- `queryKeys.integrations` 추가
- IntegrationPage 구조 변경:
  - 부모: `useIntegrations()`로 조회, 로딩 게이트
  - 자식 `IntegrationForm`: 로드된 레코드를 **초기값**으로 받아 마운트 시 1회 `useState` 초기화 → "서버→폼 동기화" useEffect 제거
  - 저장/테스트는 `useApiMutation` + `isPending`으로 로딩 표시

## 영향

- 동작 동일, 수동 `isLoading/isSaving/isTesting` state 제거
- "fetch in useEffect" + 수동 에러 핸들링 제거(invokeApi가 일관 토스트)

> AccountPage는 raw `window.callApi`가 아닌 `useSettings` 훅을 쓰며, 남은 useEffect는 store→폼 시딩이라 별도 "불필요 useEffect 정리" 단계에서 다룹니다.

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_