### PR TITLE
refactor: 불필요한 useEffect 제거 (파생 state는 렌더 중 계산)

### DIFF
--- a/src/renderer/src/components/organisms/dialogs/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/src/renderer/src/components/organisms/dialogs/CreateProjectDialog/CreateProjectDialog.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@tanstack/react-router'
 import { AlertCircle, CheckCircle2, Info } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Button } from '@/atoms/Button'
@@ -26,27 +26,18 @@ export function CreateProjectDialog({ open, onOpenChange, userId }: CreateProjec
   const [projectName, setProjectName] = useState('')
   const [projectKey, setProjectKey] = useState('')
   const [projectDesc, setProjectDesc] = useState('')
-  const [keyValid, setKeyValid] = useState<boolean | null>(null)
+
+  // 프로젝트 키 유효성은 입력값에서 렌더 중 파생한다(useState+useEffect 불필요)
+  const keyValid = projectKey ? /^[A-Z]{3,5}$/.test(projectKey) : null
 
   // hook
   const { projects, setProjects } = useProject()
   const navigate = useNavigate()
 
-  // Project key validation
-  useEffect(() => {
-    if (!projectKey) {
-      setKeyValid(null)
-      return
-    }
-
-    setKeyValid(/^[A-Z]{3,5}$/.test(projectKey))
-  }, [projectKey])
-
   const handleClear = () => {
     setProjectName('')
     setProjectKey('')
     setProjectDesc('')
-    setKeyValid(null)
     onOpenChange(false)
   }
 


### PR DESCRIPTION
## 개요

"불필요한 useEffect 정리" 트랙입니다. 다른 state에서 파생 가능한 값을 effect+state로 동기화하던 부분을 렌더 중 파생으로 단순화합니다(React 공식 "You Might Not Need an Effect").

## 변경 사항

- **CreateProjectDialog**: `projectKey` → `keyValid` 동기화 `useEffect` + `keyValid` `useState` 제거
  - `const keyValid = projectKey ? /^[A-Z]{3,5}$/.test(projectKey) : null`로 렌더 중 파생
  - `handleClear`의 `setKeyValid(null)`도 불필요해져 제거(키 초기화 시 자동 파생)

## 영향

동작 동일. 렌더-동기화 1프레임 지연 가능성 제거(파생값은 즉시 정확).

## 검증

- `pnpm typecheck` ✅ / `pnpm lint:ci` ✅ / `pnpm test` ✅ (135) / `pnpm build` ✅

> 참고: CreateIssueDialog는 이미 `useProjectMembers`(React Query)를 사용 중이며, 남은 effect(닫힐 때 폼 리셋)·다른 폼 시딩 effect는 동작 의존도가 있어 별도 검토합니다.

https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ1yRZnM3Ce4hsSBqyM2Hj)_