### PR TITLE
hotfix(brand): generate-icons.cjs 포맷으로 main CI(lint) 복구

### DIFF
--- a/assets/brand/generate-icons.cjs
+++ b/assets/brand/generate-icons.cjs
@@ -19,7 +19,7 @@ const SRC = {
   128: 'icon_128',
   256: 'icon_256',
   512: 'icon_512',
-  1024: 'icon_1024',
+  1024: 'icon_1024'
 }
 const png = (s) => read(SRC[s])
 


### PR DESCRIPTION
## 문제
#87 머지 후 **main의 CI(lint) 단계가 실패**하고 있습니다.
`assets/brand/generate-icons.cjs`의 포매팅이 biome 규칙과 어긋나 `biome check .`가 에러 1건으로 종료(exit 1)됩니다. (#87이 lint 수정 푸시 직전에 머지되어 미반영)

## 수정
- `generate-icons.cjs`에 biome 포맷 적용 (로직 변경 없음, 1줄)
- `pnpm exec biome check assets/brand/generate-icons.cjs` → 클린 확인

머지하면 main CI가 다시 그린이 됩니다. (이번엔 **CI 그린 확인 후** 머지 부탁드립니다 🙏)

🤖 Generated with [Claude Code](https://claude.com/claude-code)