### PR TITLE
refactor: MembersPage 데이터 패칭을 useQuery/useMutation으로 이관

### DIFF
--- a/src/renderer/src/components/pages/MembersPage/MembersPage.tsx
+++ b/src/renderer/src/components/pages/MembersPage/MembersPage.tsx
@@ -1,5 +1,5 @@
 import { Copy, LinkIcon, Loader2, Trash2, UserPlus } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Badge } from '@/atoms/Badge'
@@ -9,8 +9,8 @@ import { Input } from '@/atoms/Input'
 import { Label } from '@/atoms/Label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/atoms/Select'
 import { Textarea } from '@/atoms/Textarea'
+import { useUserMutations, useUsers } from '@/hooks/use-users'
 import type { User as UserRecord } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
 import { useAuthStore } from '@/stores/auth'
 
 function formatDate(date: Date | string | null): string {
@@ -26,13 +26,13 @@ function formatDate(date: Date | string | null): string {
 export default function MembersPage() {
   const { t } = useTranslation('member')
   const { t: tc } = useTranslation('common')
-  const [members, setMembers] = useState<UserRecord[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const { data: members = [], isLoading } = useUsers()
+  const { createMember, deleteUser, generateInvite } = useUserMutations()
   const [isAddOpen, setIsAddOpen] = useState(false)
   const [isInviteOpen, setIsInviteOpen] = useState(false)
   const [isDeleteOpen, setIsDeleteOpen] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<UserRecord | null>(null)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const isSubmitting = createMember.isPending || deleteUser.isPending || generateInvite.isPending
   const { currentWorkspace } = useAuthStore()
 
   // Add member form state
@@ -45,19 +45,6 @@ export default function MembersPage() {
   // Invite state
   const [expiresInHours, setExpiresInHours] = useState('24')
   const [inviteCode, setInviteCode] = useState('')
-
-  const loadMembers = useCallback(async () => {
-    setIsLoading(true)
-    const result = await window.callApi(IpcChannel.AUTH_LIST_USERS, undefined)
-    if (Array.isArray(result.data)) {
-      setMembers(result.data)
-    }
-    setIsLoading(false)
-  }, [])
-
-  useEffect(() => {
-    loadMembers()
-  }, [loadMembers])
 
   const resetAddForm = () => {
     setUserSn('')
@@ -85,25 +72,21 @@ export default function MembersPage() {
       return
     }
 
-    setIsSubmitting(true)
-    const result = await window.callApi(IpcChannel.AUTH_CREATE_MEMBER, {
-      userSn: userSn.trim(),
-      userName: userName.trim(),
-      userEmail: userEmail.trim(),
-      initialPassword: initialPassword.trim(),
-      userRole
-    })
-    setIsSubmitting(false)
-
-    if (result.error) {
-      toast.error(result.error.message || t('toast.addFailed'))
-      return
+    try {
+      await createMember.mutateAsync({
+        userSn: userSn.trim(),
+        userName: userName.trim(),
+        userEmail: userEmail.trim(),
+        initialPassword: initialPassword.trim(),
+        userRole
+      })
+    } catch {
+      return // 에러는 invokeApi가 토스트로 안내한다.
     }
 
     toast.success(t('toast.added'))
     setIsAddOpen(false)
     resetAddForm()
-    loadMembers()
   }
 
   const handleConfirmDelete = (member: UserRecord) => {
@@ -114,22 +97,15 @@ export default function MembersPage() {
   const handleDelete = async () => {
     if (!deleteTarget) return
 
-    setIsSubmitting(true)
-    const result = await window.callApi(IpcChannel.AUTH_DELETE_USER, {
-      id: deleteTarget.user_id,
-      shouldSoftDelete: false
-    })
-    setIsSubmitting(false)
-
-    if (result.error) {
-      toast.error(result.error.message || t('toast.removeFailed'))
-      return
+    try {
+      await deleteUser.mutateAsync({ id: deleteTarget.user_id, shouldSoftDelete: false })
+    } catch {
+      return // 에러는 invokeApi가 토스트로 안내한다.
     }
 
     toast.success(t('toast.removed'))
     setIsDeleteOpen(false)
     setDeleteTarget(null)
-    loadMembers()
   }
 
   const handleGenerateInvite = async () => {
@@ -138,24 +114,18 @@ export default function MembersPage() {
       return
     }
 
-    setIsSubmitting(true)
-    const result = await window.callApi(IpcChannel.INVITE_GENERATE, {
-      workspaceName: currentWorkspace.name,
-      host: currentWorkspace.host,
-      port: currentWorkspace.port,
-      dbName: currentWorkspace.dbName,
-      dbms: currentWorkspace.dbms ?? 'postgresql',
-      expiresInHours: Number(expiresInHours)
-    })
-    setIsSubmitting(false)
-
-    if (result.error) {
-      toast.error(result.error.message || t('toast.generateFailed'))
-      return
-    }
-
-    if (result.data) {
-      setInviteCode(result.data.code)
+    try {
+      const data = await generateInvite.mutateAsync({
+        workspaceName: currentWorkspace.name,
+        host: currentWorkspace.host,
+        port: currentWorkspace.port,
+        dbName: currentWorkspace.dbName,
+        dbms: currentWorkspace.dbms ?? 'postgresql',
+        expiresInHours: Number(expiresInHours)
+      })
+      if (data) setInviteCode(data.code)
+    } catch {
+      // 에러는 invokeApi가 토스트로 안내한다.
     }
   }
 

--- a/src/renderer/src/hooks/use-users.ts
+++ b/src/renderer/src/hooks/use-users.ts
@@ -1,0 +1,21 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { useApiMutation, useApiQuery } from './use-api'
+
+/** 워크스페이스의 전체 사용자(멤버) 목록을 조회한다. */
+export function useUsers() {
+  return useApiQuery(queryKeys.users.all, IpcChannel.AUTH_LIST_USERS, undefined)
+}
+
+/** 멤버 생성/삭제 및 초대코드 생성 뮤테이션. 멤버 변경 성공 시 목록 캐시를 무효화한다. */
+export function useUserMutations() {
+  const queryClient = useQueryClient()
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.users.all })
+
+  const createMember = useApiMutation(IpcChannel.AUTH_CREATE_MEMBER, { onSuccess: invalidate })
+  const deleteUser = useApiMutation(IpcChannel.AUTH_DELETE_USER, { onSuccess: invalidate })
+  const generateInvite = useApiMutation(IpcChannel.INVITE_GENERATE)
+
+  return { createMember, deleteUser, generateInvite }
+}

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -27,5 +27,8 @@ export const queryKeys = {
   },
   integrations: {
     all: ['integrations'] as const
+  },
+  users: {
+    all: ['users'] as const
   }
 } as const


### PR DESCRIPTION
## 개요

데이터 패칭 통일 리팩토링 4번째입니다. MembersPage(멤버 목록/추가/삭제/초대코드)를 React Query로 이관합니다.

## 변경 사항

- `hooks/use-users.ts` 추가
  - `useUsers()` — 워크스페이스 사용자 목록 조회
  - `useUserMutations()` — `createMember` / `deleteUser`(성공 시 목록 무효화) / `generateInvite`
- `queryKeys.users` 추가
- MembersPage: 수동 `members/isLoading/isSubmitting` state + `loadMembers`/`useEffect` 제거
  - 목록은 `useApiQuery`, 추가/삭제는 `useApiMutation`(성공 시 캐시 무효화)
  - `isSubmitting`은 뮤테이션 `isPending`에서 파생

## 영향

동작 동일. "fetch in useEffect" + 수동 에러 분기 제거(invokeApi 일관 토스트). 폼/다이얼로그 state는 그대로 유지.

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_