### PR TITLE
refactor: 안전하게 좁힐 수 있는 any 타입 제거

### DIFF
--- a/src/renderer/src/components/molecules/issues/IssueColumns/IssueColumns.tsx
+++ b/src/renderer/src/components/molecules/issues/IssueColumns/IssueColumns.tsx
@@ -13,7 +13,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { createActionsColumn, createColumn } from '@/atoms/TableColumnDef'
 import { formatKoreanDate } from '@/lib/formatDate'
 import { PRIORITY_CLASS, PRIORITY_LABEL } from '@/lib/statusTokens'
-import { IssueBadge } from '@/molecules/issues/IssueBadge'
+import { IssueBadge, type IssueState } from '@/molecules/issues/IssueBadge'
 import { UserAvatar } from '@/molecules/users/UserAvatar'
 import type { Issue, IssuePriority, IssueTableMeta } from '@/types/issue'
 import i18n from '../../../../locales'
@@ -185,10 +185,10 @@ export const statusColumn = createColumn<Issue>({
   accessorKey: 'state',
   enableSorting: false,
   cell: ({ row }) => {
-    const state = row.getValue('state')
+    const state = row.getValue('state') as IssueState
     return (
       <div className='text-left'>
-        <IssueBadge state={state as any} size='sm' />
+        <IssueBadge state={state} size='sm' />
       </div>
     )
   }

--- a/src/renderer/src/components/organisms/dialogs/IssueDetailsDialog/IssueDetailsDialog.tsx
+++ b/src/renderer/src/components/organisms/dialogs/IssueDetailsDialog/IssueDetailsDialog.tsx
@@ -60,8 +60,8 @@ export function IssueDetailsDialog({
     }
   }, [issue, defaultIssue])
 
-  // 입력 필드 변경 핸들러
-  const handleChange = (field: keyof Issue, value: any) => {
+  // 입력 필드 변경 핸들러 — 필드 키에 맞는 값 타입만 허용한다
+  const handleChange = <K extends keyof Issue>(field: K, value: Issue[K]) => {
     setFormData((prev) => ({
       ...prev,
       [field]: value


### PR DESCRIPTION
## 개요

React 19 베스트 프랙티스/유지보수 리팩토링의 타입 안전성 트랙입니다. 안전하게 좁힐 수 있는 `any`만 제거합니다(데이터 패칭 PR과 독립, `queryKeys` 미변경).

## 변경 사항

- `IssueDetailsDialog.handleChange`: `(field: keyof Issue, value: any)` → 제너릭 `<K extends keyof Issue>(field: K, value: Issue[K])`로 전환. 필드 키와 값 타입의 정합성을 컴파일 타임에 보장(모든 호출부는 이미 적절히 캐스팅하고 있어 무변경)
- `IssueColumns`: `IssueBadge state={state as any}` → `as IssueState`로 정밀화

## 보존한 any (실용적 이유)

- `AppSidebar`의 `<Link to={item.href as any}>` — TanStack Router typed-route 리터럴 유니온 제약 때문에 런타임 안전한 우회
- recharts `formatter`/`tooltipFormatter`의 `any` — 라이브러리 시그니처
- TanStack Table 제너릭(`TableColumnDef`, `useTable`)의 `any` — 제너릭 추론 깨짐 방지

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_