### PR TITLE
docs(stories): 전체 스토리 문서화 + 세밀한 argTypes 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -23,7 +23,7 @@ const rendererAliases: Record<string, string> = {
 
 const config: StorybookConfig = {
   stories: ['../src/renderer/src/**/*.stories.@(ts|tsx)'],
-  addons: [],
+  addons: ['@storybook/addon-docs'],
   framework: { name: '@storybook/react-vite', options: {} },
   viteFinal: async (viteConfig) => {
     viteConfig.resolve = viteConfig.resolve ?? {}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,6 +2,8 @@ import type { Preview } from '@storybook/react'
 import '../src/renderer/src/index.css'
 
 const preview: Preview = {
+  // 모든 스토리에 autodocs Docs 페이지를 자동 생성한다(컴포넌트 설명 + argTypes 표).
+  tags: ['autodocs'],
   parameters: {
     controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } }
   }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/shared-types": "^7.11.1",
     "@electron-toolkit/tsconfig": "^1.0.1",
+    "@storybook/addon-docs": "^10.4.4",
     "@storybook/react": "^10.4.4",
     "@storybook/react-vite": "^10.4.4",
     "@tanstack/react-query-devtools": "^5.100.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@electron-toolkit/tsconfig':
         specifier: ^1.0.1
         version: 1.0.1(@types/node@22.15.3)
+      '@storybook/addon-docs':
+        specifier: ^10.4.4
+        version: 10.4.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(esbuild@0.27.4)(rollup@4.40.1)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))(webpack@5.105.4(@swc/core@1.11.24)(esbuild@0.27.4))
       '@storybook/react':
         specifier: ^10.4.4
         version: 10.4.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
@@ -1448,6 +1451,12 @@ packages:
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
@@ -2349,6 +2358,15 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/addon-docs@10.4.4':
+    resolution: {integrity: sha512-yPshCvtmQTq52T2sXuXgjy7B/QbhA/WIZxLYggptNjBL8BJMvbOfp9bAfCKh7+KpRWGqDZ6Y6tWL1Q48Wj3vtw==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@storybook/builder-vite@10.4.4':
     resolution: {integrity: sha512-VyuZ4mEvhhVXjJa1qXMWKH8ohnas0rgEuJDf6u4aJ54XeENFebPUEAHde1Qo2PflJ4rUdVdXieOZzKbYwP5RAQ==}
     peerDependencies:
@@ -2956,6 +2974,9 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
@@ -7275,6 +7296,12 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@mdx-js/react@3.1.1(@types/react@19.1.2)(react@19.1.0)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.1.2
+      react: 19.1.0
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -8039,6 +8066,25 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/addon-docs@10.4.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(esbuild@0.27.4)(rollup@4.40.1)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))(webpack@5.105.4(@swc/core@1.11.24)(esbuild@0.27.4))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@storybook/csf-plugin': 10.4.4(esbuild@0.27.4)(rollup@4.40.1)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))(webpack@5.105.4(@swc/core@1.11.24)(esbuild@0.27.4))
+      '@storybook/icons': 2.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@storybook/react-dom-shim': 10.4.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      storybook: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@types/react': 19.1.2
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/builder-vite@10.4.4(esbuild@0.27.4)(rollup@4.40.1)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))(webpack@5.105.4(@swc/core@1.11.24)(esbuild@0.27.4))':
     dependencies:
       '@storybook/csf-plugin': 10.4.4(esbuild@0.27.4)(rollup@4.40.1)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.1.2)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))(webpack@5.105.4(@swc/core@1.11.24)(esbuild@0.27.4))
@@ -8635,6 +8681,8 @@ snapshots:
       '@types/mdurl': 2.0.0
 
   '@types/mdurl@2.0.0': {}
+
+  '@types/mdx@2.0.14': {}
 
   '@types/mute-stream@0.0.4':
     dependencies:

--- a/src/renderer/src/components/atoms/Avatar/Avatar.stories.tsx
+++ b/src/renderer/src/components/atoms/Avatar/Avatar.stories.tsx
@@ -1,13 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Avatar, AvatarFallback, AvatarImage } from './Avatar'
 
