### PR TITLE
refactor: ProjectDetailPage 데이터 패칭을 useQuery/useMutation으로 이관

### DIFF
--- a/src/renderer/src/components/pages/ProjectDetailPage/ProjectDetailPage.tsx
+++ b/src/renderer/src/components/pages/ProjectDetailPage/ProjectDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useParams } from '@tanstack/react-router'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Button } from '@/atoms/Button'
 import { Input } from '@/atoms/Input'
-import type { Issue, Milestone, Project } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
+import { useMilestoneMutations, useMilestones } from '@/hooks/use-milestones'
+import { useProjectDetail, useProjectIssueRecords } from '@/hooks/use-project-detail'
 import { formatKoreanDate } from '@/lib/formatDate'
 import { PRIORITY_CLASS, PRIORITY_LABEL, STATUS_CLASS, STATUS_LABEL } from '@/lib/statusTokens'
 import { cn } from '@/lib/utils'
@@ -29,30 +29,13 @@ function toIssueState(status: string | null | undefined): IssueState {
 
 export default function ProjectDetailPage() {
   const { projectId } = useParams({ strict: false })
-  const [project, setProject] = useState<Project | null>(null)
-  const [issues, setIssues] = useState<Issue[]>([])
-  const [milestones, setMilestones] = useState<Milestone[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const { data: project, isLoading } = useProjectDetail(projectId)
+  const { data: issues = [] } = useProjectIssueRecords(projectId)
+  const { data: milestones = [] } = useMilestones(projectId)
+  const { create: createMilestone } = useMilestoneMutations(projectId)
   const [showMilestoneForm, setShowMilestoneForm] = useState(false)
   const [milestoneTitle, setMilestoneTitle] = useState('')
   const [milestoneDueDate, setMilestoneDueDate] = useState('')
-
-  useEffect(() => {
-    if (!projectId) return
-    const load = async () => {
-      setIsLoading(true)
-      const [projectResult, issuesResult, milestonesResult] = await Promise.all([
-        window.callApi(IpcChannel.PROJECT_GET, { projectId }),
-        window.callApi(IpcChannel.ISSUE_LIST, { projectId }),
-        window.callApi(IpcChannel.MILESTONE_LIST, { projectId })
-      ])
-      if (projectResult.data) setProject(projectResult.data as Project)
-      if (Array.isArray(issuesResult.data)) setIssues(issuesResult.data as Issue[])
-      if (Array.isArray(milestonesResult.data)) setMilestones(milestonesResult.data as Milestone[])
-      setIsLoading(false)
-    }
-    load()
-  }, [projectId])
 
   if (isLoading)
     return (
@@ -75,17 +58,18 @@ export default function ProjectDetailPage() {
   const blockedIssues = issues.filter((i) => i.issue_status === 'blocked').length
 
   const handleCreateMilestone = async () => {
-    if (!milestoneTitle.trim()) return
-    const result = await window.callApi(IpcChannel.MILESTONE_CREATE, {
-      projectId: projectId!,
-      milestoneTitle: milestoneTitle.trim(),
-      milestoneDueDate: milestoneDueDate || undefined
-    })
-    if (result.data) {
-      setMilestones((prev) => [...prev, result.data as Milestone])
+    if (!milestoneTitle.trim() || !projectId) return
+    try {
+      await createMilestone.mutateAsync({
+        projectId,
+        milestoneTitle: milestoneTitle.trim(),
+        milestoneDueDate: milestoneDueDate || undefined
+      })
       setMilestoneTitle('')
       setMilestoneDueDate('')
       setShowMilestoneForm(false)
+    } catch {
+      // 에러는 invokeApi가 토스트로 안내한다.
     }
   }
 

--- a/src/renderer/src/hooks/use-milestones.ts
+++ b/src/renderer/src/hooks/use-milestones.ts
@@ -1,0 +1,25 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { useApiMutation, useApiQuery } from './use-api'
+
+/** 프로젝트의 마일스톤 목록을 조회한다. */
+export function useMilestones(projectId: string | undefined) {
+  return useApiQuery(
+    queryKeys.milestones.byProject(projectId ?? ''),
+    IpcChannel.MILESTONE_LIST,
+    { projectId: projectId ?? '' },
+    { enabled: !!projectId }
+  )
+}
+
+/** 마일스톤 생성 뮤테이션. 성공 시 해당 프로젝트의 마일스톤 캐시를 무효화한다. */
+export function useMilestoneMutations(projectId: string | undefined) {
+  const queryClient = useQueryClient()
+
+  const create = useApiMutation(IpcChannel.MILESTONE_CREATE, {
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.milestones.byProject(projectId ?? '') })
+  })
+
+  return { create }
+}

--- a/src/renderer/src/hooks/use-project-detail.ts
+++ b/src/renderer/src/hooks/use-project-detail.ts
@@ -1,0 +1,23 @@
+import { IpcChannel } from '@/interface/CoreInterface'
+import { queryKeys } from '@/lib/queryKeys'
+import { useApiQuery } from './use-api'
+
+/** 단일 프로젝트 상세를 조회한다(React Query). 스토어 기반 useProject와 별개. */
+export function useProjectDetail(projectId: string | undefined) {
+  return useApiQuery(
+    queryKeys.projects.detail(projectId ?? ''),
+    IpcChannel.PROJECT_GET,
+    { projectId: projectId ?? '' },
+    { enabled: !!projectId }
+  )
+}
+
+/** 프로젝트의 이슈 원본 레코드 목록(매핑 없이). useProjectIssues와 캐시를 공유한다. */
+export function useProjectIssueRecords(projectId: string | undefined) {
+  return useApiQuery(
+    queryKeys.issues.byProject(projectId ?? ''),
+    IpcChannel.ISSUE_LIST,
+    { projectId: projectId ?? '' },
+    { enabled: !!projectId }
+  )
+}

--- a/src/renderer/src/lib/queryKeys.ts
+++ b/src/renderer/src/lib/queryKeys.ts
@@ -11,7 +11,11 @@ export const queryKeys = {
   },
   projects: {
     all: ['projects'] as const,
+    detail: (projectId: string) => ['projects', projectId] as const,
     members: (projectId: string) => ['projects', projectId, 'members'] as const
+  },
+  milestones: {
+    byProject: (projectId: string) => ['milestones', 'project', projectId] as const
   },
   activity: {
     byEntity: (entityType: string, entityId: string) => ['activity', entityType, entityId] as const


### PR DESCRIPTION
## 개요

데이터 패칭 통일 리팩토링 5번째입니다. ProjectDetailPage(프로젝트/이슈/마일스톤 + 마일스톤 생성)를 React Query로 이관합니다.

## 변경 사항

- 도메인 훅 추가
  - `use-project-detail.ts`: `useProjectDetail(projectId)`, `useProjectIssueRecords(projectId)`(원본 레코드, `useProjectIssues`와 캐시 공유)
  - `use-milestones.ts`: `useMilestones(projectId)`, `useMilestoneMutations(projectId)`(생성, 성공 시 캐시 무효화)
- `queryKeys.projects.detail`, `queryKeys.milestones` 추가
- ProjectDetailPage: `Promise.all` 수동 패칭 + `useState`/`useEffect` 제거 → 쿼리 훅 3개. 마일스톤 생성은 뮤테이션
- 기존 스토어 기반 `useProject`(Zustand)와 이름 충돌 피하려 `useProjectDetail`로 명명

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_