### PR TITLE
refactor: ProjectSettingsPage 데이터 패칭을 useQuery/useMutation으로 이관

### DIFF
--- a/src/renderer/src/components/pages/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/src/renderer/src/components/pages/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -1,88 +1,50 @@
 import { useNavigate, useParams } from '@tanstack/react-router'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/atoms/Button'
 import { Input } from '@/components/atoms/Input'
 import { Label } from '@/components/atoms/Label'
 import { Textarea } from '@/components/atoms/Textarea'
 import { useAuth } from '@/hooks/use-auth'
+import { useProjectDetail, useProjectMutations } from '@/hooks/use-project-detail'
 import type { Project } from '@/interface/CoreInterface'
-import { IpcChannel } from '@/interface/CoreInterface'
 
-export default function ProjectSettingsPage() {
-  const { projectId } = useParams({ strict: false })
+// 폼은 로드된 프로젝트를 초기값으로 받아 마운트 시 1회 초기화한다(useEffect로 서버→폼 동기화하지 않음).
+function ProjectSettingsForm({ project }: { project: Project }) {
   const { user } = useAuth()
   const navigate = useNavigate()
-  const [project, setProject] = useState<Project | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isSaving, setIsSaving] = useState(false)
+  const { update, remove } = useProjectMutations(project.project_id)
 
-  // Editable fields
-  const [name, setName] = useState('')
-  const [desc, setDesc] = useState('')
+  const [name, setName] = useState(project.project_name)
+  const [desc, setDesc] = useState(project.project_desc || '')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
-  useEffect(() => {
-    if (!projectId) return
-    const load = async () => {
-      setIsLoading(true)
-      const result = await window.callApi(IpcChannel.PROJECT_GET, { projectId })
-      const data = result.data as Project | null
-      if (data) {
-        setProject(data)
-        setName(data.project_name)
-        setDesc(data.project_desc || '')
-      }
-      setIsLoading(false)
-    }
-    load()
-  }, [projectId])
-
   const handleSave = async () => {
-    if (!project || !user) return
-    setIsSaving(true)
-    const result = await window.callApi(IpcChannel.PROJECT_UPDATE, {
-      projectId: project.project_id,
-      userId: user.user_id,
-      projectName: name,
-      projectKey: project.project_key,
-      projectDesc: desc
-    })
-    if (result.error) {
-      toast.error(`Failed: ${result.error.message}`)
-    } else {
+    if (!user) return
+    try {
+      await update.mutateAsync({
+        projectId: project.project_id,
+        userId: user.user_id,
+        projectName: name,
+        projectKey: project.project_key,
+        projectDesc: desc
+      })
       toast.success('Project updated')
-      setProject(result.data as Project)
+    } catch {
+      // 에러는 invokeApi가 토스트로 안내한다.
     }
-    setIsSaving(false)
   }
 
   const handleDelete = async () => {
-    if (!project || !user) return
-    const result = await window.callApi(IpcChannel.PROJECT_DELETE, {
-      projectId: project.project_id,
-      userId: user.user_id
-    })
-    if (result.error) {
-      toast.error(`Failed: ${result.error.message}`)
-    } else {
+    if (!user) return
+    try {
+      await remove.mutateAsync({ projectId: project.project_id, userId: user.user_id })
       toast.success('Project deleted')
       navigate({ to: '/projects' })
+    } catch {
+      // 에러는 invokeApi가 토스트로 안내한다.
     }
   }
-
-  if (isLoading)
-    return (
-      <div className='p-6'>
-        <p className='text-muted-foreground'>Loading...</p>
-      </div>
-    )
-  if (!project)
-    return (
-      <div className='p-6'>
-        <p className='text-muted-foreground'>Project not found</p>
-      </div>
-    )
 
   return (
     <div className='p-6 h-full overflow-auto max-w-2xl'>
@@ -109,8 +71,8 @@ export default function ProjectSettingsPage() {
             className='min-h-[100px]'
           />
         </div>
-        <Button onClick={handleSave} disabled={isSaving}>
-          {isSaving ? 'Saving...' : 'Save Changes'}
+        <Button onClick={handleSave} disabled={update.isPending}>
+          {update.isPending ? 'Saving...' : 'Save Changes'}
         </Button>
       </div>
 
@@ -124,7 +86,7 @@ export default function ProjectSettingsPage() {
         {showDeleteConfirm ? (
           <div className='flex items-center gap-2'>
             <p className='text-sm text-destructive font-medium'>Are you sure?</p>
-            <Button variant='destructive' size='sm' onClick={handleDelete}>
+            <Button variant='destructive' size='sm' onClick={handleDelete} disabled={remove.isPending}>
               Yes, delete
             </Button>
             <Button variant='outline' size='sm' onClick={() => setShowDeleteConfirm(false)}>
@@ -139,4 +101,24 @@ export default function ProjectSettingsPage() {
       </div>
     </div>
   )
+}
+
+export default function ProjectSettingsPage() {
+  const { projectId } = useParams({ strict: false })
+  const { data: project, isLoading } = useProjectDetail(projectId)
+
+  if (isLoading)
+    return (
+      <div className='p-6'>
+        <p className='text-muted-foreground'>Loading...</p>
+      </div>
+    )
+  if (!project)
+    return (
+      <div className='p-6'>
+        <p className='text-muted-foreground'>Project not found</p>
+      </div>
+    )
+
+  return <ProjectSettingsForm project={project} />
 }

--- a/src/renderer/src/hooks/use-project-detail.ts
+++ b/src/renderer/src/hooks/use-project-detail.ts
@@ -1,6 +1,7 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { IpcChannel } from '@/interface/CoreInterface'
 import { queryKeys } from '@/lib/queryKeys'
-import { useApiQuery } from './use-api'
+import { useApiMutation, useApiQuery } from './use-api'
 
 /** 단일 프로젝트 상세를 조회한다(React Query). 스토어 기반 useProject와 별개. */
 export function useProjectDetail(projectId: string | undefined) {
@@ -20,4 +21,18 @@ export function useProjectIssueRecords(projectId: string | undefined) {
     { projectId: projectId ?? '' },
     { enabled: !!projectId }
   )
+}
+
+/** 프로젝트 수정/삭제 뮤테이션. 성공 시 상세·목록 캐시를 무효화한다. */
+export function useProjectMutations(projectId: string | undefined) {
+  const queryClient = useQueryClient()
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId ?? '') })
+    queryClient.invalidateQueries({ queryKey: queryKeys.projects.all })
+  }
+
+  const update = useApiMutation(IpcChannel.PROJECT_UPDATE, { onSuccess: invalidate })
+  const remove = useApiMutation(IpcChannel.PROJECT_DELETE, { onSuccess: invalidate })
+
+  return { update, remove }
 }


### PR DESCRIPTION
## 개요

데이터 패칭 통일 리팩토링 6번째입니다. ProjectSettingsPage(프로젝트 수정/삭제)를 React Query로 이관합니다. 폼 시딩은 useEffect 없이 처리합니다.

## 변경 사항

- `use-project-detail.ts`에 `useProjectMutations(projectId)` 추가 — `update`/`remove`, 성공 시 `projects.detail`·`projects.all` 캐시 무효화
- ProjectSettingsPage 구조 변경:
  - 부모: `useProjectDetail()`로 조회 + 로딩 게이트
  - 자식 `ProjectSettingsForm`: 로드된 프로젝트를 **초기값**으로 받아 마운트 시 1회 `useState` 초기화 → "서버→폼 동기화" useEffect 제거
  - 저장/삭제는 `useApiMutation` + `isPending`

## 영향

동작 동일. 수동 `isLoading/isSaving` state + fetch-effect 제거. 기존 `useProjectDetail` 재사용(중복 패칭 없음).

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_