+/**
+ * 사용자/멤버를 표현하는 원형 아바타. Radix Avatar 위에 Hydra 토큰을 입혔다.
+ *
+ * - `Avatar`는 `size-8` 원형 컨테이너이며 `className`으로 크기를 덮어쓴다.
+ * - `AvatarImage`(src)가 로드되면 이미지를, 실패/미지정이면 `AvatarFallback`(이니셜)을 그라데이션 배경으로 보여준다.
+ * - 합성 컴포넌트라 `Avatar` 루트에 노출할 의미 있는 prop은 `className`뿐이다.
+ */
 const meta: Meta<typeof Avatar> = {
   title: 'Atoms/Avatar',
-  component: Avatar
+  component: Avatar,
+  argTypes: {
+    className: {
+      description: '컨테이너 크기/모양 오버라이드. 기본은 size-8 원형이며 size-* 유틸로 키우거나 줄인다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Avatar>
 
+/** 이미지 src가 정상 로드된 경우. 이미지가 fallback을 가린다. */
 export const WithImage: Story = {
   render: () => (
     <Avatar>
@@ -16,9 +31,21 @@ export const WithImage: Story = {
     </Avatar>
   )
 }
+
+/** 이미지가 없을 때 이니셜 fallback(그라데이션 배경)이 표시된다. */
 export const Fallback: Story = {
   render: () => (
     <Avatar>
+      <AvatarFallback>HY</AvatarFallback>
+    </Avatar>
+  )
+}
+
+/** className으로 크기를 키운 큰 아바타. 프로필 헤더 등에 사용한다. */
+export const Large: Story = {
+  render: () => (
+    <Avatar className='size-16'>
+      <AvatarImage src='https://avatars.githubusercontent.com/u/167082674?v=4' alt='avatar' />
       <AvatarFallback>HY</AvatarFallback>
     </Avatar>
   )

--- a/src/renderer/src/components/atoms/Badge/Badge.stories.tsx
+++ b/src/renderer/src/components/atoms/Badge/Badge.stories.tsx
@@ -1,13 +1,68 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Badge } from './Badge'
 
+/**
+ * 상태/라벨/카운트 등 짧은 메타 정보를 표시하는 알약형 태그. CVA로 variant·size·colorScheme 3축을 조합한다.
+ *
+ * - `variant`는 채움 방식(진한 채움/틴트/보더 등), `colorScheme`은 색 계열, `size`는 패딩/글자 크기를 정한다.
+ * - 모든 조합은 AA 대비를 지키도록 동계열 텍스트 색을 사용한다(solid도 흰 전경 대신 어두운 동계열 텍스트).
+ * - 선택적 `icon`을 children 앞에 렌더한다.
+ */
 const meta: Meta<typeof Badge> = {
   title: 'Atoms/Badge',
   component: Badge,
-  args: { children: 'Badge' }
+  args: { children: 'Badge' },
+  argTypes: {
+    variant: {
+      description: '채움 스타일. solid=진한 동계열 채움, subtle/surface=틴트 배경, outline=보더, plain=배경 없음.',
+      control: 'select',
+      options: ['solid', 'subtle', 'outline', 'surface', 'plain'],
+      table: {
+        type: { summary: 'solid | subtle | outline | surface | plain' },
+        defaultValue: { summary: 'subtle' }
+      }
+    },
+    size: {
+      description: '패딩과 글자 크기. xs→lg 순으로 커진다.',
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg'],
+      table: { type: { summary: 'xs | sm | md | lg' }, defaultValue: { summary: 'sm' } }
+    },
+    colorScheme: {
+      description: '색 계열. variant와 조합되어 배경/텍스트/보더 색을 결정한다.',
+      control: 'select',
+      options: ['gray', 'red', 'orange', 'yellow', 'green', 'teal', 'blue', 'cyan', 'purple', 'pink'],
+      table: {
+        type: { summary: 'gray | red | orange | yellow | green | teal | blue | cyan | purple | pink' },
+        defaultValue: { summary: 'gray' }
+      }
+    },
+    children: {
+      description: '뱃지에 표시할 텍스트/노드.',
+      control: 'text',
+      table: { type: { summary: 'ReactNode' } }
+    },
+    icon: {
+      description: 'children 앞에 렌더할 선택적 아이콘 노드.',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Badge>
 
+/** 기본값(subtle · sm · gray). 가장 흔한 메타 라벨용. */
 export const Default: Story = {}
+
+/** 보더만 그리는 outline variant. */
 export const Outline: Story = { args: { variant: 'outline' } }
+
+/** 진한 동계열 채움(solid)에 색 계열을 적용한 예. */
+export const Solid: Story = { args: { variant: 'solid', colorScheme: 'green', children: 'Open' } }
+
+/** colorScheme로 색 계열을 바꾼 subtle 뱃지. 상태 색 구분에 사용한다. */
+export const ColorScheme: Story = { args: { colorScheme: 'red', children: 'Blocked' } }
+
+/** size를 키운 큰 뱃지. */
+export const Large: Story = { args: { size: 'lg' } }

--- a/src/renderer/src/components/atoms/Button/Button.stories.tsx
+++ b/src/renderer/src/components/atoms/Button/Button.stories.tsx
@@ -1,19 +1,90 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { ArrowRight } from 'lucide-react'
 import { Button } from './Button'
 
+/**
+ * 모든 클릭 액션의 기본 단위. shadcn/ui 버튼을 Hydra 토큰(gradient-primary, glow)으로 확장했다.
+ *
+ * - `variant`로 시각적 강조 수준을, `size`로 높이/패딩을 제어한다.
+ * - `loading`이 true면 스피너 + "Please wait" 문구를 보여주고 자동으로 비활성화된다.
+ * - `asChild`를 켜면 `<button>` 대신 자식 엘리먼트(예: `<a>`)에 스타일을 위임한다(Radix Slot).
+ */
 const meta: Meta<typeof Button> = {
   title: 'Atoms/Button',
   component: Button,
-  args: { children: 'Button' }
+  args: { children: 'Button' },
+  argTypes: {
+    variant: {
+      description:
+        '시각적 강조 수준. 기본(gradient) → outline/secondary/ghost(보조) → destructive(파괴) → link(텍스트)',
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+      table: {
+        type: { summary: 'default | destructive | outline | secondary | ghost | link' },
+        defaultValue: { summary: 'default' }
+      }
+    },
+    size: {
+      description: '버튼 높이/패딩 프리셋. `icon`은 정사각형(아이콘 전용)',
+      control: 'inline-radio',
+      options: ['default', 'sm', 'lg', 'icon'],
+      table: { type: { summary: 'default | sm | lg | icon' }, defaultValue: { summary: 'default' } }
+    },
+    loading: {
+      description: 'true면 스피너와 "Please wait"를 표시하고 클릭을 막는다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    asChild: {
+      description: '렌더 엘리먼트를 자식으로 위임(Radix Slot). 링크 등에 버튼 스타일을 입힐 때 사용.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    disabled: {
+      description: '상호작용을 막고 50% 투명도로 표시한다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } }
+    },
+    children: { description: '버튼 라벨/내용', control: 'text', table: { type: { summary: 'ReactNode' } } }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Button>
 
+/** 기본 그라데이션 버튼. 화면당 1개의 주요 액션에만 사용한다. */
 export const Default: Story = {}
+
+/** 보조 액션용 — 테두리 + 배경 강조. */
 export const Secondary: Story = { args: { variant: 'secondary' } }
-export const Destructive: Story = { args: { variant: 'destructive' } }
+
+/** 삭제·취소 등 되돌리기 어려운 파괴적 액션. */
+export const Destructive: Story = { args: { variant: 'destructive', children: 'Delete' } }
+
+/** 중립적인 테두리 버튼. */
 export const Outline: Story = { args: { variant: 'outline' } }
+
+/** 배경 없이 hover 시에만 강조되는 최소 강조 버튼. */
 export const Ghost: Story = { args: { variant: 'ghost' } }
-export const Link: Story = { args: { variant: 'link' } }
+
+/** 인라인 텍스트 링크처럼 보이는 버튼. */
+export const Link: Story = { args: { variant: 'link', children: 'Learn more' } }
+
+/** 좁은 영역(툴바, 테이블 행)용 작은 버튼. */
 export const Small: Story = { args: { size: 'sm' } }
+
+/** 강조가 필요한 폼 제출 등에 쓰는 큰 버튼. */
 export const Large: Story = { args: { size: 'lg' } }
+
+/** 비동기 처리 중 상태 — 클릭이 자동으로 막힌다. */
+export const Loading: Story = { args: { loading: true } }
+
+/** 라벨과 함께 아이콘을 배치한 예시. */
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        Continue <ArrowRight />
+      </>
+    )
+  }
+}

--- a/src/renderer/src/components/atoms/Card/Card.stories.tsx
+++ b/src/renderer/src/components/atoms/Card/Card.stories.tsx
@@ -1,13 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './Card'
+import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './Card'
 
+/**
+ * 콘텐츠를 묶어 시각적으로 구획하는 컨테이너. 둥근 모서리 + 보더 + `shadow-card`를 가진다.
+ *
+ * - 합성 컴포넌트 묶음이다: `CardHeader`(CardTitle/CardDescription/CardAction) · `CardContent` · `CardFooter`.
+ * - `CardHeader`는 컨테이너 쿼리 그리드라 `CardAction`을 두면 우측 상단에 액션이 정렬된다.
+ * - 모든 파트는 div 기반이라 의미 있는 prop은 `className`과 표준 div 속성뿐이다.
+ */
 const meta: Meta<typeof Card> = {
   title: 'Atoms/Card',
-  component: Card
+  component: Card,
+  argTypes: {
+    className: {
+      description: '카드 컨테이너의 폭/여백 등 레이아웃 오버라이드.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Card>
 
+/** 헤더·본문·푸터를 모두 갖춘 기본 카드. */
 export const Default: Story = {
   render: () => (
     <Card className='w-80'>
@@ -17,6 +32,24 @@ export const Default: Story = {
       </CardHeader>
       <CardContent>카드 본문 영역입니다.</CardContent>
       <CardFooter>푸터</CardFooter>
+    </Card>
+  )
+}
+
+/** CardAction을 헤더에 배치해 우측 상단 액션을 표시한 예. */
+export const WithAction: Story = {
+  render: () => (
+    <Card className='w-80'>
+      <CardHeader>
+        <CardTitle>프로젝트</CardTitle>
+        <CardDescription>이슈 12건 · 멤버 3명</CardDescription>
+        <CardAction>
+          <button type='button' className='rounded border px-2 py-1 text-xs'>
+            설정
+          </button>
+        </CardAction>
+      </CardHeader>
+      <CardContent>헤더 우측에 액션 버튼이 정렬된다.</CardContent>
     </Card>
   )
 }

--- a/src/renderer/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/renderer/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -1,13 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Checkbox } from './Checkbox'
 
+/**
+ * 불리언 선택을 위한 체크박스. Radix Checkbox 기반이라 controlled/uncontrolled 모두 지원한다.
+ *
+ * - 체크 상태에서 `bg-primary` 배경 + 체크 아이콘을 표시한다.
+ * - `checked`/`onCheckedChange`로 제어하거나 `defaultChecked`로 비제어 사용한다.
+ * - `aria-invalid`로 오류 링을, `disabled`로 비활성 상태를 표현한다.
+ */
 const meta: Meta<typeof Checkbox> = {
   title: 'Atoms/Checkbox',
-  component: Checkbox
+  component: Checkbox,
+  argTypes: {
+    checked: {
+      description: '제어형 체크 상태. true/false 또는 부분선택을 위한 "indeterminate".',
+      control: 'boolean',
+      table: { type: { summary: 'boolean | "indeterminate"' } }
+    },
+    defaultChecked: {
+      description: '비제어형 초기 체크 상태.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    disabled: {
+      description: 'true면 상호작용을 막고 투명도를 낮춘다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    onCheckedChange: {
+      description: '체크 상태 변경 콜백.',
+      control: false,
+      table: { category: 'Events', type: { summary: '(checked: boolean | "indeterminate") => void' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Checkbox>
 
+/** 비제어 기본 상태(미체크). */
 export const Default: Story = {}
+
+/** 초기부터 체크된 상태. */
 export const Checked: Story = { args: { defaultChecked: true } }
+
+/** 비활성화되어 클릭할 수 없는 상태. */
 export const Disabled: Story = { args: { disabled: true } }

--- a/src/renderer/src/components/atoms/Collapsible/Collapsible.stories.tsx
+++ b/src/renderer/src/components/atoms/Collapsible/Collapsible.stories.tsx
@@ -1,15 +1,58 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './Collapsible'
 
-const meta: Meta<typeof Collapsible> = { title: 'Atoms/Collapsible', component: Collapsible }
+/**
+ * 트리거를 눌러 영역을 펼치거나 접는 접이식 컨테이너. Radix Collapsible을 그대로 재노출한다.
+ *
+ * - `CollapsibleTrigger`를 클릭하면 `CollapsibleContent`가 토글된다.
+ * - `open`/`onOpenChange`로 제어하거나 `defaultOpen`으로 초기 상태만 지정한다.
+ * - 스타일이 없는 비스타일 프리미티브라 className으로 직접 꾸민다.
+ */
+const meta: Meta<typeof Collapsible> = {
+  title: 'Atoms/Collapsible',
+  component: Collapsible,
+  argTypes: {
+    open: {
+      description: '제어형 열림 상태.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } }
+    },
+    defaultOpen: {
+      description: '비제어형 초기 열림 상태.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    disabled: {
+      description: 'true면 토글을 막는다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    onOpenChange: {
+      description: '열림 상태 변경 콜백.',
+      control: false,
+      table: { category: 'Events', type: { summary: '(open: boolean) => void' } }
+    }
+  }
+}
 export default meta
 type Story = StoryObj<typeof Collapsible>
 
+/** 기본 접힘 상태에서 트리거로 토글한다. */
 export const Default: Story = {
   render: () => (
     <Collapsible className='w-80'>
       <CollapsibleTrigger className='rounded border px-3 py-1 text-sm'>토글</CollapsibleTrigger>
       <CollapsibleContent className='mt-2 text-sm text-muted-foreground'>접히는 영역의 내용입니다.</CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+/** defaultOpen으로 처음부터 펼쳐진 상태. */
+export const DefaultOpen: Story = {
+  render: () => (
+    <Collapsible defaultOpen className='w-80'>
+      <CollapsibleTrigger className='rounded border px-3 py-1 text-sm'>토글</CollapsibleTrigger>
+      <CollapsibleContent className='mt-2 text-sm text-muted-foreground'>처음부터 펼쳐져 있습니다.</CollapsibleContent>
     </Collapsible>
   )
 }

--- a/src/renderer/src/components/atoms/Input/Input.stories.tsx
+++ b/src/renderer/src/components/atoms/Input/Input.stories.tsx
@@ -1,14 +1,52 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Input } from './Input'
 
+/**
+ * 한 줄 텍스트 입력 필드. 네이티브 `<input>`을 Hydra 토큰으로 감쌌다.
+ *
+ * - 표준 input 속성(`type`, `placeholder`, `value`, `disabled` 등)을 그대로 받는다.
+ * - 포커스 시 ring, `aria-invalid`일 때 destructive 보더/ring을 보여준다.
+ * - file 입력 스타일링도 내장되어 있다.
+ */
 const meta: Meta<typeof Input> = {
   title: 'Atoms/Input',
   component: Input,
-  args: { placeholder: 'Type here…' }
+  args: { placeholder: 'Type here…' },
+  argTypes: {
+    type: {
+      description: '입력 타입. text/password/email/number/file 등 네이티브 input type.',
+      control: 'select',
+      options: ['text', 'password', 'email', 'number', 'search', 'tel', 'url', 'file'],
+      table: { type: { summary: 'HTMLInputTypeAttribute' }, defaultValue: { summary: 'text' } }
+    },
+    placeholder: {
+      description: '비어 있을 때 표시되는 안내 문구.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    disabled: {
+      description: 'true면 입력을 막고 투명도를 낮춘다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    'aria-invalid': {
+      description: 'true면 오류 상태(destructive 보더/ring)로 표시한다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Input>
 
+/** 기본 텍스트 입력. */
 export const Default: Story = {}
+
+/** 비활성화 상태. */
 export const Disabled: Story = { args: { disabled: true } }
+
+/** 비밀번호 입력 타입. */
 export const Password: Story = { args: { type: 'password', placeholder: '••••••••' } }
+
+/** aria-invalid로 오류 상태를 표현한 입력. */
+export const Invalid: Story = { args: { 'aria-invalid': true, placeholder: '잘못된 값' } }

--- a/src/renderer/src/components/atoms/Label/Label.stories.tsx
+++ b/src/renderer/src/components/atoms/Label/Label.stories.tsx
@@ -1,12 +1,42 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { Input } from '../Input'
 import { Label } from './Label'
 
+/**
+ * 폼 컨트롤에 붙는 접근성 라벨. Radix Label 기반이라 `htmlFor`로 입력과 연결된다.
+ *
+ * - 연결된 입력이 disabled면(peer/group-data) 라벨도 흐려지고 클릭이 막힌다.
+ * - `flex` + `gap-2`라 아이콘이나 보조 텍스트를 children으로 나란히 둘 수 있다.
+ */
 const meta: Meta<typeof Label> = {
   title: 'Atoms/Label',
   component: Label,
-  args: { children: 'Email' }
+  args: { children: 'Email' },
+  argTypes: {
+    htmlFor: {
+      description: '연결할 폼 컨트롤의 id. 클릭 시 해당 컨트롤에 포커스를 준다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    children: {
+      description: '라벨 텍스트/노드.',
+      control: 'text',
+      table: { type: { summary: 'ReactNode' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Label>
 
+/** 단독 라벨 텍스트. */
 export const Default: Story = {}
+
+/** htmlFor로 입력과 연결한 예. 라벨 클릭 시 입력에 포커스된다. */
+export const WithInput: Story = {
+  render: () => (
+    <div className='grid w-72 gap-2'>
+      <Label htmlFor='email'>Email</Label>
+      <Input id='email' placeholder='you@example.com' />
+    </div>
+  )
+}

--- a/src/renderer/src/components/atoms/Separator/Separator.stories.tsx
+++ b/src/renderer/src/components/atoms/Separator/Separator.stories.tsx
@@ -1,19 +1,50 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Separator } from './Separator'
 
+/**
+ * 콘텐츠를 시각적으로 가르는 1px 구분선. Radix Separator 기반이다.
+ *
+ * - `orientation`으로 가로/세로를 정한다(세로는 부모 높이를 채우므로 높이 있는 컨테이너 필요).
+ * - 기본 `decorative=true`라 스크린리더에 노출되지 않는다. 의미상 분리가 필요하면 `decorative=false`.
+ */
 const meta: Meta<typeof Separator> = {
   title: 'Atoms/Separator',
-  component: Separator
+  component: Separator,
+  argTypes: {
+    orientation: {
+      description: '구분선 방향. horizontal=가로 1px, vertical=세로 1px.',
+      control: 'inline-radio',
+      options: ['horizontal', 'vertical'],
+      table: { type: { summary: 'horizontal | vertical' }, defaultValue: { summary: 'horizontal' } }
+    },
+    decorative: {
+      description: 'true면 장식용으로 간주되어 접근성 트리에서 제외된다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Separator>
 
+/** 가로 구분선으로 위/아래 영역을 나눈다. */
 export const Horizontal: Story = {
   render: () => (
     <div className='w-64'>
       <p className='text-sm'>위</p>
       <Separator className='my-2' />
       <p className='text-sm'>아래</p>
+    </div>
+  )
+}
+
+/** 세로 구분선으로 좌/우 영역을 나눈다. 부모에 높이가 필요하다. */
+export const Vertical: Story = {
+  render: () => (
+    <div className='flex h-8 items-center'>
+      <span className='text-sm'>왼쪽</span>
+      <Separator orientation='vertical' className='mx-3' />
+      <span className='text-sm'>오른쪽</span>
     </div>
   )
 }

--- a/src/renderer/src/components/atoms/Skeleton/Skeleton.stories.tsx
+++ b/src/renderer/src/components/atoms/Skeleton/Skeleton.stories.tsx
@@ -1,19 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Skeleton } from './Skeleton'
 
+/**
+ * 로딩 중 콘텐츠 자리를 채우는 펄스 플레이스홀더. `animate-pulse`로 깜빡인다.
+ *
+ * - 크기/모양은 전적으로 `className`으로 지정한다(폭·높이·둥글기).
+ * - 실제 콘텐츠와 비슷한 형태로 배치해 레이아웃 점프를 줄인다.
+ */
 const meta: Meta<typeof Skeleton> = {
   title: 'Atoms/Skeleton',
   component: Skeleton,
-  parameters: { layout: 'centered' }
+  parameters: { layout: 'centered' },
+  argTypes: {
+    className: {
+      description: '스켈레톤 크기/모양을 정하는 유틸리티 클래스(h-*, w-*, rounded-* 등).',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 
 export default meta
 type Story = StoryObj<typeof Skeleton>
 
+/** 한 줄 텍스트 폭의 막대 스켈레톤. */
 export const Default: Story = {
   args: { className: 'h-6 w-40' }
 }
 
+/** 원형 스켈레톤. 아바타 자리에 사용한다. */
 export const Circle: Story = {
   args: { className: 'h-12 w-12 rounded-full' }
+}
+
+/** 여러 스켈레톤을 조합해 카드 로딩 형태를 표현한 예. */
+export const CardPlaceholder: Story = {
+  render: () => (
+    <div className='flex w-72 items-center gap-3'>
+      <Skeleton className='h-12 w-12 rounded-full' />
+      <div className='flex-1 space-y-2'>
+        <Skeleton className='h-4 w-32' />
+        <Skeleton className='h-3 w-20' />
+      </div>
+    </div>
+  )
 }

--- a/src/renderer/src/components/atoms/Tabs/Tabs.stories.tsx
+++ b/src/renderer/src/components/atoms/Tabs/Tabs.stories.tsx
@@ -1,10 +1,44 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './Tabs'
 
-const meta: Meta<typeof Tabs> = { title: 'Atoms/Tabs', component: Tabs }
+/**
+ * 같은 영역에서 여러 패널을 전환하는 탭. Radix Tabs 기반의 합성 컴포넌트다.
+ *
+ * - `TabsList`/`TabsTrigger`(value)로 탭 버튼을, `TabsContent`(value)로 패널을 정의한다.
+ * - 루트 `Tabs`는 `defaultValue`(비제어) 또는 `value`/`onValueChange`(제어)로 활성 탭을 정한다.
+ * - 활성 트리거는 `bg-background` + 그림자로 강조된다.
+ */
+const meta: Meta<typeof Tabs> = {
+  title: 'Atoms/Tabs',
+  component: Tabs,
+  argTypes: {
+    defaultValue: {
+      description: '비제어형 초기 활성 탭 value.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    value: {
+      description: '제어형 활성 탭 value.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    orientation: {
+      description: '탭 배치 방향. 키보드 내비게이션 축에 영향을 준다.',
+      control: 'inline-radio',
+      options: ['horizontal', 'vertical'],
+      table: { type: { summary: 'horizontal | vertical' }, defaultValue: { summary: 'horizontal' } }
+    },
+    onValueChange: {
+      description: '활성 탭 변경 콜백.',
+      control: false,
+      table: { category: 'Events', type: { summary: '(value: string) => void' } }
+    }
+  }
+}
 export default meta
 type Story = StoryObj<typeof Tabs>
 
+/** 두 개의 탭을 전환하는 기본 예시. */
 export const Default: Story = {
   render: () => (
     <Tabs defaultValue='overview' className='w-80'>
@@ -14,6 +48,24 @@ export const Default: Story = {
       </TabsList>
       <TabsContent value='overview'>개요 내용</TabsContent>
       <TabsContent value='activity'>활동 내용</TabsContent>
+    </Tabs>
+  )
+}
+
+/** 세 개 이상의 탭과 비활성(disabled) 트리거를 포함한 예. */
+export const ManyTabs: Story = {
+  render: () => (
+    <Tabs defaultValue='issues' className='w-96'>
+      <TabsList>
+        <TabsTrigger value='issues'>이슈</TabsTrigger>
+        <TabsTrigger value='tasks'>태스크</TabsTrigger>
+        <TabsTrigger value='archived' disabled>
+          보관됨
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value='issues'>이슈 목록</TabsContent>
+      <TabsContent value='tasks'>태스크 목록</TabsContent>
+      <TabsContent value='archived'>보관된 항목</TabsContent>
     </Tabs>
   )
 }

--- a/src/renderer/src/components/atoms/Textarea/Textarea.stories.tsx
+++ b/src/renderer/src/components/atoms/Textarea/Textarea.stories.tsx
@@ -1,13 +1,50 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Textarea } from './Textarea'
 
+/**
+ * 여러 줄 텍스트 입력 필드. 네이티브 `<textarea>`를 Hydra 토큰으로 감쌌다.
+ *
+ * - `field-sizing-content`라 내용에 맞춰 높이가 자라며 최소 `min-h-16`을 유지한다.
+ * - 표준 textarea 속성(`placeholder`, `value`, `rows`, `disabled` 등)을 그대로 받는다.
+ * - 포커스 ring, `aria-invalid` 오류 스타일을 내장한다.
+ */
 const meta: Meta<typeof Textarea> = {
   title: 'Atoms/Textarea',
   component: Textarea,
-  args: { placeholder: 'Write a description…' }
+  args: { placeholder: 'Write a description…' },
+  argTypes: {
+    placeholder: {
+      description: '비어 있을 때 표시되는 안내 문구.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    rows: {
+      description: '초기 표시 행 수. 내용에 따라 더 늘어날 수 있다.',
+      control: 'number',
+      table: { type: { summary: 'number' } }
+    },
+    disabled: {
+      description: 'true면 입력을 막고 투명도를 낮춘다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    'aria-invalid': {
+      description: 'true면 오류 상태(destructive 보더/ring)로 표시한다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Textarea>
 
+/** 기본 textarea. */
 export const Default: Story = {}
+
+/** 비활성화 상태. */
 export const Disabled: Story = { args: { disabled: true } }
+
+/** 초기 내용이 채워진 textarea. */
+export const WithValue: Story = {
+  args: { defaultValue: '여러 줄에 걸친\n설명 텍스트입니다.' }
+}

--- a/src/renderer/src/components/atoms/Tooltip/Tooltip.stories.tsx
+++ b/src/renderer/src/components/atoms/Tooltip/Tooltip.stories.tsx
@@ -1,16 +1,62 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './Tooltip'
 
-const meta: Meta<typeof Tooltip> = { title: 'Atoms/Tooltip', component: Tooltip }
+/**
+ * 트리거에 호버/포커스하면 짧은 보조 설명을 띄우는 툴팁. Radix Tooltip 기반이다.
+ *
+ * - `TooltipTrigger`(트리거 요소) + `TooltipContent`(말풍선)로 구성한다.
+ * - 루트 `Tooltip`이 자체 `TooltipProvider`를 감싸므로 단독 사용이 가능하지만,
+ *   `delayDuration`을 공유하려면 상위에 `TooltipProvider`를 두는 것이 좋다(기본 delay 0).
+ * - `TooltipContent`의 `side`/`sideOffset`로 위치를 조정한다.
+ */
+const meta: Meta<typeof Tooltip> = {
+  title: 'Atoms/Tooltip',
+  component: Tooltip,
+  argTypes: {
+    open: {
+      description: '제어형 열림 상태.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } }
+    },
+    defaultOpen: {
+      description: '비제어형 초기 열림 상태.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    delayDuration: {
+      description: '호버 후 툴팁이 뜨기까지의 지연(ms). Provider 기본은 0이다.',
+      control: 'number',
+      table: { type: { summary: 'number' }, defaultValue: { summary: '0' } }
+    },
+    onOpenChange: {
+      description: '열림 상태 변경 콜백.',
+      control: false,
+      table: { category: 'Events', type: { summary: '(open: boolean) => void' } }
+    }
+  }
+}
 export default meta
 type Story = StoryObj<typeof Tooltip>
 
+/** 트리거에 호버하면 말풍선이 뜨는 기본 예시. */
 export const Default: Story = {
   render: () => (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger className='rounded border px-3 py-1 text-sm'>호버하세요</TooltipTrigger>
         <TooltipContent>툴팁 내용</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+/** side로 툴팁이 트리거 오른쪽에 뜨도록 한 예. */
+export const SidePlacement: Story = {
+  render: () => (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className='rounded border px-3 py-1 text-sm'>오른쪽 툴팁</TooltipTrigger>
+        <TooltipContent side='right'>오른쪽에 표시됩니다</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   )

--- a/src/renderer/src/components/atoms/charts/AreaTrendChart/AreaTrendChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/AreaTrendChart/AreaTrendChart.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { AreaTrendChart } from './AreaTrendChart'
 
+/**
+ * 시간 흐름에 따른 추세를 그라데이션 면적 차트로 보여준다. 여러 시리즈를 겹쳐 그릴 수 있어
+ * 생성/완료 이슈처럼 둘 이상의 추세를 비교할 때 적합하다. X축은 데이터의 `name` 키를 사용하고,
+ * 각 시리즈는 `lines`로 dataKey·색상·그라데이션 id를 지정한다.
+ */
 const meta: Meta<typeof AreaTrendChart> = {
   title: 'Atoms/Charts/AreaTrendChart',
   component: AreaTrendChart,
@@ -10,11 +15,32 @@ const meta: Meta<typeof AreaTrendChart> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    data: {
+      description: '시계열 데이터 배열. 각 항목은 X축 라벨이 되는 { name } + lines의 dataKey에 대응하는 숫자 필드.',
+      control: 'object',
+      table: { type: { summary: 'Array<{ name: string; [key: string]: string | number }>' } }
+    },
+    lines: {
+      description:
+        '그릴 면적 시리즈 정의. 각 항목은 { dataKey, name?, color, gradientId }. color는 CSS 변수 권장, gradientId는 시리즈마다 고유해야 한다.',
+      control: 'object',
+      table: {
+        type: { summary: 'Array<{ dataKey: string; name?: string; color: string; gradientId: string }>' }
+      }
+    },
+    height: {
+      description: '차트 높이(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof AreaTrendChart>
 
+/** 생성/완료 두 시리즈를 겹쳐 보여주는 기본 예시. */
 export const Default: Story = {
   args: {
     data: [
@@ -28,5 +54,26 @@ export const Default: Story = {
       { dataKey: 'created', name: 'Created', color: 'var(--chart-1)', gradientId: 'g-created' },
       { dataKey: 'closed', name: 'Closed', color: 'var(--chart-2)', gradientId: 'g-closed' }
     ]
+  }
+}
+
+/** 시리즈가 하나뿐인 단일 추세 예시. */
+export const SingleLine: Story = {
+  args: {
+    data: [
+      { name: 'Week 1', velocity: 12 },
+      { name: 'Week 2', velocity: 18 },
+      { name: 'Week 3', velocity: 15 },
+      { name: 'Week 4', velocity: 22 }
+    ],
+    lines: [{ dataKey: 'velocity', name: 'Velocity', color: 'var(--chart-3)', gradientId: 'g-velocity' }]
+  }
+}
+
+/** 데이터가 비어 있을 때. 축만 그려지고 면적은 표시되지 않는다. */
+export const Empty: Story = {
+  args: {
+    data: [],
+    lines: [{ dataKey: 'created', name: 'Created', color: 'var(--chart-1)', gradientId: 'g-empty' }]
   }
 }

--- a/src/renderer/src/components/atoms/charts/BubbleChart/BubbleChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/BubbleChart/BubbleChart.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { BubbleChart } from './BubbleChart'
 
+/**
+ * 세 개의 축(X 카테고리/숫자, Y 값, Z 버블 크기)으로 데이터를 산점도 버블로 표현한다.
+ * 예를 들어 이슈 유형별 중요도(Y)와 개수(버블 크기)를 동시에 비교할 때 사용한다.
+ * 색상은 토큰을 런타임 hex로 읽어 라이트/다크 테마를 자동으로 따른다.
+ */
 const meta: Meta<typeof BubbleChart> = {
   title: 'Atoms/Charts/BubbleChart',
   component: BubbleChart,
@@ -10,11 +15,67 @@ const meta: Meta<typeof BubbleChart> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    data: {
+      description:
+        '버블 데이터 배열. 각 항목은 { name, value, count }(+추가 필드 허용). 기본 설정에서 name→X, value→Y, count→버블 크기에 매핑된다.',
+      control: 'object',
+      table: { type: { summary: 'Array<{ name: string; value: number; count: number }>' } }
+    },
+    colors: {
+      description: '버블 색상 배열. 인덱스를 순환 적용한다. 미지정 시 차트 토큰 기반 기본 팔레트.',
+      control: 'object',
+      table: { type: { summary: 'string[]' }, defaultValue: { summary: '토큰 기반 기본 팔레트' } }
+    },
+    height: {
+      description: '차트 높이(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
+    },
+    margin: {
+      description: '차트 여백.',
+      control: 'object',
+      table: {
+        type: { summary: '{ top: number; right: number; bottom: number; left: number }' },
+        defaultValue: { summary: '{ top: 10, right: 10, bottom: 10, left: 10 }' }
+      }
+    },
+    xAxisConfig: {
+      description: 'X축 설정. { dataKey, name, type }. type은 카테고리/숫자 축을 결정한다.',
+      control: 'object',
+      table: {
+        type: { summary: "{ dataKey: string; name: string; type: 'category' | 'number' }" },
+        defaultValue: { summary: "{ dataKey: 'name', name: '카테고리', type: 'category' }" }
+      }
+    },
+    yAxisConfig: {
+      description: 'Y축 설정. { dataKey, name }. 항상 숫자 축이다.',
+      control: 'object',
+      table: {
+        type: { summary: '{ dataKey: string; name: string }' },
+        defaultValue: { summary: "{ dataKey: 'value', name: '중요도' }" }
+      }
+    },
+    zAxisConfig: {
+      description: 'Z축(버블 크기) 설정. { dataKey, name, range }. range는 [최소, 최대] 픽셀 크기.',
+      control: 'object',
+      table: {
+        type: { summary: '{ dataKey: string; name: string; range: [number, number] }' },
+        defaultValue: { summary: "{ dataKey: 'count', name: '이슈 수', range: [30, 120] }" }
+      }
+    },
+    tooltipFormatter: {
+      description: '툴팁 값 포매터. (value, name) => [표시값, 표시라벨].',
+      control: false,
+      table: { type: { summary: '(value: any, name: string) => [string, string]' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof BubbleChart>
 
+/** 이슈 유형별 중요도(Y)와 개수(버블 크기) 기본 예시. */
 export const Default: Story = {
   args: {
     data: [
@@ -23,5 +84,24 @@ export const Default: Story = {
       { name: 'Chore', value: 6, count: 12 },
       { name: 'Docs', value: 4, count: 3 }
     ]
+  }
+}
+
+/** 단색 팔레트로 모든 버블을 동일 색상으로 통일한 예시. */
+export const SingleColor: Story = {
+  args: {
+    data: [
+      { name: 'Bug', value: 12, count: 8 },
+      { name: 'Feature', value: 20, count: 5 },
+      { name: 'Chore', value: 6, count: 12 }
+    ],
+    colors: ['var(--chart-1)']
+  }
+}
+
+/** 데이터가 비어 있을 때. 축만 그려지고 버블은 표시되지 않는다. */
+export const Empty: Story = {
+  args: {
+    data: []
   }
 }

--- a/src/renderer/src/components/atoms/charts/HorizontalBarChart/HorizontalBarChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/HorizontalBarChart/HorizontalBarChart.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { HorizontalBarChart } from './HorizontalBarChart'
 
+/**
+ * 카테고리별 값을 가로 막대로 보여준다(세로 레이아웃 BarChart). 라벨이 긴 항목을
+ * 비교하기 좋아 담당자별/프로젝트별 이슈 수 같은 순위형 데이터에 적합하다.
+ * 단색 또는 가로 그라데이션(gradientId + gradientColors)으로 막대를 채울 수 있다.
+ */
 const meta: Meta<typeof HorizontalBarChart> = {
   title: 'Atoms/Charts/HorizontalBarChart',
   component: HorizontalBarChart,
@@ -10,11 +15,72 @@ const meta: Meta<typeof HorizontalBarChart> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    data: {
+      description: '막대 데이터 배열. 각 항목은 Y축 라벨 { name } + dataKey에 대응하는 숫자 필드.',
+      control: 'object',
+      table: { type: { summary: 'Array<{ name: string; [key: string]: string | number }>' } }
+    },
+    dataKey: {
+      description: '막대 길이로 그릴 값의 키.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    fill: {
+      description: '막대 단색 채움. gradientId가 없을 때 사용된다. 기본값은 --chart-1 토큰의 런타임 hex.',
+      control: 'color',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'var(--chart-1)' } }
+    },
+    gradientId: {
+      description: '그라데이션 채움 id. gradientColors와 함께 지정하면 fill 대신 그라데이션을 적용한다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    gradientColors: {
+      description: '가로 그라데이션 시작/끝 색상. { start, end }.',
+      control: 'object',
+      table: { type: { summary: '{ start: string; end: string }' } }
+    },
+    height: {
+      description: '차트 높이(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
+    },
+    yAxisWidth: {
+      description: 'Y축(라벨) 영역 너비(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '80' } }
+    },
+    barSize: {
+      description: '막대 두께(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '14' } }
+    },
+    margin: {
+      description: '차트 여백.',
+      control: 'object',
+      table: {
+        type: { summary: '{ top: number; right: number; bottom: number; left: number }' },
+        defaultValue: { summary: '{ top: 10, right: 10, bottom: 10, left: 80 }' }
+      }
+    },
+    domain: {
+      description: 'X축(값) 범위 [최소, 최대]. 미지정 시 데이터에 맞춰 자동 계산.',
+      control: 'object',
+      table: { type: { summary: '[number, number]' } }
+    },
+    formatter: {
+      description: '툴팁 값 포매터. (value) => [표시값, 표시라벨].',
+      control: false,
+      table: { type: { summary: '(value: any) => [string, string]' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof HorizontalBarChart>
 
+/** 담당자별 이슈 수 기본 예시. */
 export const Default: Story = {
   args: {
     dataKey: 'count',
@@ -24,5 +90,27 @@ export const Default: Story = {
       { name: 'Carol', count: 5 },
       { name: 'Dave', count: 3 }
     ]
+  }
+}
+
+/** 가로 그라데이션으로 막대를 채운 예시. */
+export const Gradient: Story = {
+  args: {
+    dataKey: 'count',
+    data: [
+      { name: 'Alice', count: 12 },
+      { name: 'Bob', count: 8 },
+      { name: 'Carol', count: 5 }
+    ],
+    gradientId: 'hbar-grad',
+    gradientColors: { start: 'var(--chart-1)', end: 'var(--chart-2)' }
+  }
+}
+
+/** 데이터가 비어 있을 때. 축만 그려지고 막대는 표시되지 않는다. */
+export const Empty: Story = {
+  args: {
+    dataKey: 'count',
+    data: []
   }
 }

--- a/src/renderer/src/components/atoms/charts/StackedBarChart/StackedBarChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/StackedBarChart/StackedBarChart.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { StackedBarChart } from './StackedBarChart'
 
+/**
+ * 여러 시리즈를 같은 stackId로 쌓아 누적 막대로 보여준다. 스프린트별 done/in-progress처럼
+ * 부분 합과 전체 합을 함께 비교할 때 사용한다. layout으로 가로(vertical)/세로(horizontal)
+ * 막대를 전환할 수 있고, 각 막대는 bars 설정으로 dataKey·색상·모서리 반경을 지정한다.
+ */
 const meta: Meta<typeof StackedBarChart> = {
   title: 'Atoms/Charts/StackedBarChart',
   component: StackedBarChart,
@@ -10,11 +15,59 @@ const meta: Meta<typeof StackedBarChart> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    data: {
+      description: '막대 데이터 배열. 각 항목은 축 라벨 { name } + bars의 dataKey에 대응하는 숫자 필드.',
+      control: 'object',
+      table: { type: { summary: 'Array<{ name: string; [key: string]: string | number }>' } }
+    },
+    bars: {
+      description:
+        '쌓을 막대 시리즈 정의. 각 항목은 { dataKey, stackId, fill, radius? }. 같은 stackId끼리 누적되며 fill은 CSS 변수 권장.',
+      control: 'object',
+      table: {
+        type: {
+          summary:
+            'Array<{ dataKey: string; stackId: string; fill: string; radius?: [number, number, number, number] }>'
+        }
+      }
+    },
+    layout: {
+      description: '막대 방향. vertical은 가로 막대, horizontal은 세로 막대.',
+      control: 'inline-radio',
+      options: ['vertical', 'horizontal'],
+      table: { type: { summary: "'vertical' | 'horizontal'" }, defaultValue: { summary: "'vertical'" } }
+    },
+    height: {
+      description: '차트 높이(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
+    },
+    yAxisWidth: {
+      description: 'Y축(라벨) 영역 너비(px). vertical 레이아웃에서 의미 있다.',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '80' } }
+    },
+    barSize: {
+      description: '막대 두께(px).',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '14' } }
+    },
+    margin: {
+      description: '차트 여백.',
+      control: 'object',
+      table: {
+        type: { summary: '{ top: number; right: number; bottom: number; left: number }' },
+        defaultValue: { summary: '{ top: 10, right: 10, bottom: 10, left: 80 }' }
+      }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof StackedBarChart>
 
+/** 스프린트별 done/in-progress 누적 막대 기본 예시(가로 막대). */
 export const Default: Story = {
   args: {
     data: [
@@ -22,6 +75,33 @@ export const Default: Story = {
       { name: 'Sprint 2', done: 12, inProgress: 5 },
       { name: 'Sprint 3', done: 6, inProgress: 7 }
     ],
+    bars: [
+      { dataKey: 'done', stackId: 's', fill: 'var(--chart-1)' },
+      { dataKey: 'inProgress', stackId: 's', fill: 'var(--chart-2)' }
+    ]
+  }
+}
+
+/** 세로 막대(horizontal) 레이아웃 예시. */
+export const Horizontal: Story = {
+  args: {
+    layout: 'horizontal',
+    data: [
+      { name: 'Sprint 1', done: 8, inProgress: 3 },
+      { name: 'Sprint 2', done: 12, inProgress: 5 },
+      { name: 'Sprint 3', done: 6, inProgress: 7 }
+    ],
+    bars: [
+      { dataKey: 'done', stackId: 's', fill: 'var(--chart-1)' },
+      { dataKey: 'inProgress', stackId: 's', fill: 'var(--chart-2)' }
+    ]
+  }
+}
+
+/** 데이터가 비어 있을 때. 축과 범례만 그려지고 막대는 표시되지 않는다. */
+export const Empty: Story = {
+  args: {
+    data: [],
     bars: [
       { dataKey: 'done', stackId: 's', fill: 'var(--chart-1)' },
       { dataKey: 'inProgress', stackId: 's', fill: 'var(--chart-2)' }

--- a/src/renderer/src/components/atoms/charts/StatusDonutChart/StatusDonutChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/StatusDonutChart/StatusDonutChart.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { StatusDonutChart } from './StatusDonutChart'
 
+/**
+ * 상태별 이슈 분포를 도넛 차트로 보여준다. 각 조각의 색상은 데이터가 직접 지정하며,
+ * 가운데가 비어 있어 범례나 합계 텍스트를 함께 배치하기 좋다.
+ * 프로젝트 대시보드에서 Backlog/In Progress/Done 같은 상태 비중을 한눈에 비교할 때 사용한다.
+ */
 const meta: Meta<typeof StatusDonutChart> = {
   title: 'Atoms/Charts/StatusDonutChart',
   component: StatusDonutChart,
@@ -10,11 +15,29 @@ const meta: Meta<typeof StatusDonutChart> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    data: {
+      description: '도넛 조각 배열. 각 항목은 { name, value, color }. color는 CSS 변수(var(--chart-1)) 권장.',
+      control: 'object',
+      table: { type: { summary: 'Array<{ name: string; value: number; color: string }>' } }
+    },
+    height: {
+      description: '차트 높이(px). innerRadius/outerRadius가 이 값에 비례해 계산된다.',
+      control: { type: 'number' },
+      table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
+    },
+    showLabels: {
+      description: '각 조각에 백분율 라벨을 표시할지 여부.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof StatusDonutChart>
 
+/** 기본 상태 분포 예시. */
 export const Default: Story = {
   args: {
     data: [
@@ -23,5 +46,24 @@ export const Default: Story = {
       { name: 'Review', value: 3, color: 'var(--chart-3)' },
       { name: 'Done', value: 12, color: 'var(--chart-4)' }
     ]
+  }
+}
+
+/** 백분율 라벨을 숨긴 형태. 범례를 외부에 따로 둘 때 적합하다. */
+export const WithoutLabels: Story = {
+  args: {
+    data: [
+      { name: 'Backlog', value: 8, color: 'var(--chart-1)' },
+      { name: 'In Progress', value: 5, color: 'var(--chart-2)' },
+      { name: 'Done', value: 12, color: 'var(--chart-4)' }
+    ],
+    showLabels: false
+  }
+}
+
+/** 데이터가 비어 있을 때. 조각 없이 빈 도넛 영역만 렌더된다. */
+export const Empty: Story = {
+  args: {
+    data: []
   }
 }

--- a/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.stories.tsx
+++ b/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.stories.tsx
@@ -13,13 +13,32 @@ const sample = (over: Partial<ActivityLogRecord>): ActivityLogRecord => ({
   ...over
 })
 
+/**
+ * 이슈의 활동 로그(상태 변경 / 담당자 변경 / 댓글 작성)를 시간순 목록으로 표시하는 컴포넌트.
+ * 각 항목은 `activity_action`과 `activity_metadata`를 사람이 읽을 문장으로 변환해 보여준다.
+ * 로딩 중이거나 활동이 없을 때는 안내 문구를 대신 렌더한다.
+ */
 const meta: Meta<typeof ActivityTimeline> = {
   title: 'Molecules/ActivityTimeline',
-  component: ActivityTimeline
+  component: ActivityTimeline,
+  argTypes: {
+    activities: {
+      description:
+        '표시할 활동 로그 배열. 각 항목은 ActivityLogRecord(activity_id, activity_action, activity_metadata, activity_created_at 등)이며 status_changed/assigned는 metadata의 from→to를, comment_created는 고정 문구를 렌더한다.',
+      control: 'object',
+      table: { type: { summary: 'ActivityLogRecord[]' } }
+    },
+    isLoading: {
+      description: 'true이면 활동 대신 로딩 안내 문구를 표시한다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof ActivityTimeline>
 
+/** 상태 변경 + 댓글 작성 활동이 섞인 기본 타임라인. */
 export const Default: Story = {
   args: {
     activities: [
@@ -32,5 +51,8 @@ export const Default: Story = {
   }
 }
 
+/** 데이터를 불러오는 중인 로딩 상태. */
 export const Loading: Story = { args: { activities: [], isLoading: true } }
+
+/** 활동이 하나도 없을 때의 빈 상태. */
 export const Empty: Story = { args: { activities: [] } }

--- a/src/renderer/src/components/molecules/Divider/Divider.stories.tsx
+++ b/src/renderer/src/components/molecules/Divider/Divider.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Divider } from './Divider'
 
+/**
+ * 가운데에 텍스트 라벨을 둔 수평 구분선. 라벨 양옆으로 가로선이 이어져
+ * "OR", "Or continue with" 같은 섹션 구분 문구를 표시할 때 사용한다.
+ */
 const meta: Meta<typeof Divider> = {
   title: 'Molecules/Divider',
   component: Divider,
@@ -10,10 +14,25 @@ const meta: Meta<typeof Divider> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    text: {
+      description: '구분선 가운데에 표시되는 라벨 텍스트',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    className: {
+      description: '루트 요소에 합쳐지는 추가 Tailwind 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof Divider>
 
+/** 짧은 라벨("OR")이 들어간 기본 구분선. */
 export const Default: Story = { args: { text: 'OR' } }
+
+/** 소셜 로그인 등에서 쓰는 긴 안내 라벨. */
 export const Continue: Story = { args: { text: 'Or continue with' } }

--- a/src/renderer/src/components/molecules/InfoRow/InfoRow.stories.tsx
+++ b/src/renderer/src/components/molecules/InfoRow/InfoRow.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { InfoRow } from './InfoRow'
 
+/**
+ * 라벨 + 값을 4칸 그리드로 나란히 배치하는 정보 행. 상세 패널이나 설정 화면에서
+ * "Status: In Progress"처럼 속성을 한 줄씩 표시할 때 사용한다.
+ * `labelWidth`로 라벨이 차지하는 칸 수를 조절하면 값 칸은 자동으로 나머지를 채운다.
+ */
 const meta: Meta<typeof InfoRow> = {
   title: 'Molecules/InfoRow',
   component: InfoRow,
@@ -10,10 +15,31 @@ const meta: Meta<typeof InfoRow> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    label: {
+      description: '왼쪽에 굵게 표시되는 속성 라벨',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    value: {
+      description: '오른쪽에 표시되는 값(텍스트 또는 ReactNode)',
+      control: 'text',
+      table: { type: { summary: 'ReactNode' } }
+    },
+    labelWidth: {
+      description: '4칸 그리드 중 라벨이 차지하는 칸 수. 값 칸은 (4 - labelWidth)칸을 차지한다.',
+      control: 'select',
+      options: [1, 2, 3, 4],
+      table: { type: { summary: '1 | 2 | 3 | 4' }, defaultValue: { summary: '1' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof InfoRow>
 
+/** 라벨 1칸 + 값 3칸의 기본 비율. */
 export const Default: Story = { args: { label: 'Status', value: 'In Progress' } }
+
+/** 라벨을 2칸으로 넓혀 긴 라벨을 수용. */
 export const WideLabel: Story = { args: { label: 'Created at', value: '2026-06-14', labelWidth: 2 } }

--- a/src/renderer/src/components/molecules/InputField/InputField.stories.tsx
+++ b/src/renderer/src/components/molecules/InputField/InputField.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { InputField } from './InputField'
 
+/**
+ * 라벨 + 입력 + 에러 메시지를 묶는 폼 필드 컨테이너. Context로 `id`/`error`를 자식에 내려주며,
+ * 실제 입력은 compound 서브컴포넌트로 조합한다: `InputField.Input`, `InputField.Email`,
+ * `InputField.Password`, `InputField.OTP`. `error`가 있으면 하단에 destructive 메시지를 렌더하고
+ * 입력에 `aria-invalid`를 부여한다.
+ */
 const meta: Meta<typeof InputField> = {
   title: 'Molecules/InputField',
   component: InputField,
@@ -10,11 +16,34 @@ const meta: Meta<typeof InputField> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    label: {
+      description: '필드 상단에 표시되는 라벨. 생략하면 라벨을 렌더하지 않는다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    error: {
+      description: '설정 시 하단에 빨간 에러 메시지를 표시하고 입력에 aria-invalid를 부여한다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    id: {
+      description: '라벨/입력을 연결하는 id. 생략하면 useId로 자동 생성한다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    children: {
+      description: 'InputField.Input / .Email / .Password / .OTP 등 입력 서브컴포넌트',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof InputField>
 
+/** 이메일 입력(InputField.Email)을 감싼 기본 텍스트 필드. */
 export const Text: Story = {
   render: () => (
     <InputField label='Email'>
@@ -23,6 +52,7 @@ export const Text: Story = {
   )
 }
 
+/** 비밀번호 입력(InputField.Password) 필드. */
 export const Password: Story = {
   render: () => (
     <InputField label='Password'>
@@ -31,10 +61,20 @@ export const Password: Story = {
   )
 }
 
+/** error prop이 설정되어 에러 메시지가 노출된 상태. */
 export const WithError: Story = {
   render: () => (
     <InputField label='Email' error='Invalid email address'>
       <InputField.Email placeholder='you@example.com' />
+    </InputField>
+  )
+}
+
+/** 6자리 OTP 입력(InputField.OTP). */
+export const OTP: Story = {
+  render: () => (
+    <InputField label='Verification code'>
+      <InputField.OTP value='' onChange={() => {}} />
     </InputField>
   )
 }

--- a/src/renderer/src/components/molecules/cards/ChartCard/ChartCard.stories.tsx
+++ b/src/renderer/src/components/molecules/cards/ChartCard/ChartCard.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ChartCard } from './ChartCard'
 
+/**
+ * 대시보드 차트를 감싸는 유리 효과(glass-soft) 카드. 제목 + 선택적 설명 헤더 아래
+ * children 영역에 Recharts 등 차트를 배치한다. 카드 배경은 투명 처리되어 있다.
+ */
 const meta: Meta<typeof ChartCard> = {
   title: 'Molecules/ChartCard',
   component: ChartCard,
@@ -10,15 +14,45 @@ const meta: Meta<typeof ChartCard> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    title: {
+      description: '카드 헤더에 표시되는 제목',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    description: {
+      description: '제목 아래에 표시되는 보조 설명(선택)',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    children: {
+      description: '본문에 렌더되는 차트/콘텐츠(ReactNode)',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof ChartCard>
 
+/** 제목 + 설명 + 플레이스홀더 차트 영역. */
 export const Default: Story = {
   args: {
     title: 'Issues by status',
     description: '현재 스프린트 기준',
+    children: (
+      <div className='flex h-40 items-center justify-center rounded-md bg-muted text-sm text-muted-foreground'>
+        차트 영역
+      </div>
+    )
+  }
+}
+
+/** 설명 없이 제목만 있는 카드. */
+export const WithoutDescription: Story = {
+  args: {
+    title: 'Throughput',
     children: (
       <div className='flex h-40 items-center justify-center rounded-md bg-muted text-sm text-muted-foreground'>
         차트 영역

--- a/src/renderer/src/components/molecules/cards/SettingCard/SettingCard.stories.tsx
+++ b/src/renderer/src/components/molecules/cards/SettingCard/SettingCard.stories.tsx
@@ -2,6 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from '@/atoms/Button'
 import { SettingCard } from './SettingCard'
 
+/**
+ * 설정 화면의 한 섹션을 담는 카드. 제목 + 선택적 설명 헤더, 본문(children),
+ * 그리고 footer가 있으면 상단 구분선이 그어진 우측 정렬 푸터(보통 저장 버튼)를 렌더한다.
+ */
 const meta: Meta<typeof SettingCard> = {
   title: 'Molecules/SettingCard',
   component: SettingCard,
@@ -11,16 +15,53 @@ const meta: Meta<typeof SettingCard> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    title: {
+      description: '카드 헤더 제목',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    description: {
+      description: '제목 아래 보조 설명(선택)',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    children: {
+      description: '본문에 렌더되는 설정 폼/콘텐츠(ReactNode)',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    },
+    footer: {
+      description: '설정 시 상단 구분선 + 우측 정렬 푸터로 렌더된다(보통 저장 버튼). 없으면 푸터를 생략한다.',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    },
+    className: {
+      description: 'Card 루트에 합쳐지는 추가 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof SettingCard>
 
+/** 제목 + 설명 + 본문 + 저장 버튼 푸터를 모두 갖춘 기본 카드. */
 export const Default: Story = {
   args: {
     title: 'Profile',
     description: '계정 정보를 관리합니다',
     children: <p className='text-sm text-muted-foreground'>설정 폼 영역</p>,
     footer: <Button>저장</Button>
+  }
+}
+
+/** footer가 없어 푸터/구분선이 생략된 카드. */
+export const WithoutFooter: Story = {
+  args: {
+    title: 'Danger zone',
+    description: '되돌릴 수 없는 작업입니다',
+    children: <p className='text-sm text-muted-foreground'>설정 폼 영역</p>
   }
 }

--- a/src/renderer/src/components/molecules/cards/StatCard/StatCard.stories.tsx
+++ b/src/renderer/src/components/molecules/cards/StatCard/StatCard.stories.tsx
@@ -2,6 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { CircleDashed } from 'lucide-react'
 import { StatCard } from './StatCard'
 
+/**
+ * 대시보드 상단의 단일 지표 카드. 좌측 아이콘 박스 + (라벨 / 큰 수치 + 보조 설명)으로 구성한다.
+ * `iconColor`로 아이콘 박스의 텍스트 색을 바꿔 지표별 강조 톤을 지정할 수 있다.
+ */
 const meta: Meta<typeof StatCard> = {
   title: 'Molecules/StatCard',
   component: StatCard,
@@ -11,16 +15,55 @@ const meta: Meta<typeof StatCard> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    title: {
+      description: '지표 라벨(작은 글씨)',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    value: {
+      description: '큰 글씨로 표시되는 지표 값',
+      control: 'text',
+      table: { type: { summary: 'string | number' } }
+    },
+    icon: {
+      description: '좌측 아이콘 박스에 들어가는 아이콘(ReactNode)',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    },
+    iconColor: {
+      description: '아이콘 박스의 텍스트 색상 Tailwind 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'text-muted-foreground' } }
+    },
+    description: {
+      description: '값 옆에 표시되는 보조 설명(선택)',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof StatCard>
 
+/** 기본 지표 카드. */
 export const Default: Story = {
   args: {
     title: 'Open issues',
     value: 24,
     icon: <CircleDashed size={18} />,
     description: 'this week'
+  }
+}
+
+/** iconColor로 아이콘 톤을 강조한 카드. */
+export const ColoredIcon: Story = {
+  args: {
+    title: 'Blocked',
+    value: 3,
+    icon: <CircleDashed size={18} />,
+    iconColor: 'text-destructive',
+    description: 'needs attention'
   }
 }

--- a/src/renderer/src/components/molecules/issues/IssueBadge/IssueBadge.stories.tsx
+++ b/src/renderer/src/components/molecules/issues/IssueBadge/IssueBadge.stories.tsx
@@ -1,19 +1,54 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { IssueBadge } from './IssueBadge'
 
+/**
+ * 이슈 상태(IssueStatus)를 색상 틴트 배경 + 동계열 텍스트 + 아이콘 배지로 표시하는 컴포넌트.
+ * 라벨/색상/아이콘은 상태값에 따라 statusTokens(STATUS_LABEL/STATUS_CLASS)와 내부 STATUS_ICON에서 결정된다.
+ * `variant`는 호환을 위해 받지만 무시되며 항상 동일한 틴트 스타일로 렌더한다.
+ */
 const meta: Meta<typeof IssueBadge> = {
   title: 'Molecules/IssueBadge',
-  component: IssueBadge
+  component: IssueBadge,
+  argTypes: {
+    state: {
+      description: '이슈 상태값(공유 IssueStatus union). 라벨/색상/아이콘을 결정한다.',
+      control: 'select',
+      options: ['backlog', 'in_progress', 'review', 'done', 'blocked'],
+      table: { type: { summary: "'backlog' | 'in_progress' | 'review' | 'done' | 'blocked'" } }
+    },
+    size: {
+      description: '배지 크기',
+      control: 'radio',
+      options: ['sm', 'lg'],
+      table: { type: { summary: "'sm' | 'lg'" }, defaultValue: { summary: 'sm' } }
+    },
+    variant: {
+      description: '호환용으로 받지만 사용하지 않는다(스타일에 영향 없음).',
+      control: false,
+      table: { type: { summary: "'solid' | 'subtle' | 'outline' | 'surface' | 'plain'" } }
+    },
+    className: {
+      description: '배지에 합쳐지는 추가 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof IssueBadge>
 
+/** Backlog 상태 배지. */
 export const Backlog: Story = { args: { state: 'backlog' } }
+/** In progress 상태 배지. */
 export const InProgress: Story = { args: { state: 'in_progress' } }
+/** Review 상태 배지. */
 export const Review: Story = { args: { state: 'review' } }
+/** Done 상태 배지. */
 export const Done: Story = { args: { state: 'done' } }
+/** Blocked 상태 배지. */
 export const Blocked: Story = { args: { state: 'blocked' } }
 
+/** 모든 상태값을 한눈에 비교. */
 export const AllStates: Story = {
   render: () => (
     <div className='flex flex-wrap gap-2'>
@@ -25,3 +60,6 @@ export const AllStates: Story = {
     </div>
   )
 }
+
+/** lg 크기 배지. */
+export const LargeSize: Story = { args: { state: 'in_progress', size: 'lg' } }

--- a/src/renderer/src/components/molecules/tables/TableEmpty/TableEmpty.stories.tsx
+++ b/src/renderer/src/components/molecules/tables/TableEmpty/TableEmpty.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { TableEmpty } from './TableEmpty'
 
+/**
+ * 테이블에 표시할 데이터가 없거나 로딩 중일 때 보여주는 상태 컴포넌트.
+ * 기본 아이콘(ClipboardList) + 메시지를 가운데 정렬로 렌더하며, `isLoading`이면
+ * pulse 애니메이션과 함께 `loadingMessage`를 표시한다. 빈 상태에서는 `description`을 추가로 보여준다.
+ */
 const meta: Meta<typeof TableEmpty> = {
   title: 'Molecules/TableEmpty',
   component: TableEmpty,
@@ -10,12 +15,47 @@ const meta: Meta<typeof TableEmpty> = {
         <Story />
       </div>
     )
-  ]
+  ],
+  argTypes: {
+    message: {
+      description: '빈 상태일 때 표시되는 주 메시지',
+      control: 'text',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'No data available' } }
+    },
+    description: {
+      description: '빈 상태에서 메시지 아래에 표시되는 보조 설명(선택)',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    icon: {
+      description: '기본 아이콘 대신 사용할 아이콘(ReactNode). 미지정 시 ClipboardList 사용.',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    },
+    isLoading: {
+      description: 'true이면 pulse 애니메이션과 loadingMessage를 표시한다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    loadingMessage: {
+      description: '로딩 중 표시되는 메시지',
+      control: 'text',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'Loading data...' } }
+    },
+    className: {
+      description: '컨테이너에 합쳐지는 추가 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof TableEmpty>
 
+/** 메시지 + 설명이 있는 빈 상태. */
 export const Empty: Story = {
   args: { message: 'No issues found', description: 'Create your first issue to get started' }
 }
+
+/** 데이터를 불러오는 중인 로딩 상태. */
 export const Loading: Story = { args: { isLoading: true } }

--- a/src/renderer/src/components/molecules/users/UserAvatar/UserAvatar.stories.tsx
+++ b/src/renderer/src/components/molecules/users/UserAvatar/UserAvatar.stories.tsx
@@ -1,13 +1,68 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { UserAvatar } from './UserAvatar'
 
+/**
+ * 사용자 아바타 + 이름(선택적으로 이메일)을 한 줄로 표시하는 컴포넌트.
+ * `avatar` 이미지가 없으면 User 아이콘 fallback을 보여준다. `showInfo`가 true면
+ * 이름/이메일을 세로 스택으로, false면 이름만 옆에 표시한다. `size`로 4단계 크기를,
+ * `align`으로 좌측/가운데 정렬을 조절한다.
+ */
 const meta: Meta<typeof UserAvatar> = {
   title: 'Molecules/UserAvatar',
-  component: UserAvatar
+  component: UserAvatar,
+  argTypes: {
+    name: {
+      description: '사용자 이름. fallback alt 및 라벨로 사용된다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    avatar: {
+      description: '아바타 이미지 URL. 없으면 User 아이콘 fallback을 표시한다.',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    email: {
+      description: 'showInfo가 true일 때 이름 아래에 표시되는 이메일',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    },
+    size: {
+      description: '아바타/텍스트 크기 단계',
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg'],
+      table: { type: { summary: "'xs' | 'sm' | 'md' | 'lg'" }, defaultValue: { summary: 'md' } }
+    },
+    showInfo: {
+      description: 'true면 이름+이메일을 세로 스택으로, false면 이름만 옆에 표시한다.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    align: {
+      description: '컨테이너 내 정렬',
+      control: 'radio',
+      options: ['left', 'center'],
+      table: { type: { summary: "'left' | 'center'" }, defaultValue: { summary: 'left' } }
+    },
+    fallback: {
+      description: '기본 User 아이콘 대신 사용할 fallback 노드(ReactNode)',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    },
+    className: {
+      description: '컨테이너에 합쳐지는 추가 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof UserAvatar>
 
+/** 이름만 옆에 표시되는 기본 아바타. */
 export const Default: Story = { args: { name: 'Alice Kim' } }
+
+/** showInfo로 이름 + 이메일을 함께 표시. */
 export const WithInfo: Story = { args: { name: 'Alice Kim', email: 'alice@example.com', showInfo: true } }
+
+/** lg 크기의 정보 포함 아바타. */
 export const Large: Story = { args: { name: 'Alice Kim', email: 'alice@example.com', showInfo: true, size: 'lg' } }

--- a/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.stories.tsx
+++ b/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.stories.tsx
@@ -15,14 +15,37 @@ const issue = (over: Partial<Issue>): Issue => ({
   ...over
 })
 
+/**
+ * dnd-kit 기반 칸반 보드. 이슈 상태(backlog / in_progress / review / done / blocked)별 컬럼에 카드를 배치하고,
+ * 카드를 다른 컬럼으로 드래그하면 `onMove(issueId, newState)`를 호출한다. 카드 클릭 시 `onSelectIssue`가 호출된다.
+ * 프로젝트 보드 화면에서 이슈를 상태별로 시각화/이동할 때 사용한다.
+ */
 const meta: Meta<typeof KanbanBoard> = {
   title: 'Organisms/KanbanBoard',
   component: KanbanBoard,
+  argTypes: {
+    issues: {
+      description: '보드에 표시할 이슈 배열. 각 이슈의 state 값에 따라 컬럼으로 분류된다.',
+      control: 'object',
+      table: { type: { summary: 'Issue[]' } }
+    },
+    onMove: {
+      description: '카드를 다른 상태 컬럼으로 드롭했을 때 호출. (issueId: string, newState: IssueStatus) => void',
+      control: false,
+      table: { type: { summary: '(issueId: string, newState: IssueStatus) => void' } }
+    },
+    onSelectIssue: {
+      description: '카드 클릭 시 호출(선택). (issue: Issue) => void',
+      control: false,
+      table: { type: { summary: '(issue: Issue) => void' } }
+    }
+  },
   args: { onMove: () => {} }
 }
 export default meta
 type Story = StoryObj<typeof KanbanBoard>
 
+/** 다섯 개 상태 컬럼에 이슈가 하나씩 배치된 기본 보드. */
 export const Default: Story = {
   args: {
     issues: [
@@ -35,4 +58,5 @@ export const Default: Story = {
   }
 }
 
+/** 이슈가 없을 때 빈 컬럼만 표시되는 상태. */
 export const Empty: Story = { args: { issues: [] } }

--- a/src/renderer/src/components/templates/AuthLayout/AuthLayout.stories.tsx
+++ b/src/renderer/src/components/templates/AuthLayout/AuthLayout.stories.tsx
@@ -1,14 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { AuthLayout } from './AuthLayout'
 
+/**
+ * 로그인/관리자 설정 등 인증 화면의 공통 셸. 좌측 브랜드 패널(md 이상에서만 표시) + 우측 폼 카드 구조이며,
+ * 제목/부제 슬롯과 본문(`children`) 슬롯을 제공한다. 로그인·셋업 등 인증 흐름의 페이지 골격으로 사용한다.
+ */
 const meta: Meta<typeof AuthLayout> = {
   title: 'Templates/AuthLayout',
   component: AuthLayout,
-  parameters: { layout: 'fullscreen' }
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    title: { description: '카드 상단 제목', control: 'text', table: { type: { summary: 'string' } } },
+    subtitle: { description: '제목 아래 보조 설명', control: 'text', table: { type: { summary: 'string' } } },
+    children: { description: '폼 등 카드 본문 슬롯', control: false, table: { type: { summary: 'ReactNode' } } }
+  }
 }
 export default meta
 type Story = StoryObj<typeof AuthLayout>
 
+/** 워크스페이스 로그인 화면 예시. */
 export const SignIn: Story = {
   args: {
     title: '로그인',
@@ -19,6 +29,7 @@ export const SignIn: Story = {
   }
 }
 
+/** 빈 DB 최초 연결 시 노출되는 관리자 계정 셋업 화면 예시. */
 export const AdminSetup: Story = {
   args: {
     title: '관리자 설정',

--- a/src/renderer/src/components/templates/DialogTemplate/DialogTemplate.stories.tsx
+++ b/src/renderer/src/components/templates/DialogTemplate/DialogTemplate.stories.tsx
@@ -2,13 +2,41 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from '@/atoms/Button'
 import { DialogTemplate } from './DialogTemplate'
 
+/**
+ * 제목·설명·본문·푸터 슬롯을 갖춘 표준 다이얼로그 셸. shadcn `Dialog`를 감싸 모달의 공통 골격을 제공한다.
+ * `onSubmit`을 넘기면 본문/푸터를 `<form>`으로 감싸 폼 제출형 다이얼로그(생성/수정 등)로 동작한다.
+ * 프로젝트·이슈 생성처럼 입력 폼이 들어가는 모달에 사용한다.
+ */
 const meta: Meta<typeof DialogTemplate> = {
   title: 'Templates/DialogTemplate',
-  component: DialogTemplate
+  component: DialogTemplate,
+  argTypes: {
+    open: { description: '다이얼로그 열림/닫힘 상태', control: 'boolean', table: { type: { summary: 'boolean' } } },
+    onOpenChange: {
+      description: '열림 상태 변경 핸들러. (open: boolean) => void',
+      control: false,
+      table: { type: { summary: '(open: boolean) => void' } }
+    },
+    title: { description: '다이얼로그 제목', control: 'text', table: { type: { summary: 'string' } } },
+    description: { description: '제목 아래 보조 설명(선택)', control: 'text', table: { type: { summary: 'string' } } },
+    children: { description: '본문 슬롯(폼/컨텐츠 영역)', control: false, table: { type: { summary: 'ReactNode' } } },
+    footer: { description: '푸터 슬롯(주로 액션 버튼)', control: false, table: { type: { summary: 'ReactNode' } } },
+    maxWidthClass: {
+      description: '컨텐츠 최대 너비 Tailwind 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'sm:max-w-[425px]' } }
+    },
+    onSubmit: {
+      description: '폼 제출 핸들러(선택). 지정 시 본문/푸터가 <form>으로 감싸진다. (e: FormEvent) => void',
+      control: false,
+      table: { type: { summary: '(e: React.FormEvent) => void' } }
+    }
+  }
 }
 export default meta
 type Story = StoryObj<typeof DialogTemplate>
 
+/** 제목·설명·본문·취소/생성 버튼 푸터를 갖춘 기본 다이얼로그. */
 export const Default: Story = {
   args: {
     open: true,

--- a/src/renderer/src/components/templates/SignInTemplate/SignInTemplate.stories.tsx
+++ b/src/renderer/src/components/templates/SignInTemplate/SignInTemplate.stories.tsx
@@ -1,9 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { SignInTemplate } from './SignInTemplate'
 
+/**
+ * 로그인 화면용 2열 카드 셸. 좌측은 폼(`children`)을 감싼 `<form>`, 우측은 일러스트 이미지(md 이상에서만 표시)이며
+ * 하단에 약관/개인정보 고지 문구가 붙는다. `div`의 기본 속성(`className` 포함)을 그대로 받아 전달한다.
+ * 로그인 폼을 카드 형태로 배치할 때 사용한다.
+ */
 const meta: Meta<typeof SignInTemplate> = {
   title: 'Templates/SignInTemplate',
   component: SignInTemplate,
+  argTypes: {
+    children: {
+      description: '좌측 폼 영역에 렌더링될 본문',
+      control: false,
+      table: { type: { summary: 'ReactNode' } }
+    },
+    className: {
+      description: '루트 컨테이너에 병합되는 추가 클래스',
+      control: 'text',
+      table: { type: { summary: 'string' } }
+    }
+  },
   decorators: [
     (Story) => (
       <div className='w-[720px] p-6'>
@@ -15,6 +32,7 @@ const meta: Meta<typeof SignInTemplate> = {
 export default meta
 type Story = StoryObj<typeof SignInTemplate>
 
+/** 기본 로그인 폼이 좌측에 배치된 예시. */
 export const Default: Story = {
   args: {
     children: (


### PR DESCRIPTION
- @storybook/addon-docs 도입 및 autodocs 전역 활성화(preview.ts)
- 32개 스토리에 컴포넌트 설명(JSDoc) + 상세 argTypes(설명/컨트롤/옵션/table) 추가
- 누락 상태 데모 스토리 보강(loading, empty, variant 등) → 스모크 64→94
- storybook-static gitignore 처리

https://claude.ai/code/session_013bHPg24sPPzWCSAS5rfZgR