### PR TITLE
docs(stories): 스토리 문서 글투를 사람이 쓴 것처럼 다듬기

### DIFF
--- a/src/renderer/src/components/atoms/Avatar/Avatar.stories.tsx
+++ b/src/renderer/src/components/atoms/Avatar/Avatar.stories.tsx
@@ -2,18 +2,17 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Avatar, AvatarFallback, AvatarImage } from './Avatar'
 
 /**
- * 사용자/멤버를 표현하는 원형 아바타. Radix Avatar 위에 Hydra 토큰을 입혔다.
- *
- * - `Avatar`는 `size-8` 원형 컨테이너이며 `className`으로 크기를 덮어쓴다.
- * - `AvatarImage`(src)가 로드되면 이미지를, 실패/미지정이면 `AvatarFallback`(이니셜)을 그라데이션 배경으로 보여준다.
- * - 합성 컴포넌트라 `Avatar` 루트에 노출할 의미 있는 prop은 `className`뿐이다.
+ * 멤버를 나타내는 원형 아바타로, Radix Avatar에 Hydra 토큰을 입힌 것이다. 기본은 size-8짜리 원이고
+ * 크기는 className으로 덮어쓴다. AvatarImage의 src가 잘 로드되면 그 이미지를 쓰고, 로드에 실패하거나
+ * src가 아예 없으면 AvatarFallback의 이니셜을 그라데이션 배경 위에 대신 보여준다. 합성 컴포넌트라
+ * 루트에서 만질 만한 건 className 정도다.
  */
 const meta: Meta<typeof Avatar> = {
   title: 'Atoms/Avatar',
   component: Avatar,
   argTypes: {
     className: {
-      description: '컨테이너 크기/모양 오버라이드. 기본은 size-8 원형이며 size-* 유틸로 키우거나 줄인다.',
+      description: '컨테이너 크기와 모양을 덮어쓴다. 기본 size-8에서 size-* 유틸로 키우거나 줄이면 된다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -22,7 +21,7 @@ const meta: Meta<typeof Avatar> = {
 export default meta
 type Story = StoryObj<typeof Avatar>
 
-/** 이미지 src가 정상 로드된 경우. 이미지가 fallback을 가린다. */
+/** src가 제대로 로드돼서 이미지가 fallback을 덮은 경우. */
 export const WithImage: Story = {
   render: () => (
     <Avatar>
@@ -32,7 +31,7 @@ export const WithImage: Story = {
   )
 }
 
-/** 이미지가 없을 때 이니셜 fallback(그라데이션 배경)이 표시된다. */
+/** 이미지가 없어서 이니셜 fallback이 그라데이션 배경으로 뜨는 모양. */
 export const Fallback: Story = {
   render: () => (
     <Avatar>
@@ -41,7 +40,7 @@ export const Fallback: Story = {
   )
 }
 
-/** className으로 크기를 키운 큰 아바타. 프로필 헤더 등에 사용한다. */
+/** className으로 키운 큰 아바타. 프로필 헤더처럼 크게 보여줄 자리에 쓴다. */
 export const Large: Story = {
   render: () => (
     <Avatar className='size-16'>

--- a/src/renderer/src/components/atoms/Badge/Badge.stories.tsx
+++ b/src/renderer/src/components/atoms/Badge/Badge.stories.tsx
@@ -2,11 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Badge } from './Badge'
 
 /**
- * 상태/라벨/카운트 등 짧은 메타 정보를 표시하는 알약형 태그. CVA로 variant·size·colorScheme 3축을 조합한다.
- *
- * - `variant`는 채움 방식(진한 채움/틴트/보더 등), `colorScheme`은 색 계열, `size`는 패딩/글자 크기를 정한다.
- * - 모든 조합은 AA 대비를 지키도록 동계열 텍스트 색을 사용한다(solid도 흰 전경 대신 어두운 동계열 텍스트).
- * - 선택적 `icon`을 children 앞에 렌더한다.
+ * 상태나 개수처럼 짧은 정보를 보여주는 알약 모양 태그다. 채우는 방식은 variant로, 색은
+ * colorScheme으로, 크기는 size로 고른다. 어떤 조합을 써도 글자색은 배경과 같은 계열의 진한
+ * 톤이라 대비가 충분하다. solid조차 흰 글자가 아니라 어두운 동계열 글자를 쓴다. icon을 넘기면
+ * 글자 왼쪽에 붙는다.
  */
 const meta: Meta<typeof Badge> = {
   title: 'Atoms/Badge',
@@ -14,7 +13,8 @@ const meta: Meta<typeof Badge> = {
   args: { children: 'Badge' },
   argTypes: {
     variant: {
-      description: '채움 스타일. solid=진한 동계열 채움, subtle/surface=틴트 배경, outline=보더, plain=배경 없음.',
+      description:
+        '채우는 방식. solid는 진하게 채우고, subtle과 surface는 옅게 깔고, outline은 테두리만, plain은 글자만 남긴다.',
       control: 'select',
       options: ['solid', 'subtle', 'outline', 'surface', 'plain'],
       table: {
@@ -23,13 +23,13 @@ const meta: Meta<typeof Badge> = {
       }
     },
     size: {
-      description: '패딩과 글자 크기. xs→lg 순으로 커진다.',
+      description: '크기. xs가 가장 작고 lg로 갈수록 커진다.',
       control: 'select',
       options: ['xs', 'sm', 'md', 'lg'],
       table: { type: { summary: 'xs | sm | md | lg' }, defaultValue: { summary: 'sm' } }
     },
     colorScheme: {
-      description: '색 계열. variant와 조합되어 배경/텍스트/보더 색을 결정한다.',
+      description: '색 계열. variant와 맞물려 배경과 글자, 테두리 색이 정해진다.',
       control: 'select',
       options: ['gray', 'red', 'orange', 'yellow', 'green', 'teal', 'blue', 'cyan', 'purple', 'pink'],
       table: {
@@ -38,12 +38,12 @@ const meta: Meta<typeof Badge> = {
       }
     },
     children: {
-      description: '뱃지에 표시할 텍스트/노드.',
+      description: '태그에 들어갈 텍스트나 노드.',
       control: 'text',
       table: { type: { summary: 'ReactNode' } }
     },
     icon: {
-      description: 'children 앞에 렌더할 선택적 아이콘 노드.',
+      description: '글자 앞에 붙일 아이콘. 없어도 된다.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     }
@@ -52,17 +52,17 @@ const meta: Meta<typeof Badge> = {
 export default meta
 type Story = StoryObj<typeof Badge>
 
-/** 기본값(subtle · sm · gray). 가장 흔한 메타 라벨용. */
+/** 가장 자주 보게 될 기본 모양. subtle, sm, gray 조합이다. */
 export const Default: Story = {}
 
-/** 보더만 그리는 outline variant. */
+/** 테두리만 두른 모양. */
 export const Outline: Story = { args: { variant: 'outline' } }
 
-/** 진한 동계열 채움(solid)에 색 계열을 적용한 예. */
+/** 진하게 채운 뒤 색을 입혀봤다. */
 export const Solid: Story = { args: { variant: 'solid', colorScheme: 'green', children: 'Open' } }
 
-/** colorScheme로 색 계열을 바꾼 subtle 뱃지. 상태 색 구분에 사용한다. */
+/** 색만 바꿔 상태를 구분하는 경우. */
 export const ColorScheme: Story = { args: { colorScheme: 'red', children: 'Blocked' } }
 
-/** size를 키운 큰 뱃지. */
+/** 한 단계 키운 뱃지. */
 export const Large: Story = { args: { size: 'lg' } }

--- a/src/renderer/src/components/atoms/Button/Button.stories.tsx
+++ b/src/renderer/src/components/atoms/Button/Button.stories.tsx
@@ -3,11 +3,10 @@ import { ArrowRight } from 'lucide-react'
 import { Button } from './Button'
 
 /**
- * 모든 클릭 액션의 기본 단위. shadcn/ui 버튼을 Hydra 토큰(gradient-primary, glow)으로 확장했다.
- *
- * - `variant`로 시각적 강조 수준을, `size`로 높이/패딩을 제어한다.
- * - `loading`이 true면 스피너 + "Please wait" 문구를 보여주고 자동으로 비활성화된다.
- * - `asChild`를 켜면 `<button>` 대신 자식 엘리먼트(예: `<a>`)에 스타일을 위임한다(Radix Slot).
+ * 클릭 액션의 기본 단위로, shadcn/ui 버튼에 Hydra 토큰인 gradient-primary와 glow를 더했다. 얼마나
+ * 강조할지는 variant로, 높이와 패딩은 size로 고른다. loading을 켜면 스피너와 함께 "Please wait"가 뜨고
+ * 그동안 클릭이 알아서 막힌다. asChild를 주면 button 대신 안에 넣은 엘리먼트, 가령 a 태그에 스타일만
+ * 얹는다.
  */
 const meta: Meta<typeof Button> = {
   title: 'Atoms/Button',
@@ -16,7 +15,7 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       description:
-        '시각적 강조 수준. 기본(gradient) → outline/secondary/ghost(보조) → destructive(파괴) → link(텍스트)',
+        '강조 정도. default가 그라데이션으로 가장 세고, outline이나 secondary, ghost는 보조용, destructive는 위험한 액션, link는 텍스트처럼 보인다.',
       control: 'select',
       options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
       table: {
@@ -25,60 +24,64 @@ const meta: Meta<typeof Button> = {
       }
     },
     size: {
-      description: '버튼 높이/패딩 프리셋. `icon`은 정사각형(아이콘 전용)',
+      description: '높이와 패딩 프리셋. icon은 아이콘 하나만 넣는 정사각형이다.',
       control: 'inline-radio',
       options: ['default', 'sm', 'lg', 'icon'],
       table: { type: { summary: 'default | sm | lg | icon' }, defaultValue: { summary: 'default' } }
     },
     loading: {
-      description: 'true면 스피너와 "Please wait"를 표시하고 클릭을 막는다.',
+      description: '켜면 스피너와 "Please wait"가 뜨면서 클릭이 막힌다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     asChild: {
-      description: '렌더 엘리먼트를 자식으로 위임(Radix Slot). 링크 등에 버튼 스타일을 입힐 때 사용.',
+      description: '실제 렌더는 안에 넣은 자식 엘리먼트가 맡는다. 링크에 버튼 모양을 입히고 싶을 때.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     disabled: {
-      description: '상호작용을 막고 50% 투명도로 표시한다.',
+      description: '누를 수 없게 막고 절반쯤 흐려진다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' } }
     },
-    children: { description: '버튼 라벨/내용', control: 'text', table: { type: { summary: 'ReactNode' } } }
+    children: {
+      description: '버튼 안에 들어가는 라벨이나 내용.',
+      control: 'text',
+      table: { type: { summary: 'ReactNode' } }
+    }
   }
 }
 export default meta
 type Story = StoryObj<typeof Button>
 
-/** 기본 그라데이션 버튼. 화면당 1개의 주요 액션에만 사용한다. */
+/** 기본 그라데이션 버튼. 화면에서 가장 중요한 액션 하나에만 쓰는 게 좋다. */
 export const Default: Story = {}
 
-/** 보조 액션용 — 테두리 + 배경 강조. */
+/** 테두리에 옅은 배경을 깐 보조 액션용. */
 export const Secondary: Story = { args: { variant: 'secondary' } }
 
-/** 삭제·취소 등 되돌리기 어려운 파괴적 액션. */
+/** 삭제처럼 한 번 누르면 되돌리기 힘든 액션. */
 export const Destructive: Story = { args: { variant: 'destructive', children: 'Delete' } }
 
-/** 중립적인 테두리 버튼. */
+/** 배경 없이 테두리만 두른 중립적인 버튼. */
 export const Outline: Story = { args: { variant: 'outline' } }
 
-/** 배경 없이 hover 시에만 강조되는 최소 강조 버튼. */
+/** 평소엔 밋밋하다가 hover할 때만 살짝 드러나는 버튼. */
 export const Ghost: Story = { args: { variant: 'ghost' } }
 
-/** 인라인 텍스트 링크처럼 보이는 버튼. */
+/** 본문 속 링크처럼 보이는 버튼. */
 export const Link: Story = { args: { variant: 'link', children: 'Learn more' } }
 
-/** 좁은 영역(툴바, 테이블 행)용 작은 버튼. */
+/** 툴바나 테이블 행처럼 좁은 자리에 들어가는 작은 버튼. */
 export const Small: Story = { args: { size: 'sm' } }
 
-/** 강조가 필요한 폼 제출 등에 쓰는 큰 버튼. */
+/** 폼 제출처럼 확실히 눈에 띄어야 하는 자리에 쓰는 큰 버튼. */
 export const Large: Story = { args: { size: 'lg' } }
 
-/** 비동기 처리 중 상태 — 클릭이 자동으로 막힌다. */
+/** 비동기 작업이 도는 동안의 모습. 그동안 클릭은 알아서 막힌다. */
 export const Loading: Story = { args: { loading: true } }
 
-/** 라벨과 함께 아이콘을 배치한 예시. */
+/** 라벨 옆에 아이콘을 같이 둔 경우. */
 export const WithIcon: Story = {
   args: {
     children: (

--- a/src/renderer/src/components/atoms/Card/Card.stories.tsx
+++ b/src/renderer/src/components/atoms/Card/Card.stories.tsx
@@ -2,18 +2,17 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './Card'
 
 /**
- * 콘텐츠를 묶어 시각적으로 구획하는 컨테이너. 둥근 모서리 + 보더 + `shadow-card`를 가진다.
- *
- * - 합성 컴포넌트 묶음이다: `CardHeader`(CardTitle/CardDescription/CardAction) · `CardContent` · `CardFooter`.
- * - `CardHeader`는 컨테이너 쿼리 그리드라 `CardAction`을 두면 우측 상단에 액션이 정렬된다.
- * - 모든 파트는 div 기반이라 의미 있는 prop은 `className`과 표준 div 속성뿐이다.
+ * 관련된 내용을 한 덩어리로 묶어 구획하는 컨테이너로, 둥근 모서리에 보더와 shadow-card가 붙는다.
+ * 여러 파트를 조합해 쓴다. 머리말은 CardHeader 안에 CardTitle이나 CardDescription, CardAction을 넣고,
+ * 본문은 CardContent, 맨 아래는 CardFooter다. CardHeader가 컨테이너 쿼리 그리드라 CardAction을 두면
+ * 액션이 우측 상단에 알아서 붙는다. 전부 div라 손댈 만한 건 className과 평범한 div 속성뿐이다.
  */
 const meta: Meta<typeof Card> = {
   title: 'Atoms/Card',
   component: Card,
   argTypes: {
     className: {
-      description: '카드 컨테이너의 폭/여백 등 레이아웃 오버라이드.',
+      description: '카드 폭이나 여백 같은 레이아웃을 덮어쓴다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -22,7 +21,7 @@ const meta: Meta<typeof Card> = {
 export default meta
 type Story = StoryObj<typeof Card>
 
-/** 헤더·본문·푸터를 모두 갖춘 기본 카드. */
+/** 머리말, 본문, 푸터를 다 갖춘 기본 카드. */
 export const Default: Story = {
   render: () => (
     <Card className='w-80'>
@@ -36,7 +35,7 @@ export const Default: Story = {
   )
 }
 
-/** CardAction을 헤더에 배치해 우측 상단 액션을 표시한 예. */
+/** 헤더에 CardAction을 넣어 우측 상단에 버튼을 붙인 경우. */
 export const WithAction: Story = {
   render: () => (
     <Card className='w-80'>

--- a/src/renderer/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/renderer/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -2,33 +2,31 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Checkbox } from './Checkbox'
 
 /**
- * 불리언 선택을 위한 체크박스. Radix Checkbox 기반이라 controlled/uncontrolled 모두 지원한다.
- *
- * - 체크 상태에서 `bg-primary` 배경 + 체크 아이콘을 표시한다.
- * - `checked`/`onCheckedChange`로 제어하거나 `defaultChecked`로 비제어 사용한다.
- * - `aria-invalid`로 오류 링을, `disabled`로 비활성 상태를 표현한다.
+ * 켜고 끄는 체크박스다. Radix 기반이라 checked로 직접 쥐고 흔들 수도 있고, defaultChecked만
+ * 넘기고 나머지는 맡겨둘 수도 있다. 켜지면 배경이 채워지면서 체크 표시가 뜬다. 오류는
+ * aria-invalid로 링을 둘러 알리고, disabled를 주면 잠긴다.
  */
 const meta: Meta<typeof Checkbox> = {
   title: 'Atoms/Checkbox',
   component: Checkbox,
   argTypes: {
     checked: {
-      description: '제어형 체크 상태. true/false 또는 부분선택을 위한 "indeterminate".',
+      description: '직접 제어할 때 쓰는 체크 상태. true/false 말고, 부분 선택을 뜻하는 "indeterminate"도 받는다.',
       control: 'boolean',
       table: { type: { summary: 'boolean | "indeterminate"' } }
     },
     defaultChecked: {
-      description: '비제어형 초기 체크 상태.',
+      description: '제어를 맡겨둘 때의 처음 상태.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     disabled: {
-      description: 'true면 상호작용을 막고 투명도를 낮춘다.',
+      description: '켜면 클릭이 막히고 흐릿해진다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     onCheckedChange: {
-      description: '체크 상태 변경 콜백.',
+      description: '체크가 바뀔 때마다 불린다.',
       control: false,
       table: { category: 'Events', type: { summary: '(checked: boolean | "indeterminate") => void' } }
     }
@@ -37,11 +35,11 @@ const meta: Meta<typeof Checkbox> = {
 export default meta
 type Story = StoryObj<typeof Checkbox>
 
-/** 비제어 기본 상태(미체크). */
+/** 아무것도 건드리지 않은 기본 상태. */
 export const Default: Story = {}
 
-/** 초기부터 체크된 상태. */
+/** 처음부터 켜져 있는 경우. */
 export const Checked: Story = { args: { defaultChecked: true } }
 
-/** 비활성화되어 클릭할 수 없는 상태. */
+/** 잠겨서 누를 수 없는 상태. */
 export const Disabled: Story = { args: { disabled: true } }

--- a/src/renderer/src/components/atoms/Collapsible/Collapsible.stories.tsx
+++ b/src/renderer/src/components/atoms/Collapsible/Collapsible.stories.tsx
@@ -2,33 +2,32 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './Collapsible'
 
 /**
- * 트리거를 눌러 영역을 펼치거나 접는 접이식 컨테이너. Radix Collapsible을 그대로 재노출한다.
- *
- * - `CollapsibleTrigger`를 클릭하면 `CollapsibleContent`가 토글된다.
- * - `open`/`onOpenChange`로 제어하거나 `defaultOpen`으로 초기 상태만 지정한다.
- * - 스타일이 없는 비스타일 프리미티브라 className으로 직접 꾸민다.
+ * 트리거를 눌러 영역을 접었다 펼치는 컨테이너로, Radix Collapsible을 그대로 다시 내보낸 것이다.
+ * CollapsibleTrigger를 클릭하면 CollapsibleContent가 토글된다. 열고 닫는 걸 직접 쥐려면 open과
+ * onOpenChange를 쓰고, 처음 상태만 정해두고 나머지를 맡기려면 defaultOpen만 넘기면 된다. 스타일이
+ * 없는 프리미티브라 모양은 className으로 직접 입혀야 한다.
  */
 const meta: Meta<typeof Collapsible> = {
   title: 'Atoms/Collapsible',
   component: Collapsible,
   argTypes: {
     open: {
-      description: '제어형 열림 상태.',
+      description: '열림 상태를 직접 쥐고 흔들 때.',
       control: 'boolean',
       table: { type: { summary: 'boolean' } }
     },
     defaultOpen: {
-      description: '비제어형 초기 열림 상태.',
+      description: '처음 열려 있을지만 정하고 나머지는 맡긴다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     disabled: {
-      description: 'true면 토글을 막는다.',
+      description: '켜면 토글이 막힌다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     onOpenChange: {
-      description: '열림 상태 변경 콜백.',
+      description: '열리거나 닫힐 때마다 불린다.',
       control: false,
       table: { category: 'Events', type: { summary: '(open: boolean) => void' } }
     }
@@ -37,7 +36,7 @@ const meta: Meta<typeof Collapsible> = {
 export default meta
 type Story = StoryObj<typeof Collapsible>
 
-/** 기본 접힘 상태에서 트리거로 토글한다. */
+/** 접힌 채로 시작해 트리거로 여닫는 기본 모양. */
 export const Default: Story = {
   render: () => (
     <Collapsible className='w-80'>
@@ -47,7 +46,7 @@ export const Default: Story = {
   )
 }
 
-/** defaultOpen으로 처음부터 펼쳐진 상태. */
+/** defaultOpen을 줘서 처음부터 펼쳐져 있는 경우. */
 export const DefaultOpen: Story = {
   render: () => (
     <Collapsible defaultOpen className='w-80'>

--- a/src/renderer/src/components/atoms/Input/Input.stories.tsx
+++ b/src/renderer/src/components/atoms/Input/Input.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Input } from './Input'
 
 /**
- * 한 줄 텍스트 입력 필드. 네이티브 `<input>`을 Hydra 토큰으로 감쌌다.
- *
- * - 표준 input 속성(`type`, `placeholder`, `value`, `disabled` 등)을 그대로 받는다.
- * - 포커스 시 ring, `aria-invalid`일 때 destructive 보더/ring을 보여준다.
- * - file 입력 스타일링도 내장되어 있다.
+ * 한 줄짜리 텍스트 입력 필드로, 네이티브 input을 Hydra 토큰으로 감싼 것이다. type이나 placeholder,
+ * value, disabled 같은 표준 input 속성은 그대로 넘기면 된다. 포커스가 가면 링이 둘리고, aria-invalid를
+ * 주면 보더와 링이 destructive 색으로 바뀐다. file 타입 스타일도 미리 들어가 있다.
  */
 const meta: Meta<typeof Input> = {
   title: 'Atoms/Input',
@@ -14,23 +12,23 @@ const meta: Meta<typeof Input> = {
   args: { placeholder: 'Type here…' },
   argTypes: {
     type: {
-      description: '입력 타입. text/password/email/number/file 등 네이티브 input type.',
+      description: '네이티브 input type 그대로. text나 password, email, number, file 등을 쓴다.',
       control: 'select',
       options: ['text', 'password', 'email', 'number', 'search', 'tel', 'url', 'file'],
       table: { type: { summary: 'HTMLInputTypeAttribute' }, defaultValue: { summary: 'text' } }
     },
     placeholder: {
-      description: '비어 있을 때 표시되는 안내 문구.',
+      description: '비어 있을 때 자리에 깔리는 안내 문구.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     disabled: {
-      description: 'true면 입력을 막고 투명도를 낮춘다.',
+      description: '켜면 입력이 막히고 흐릿해진다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     'aria-invalid': {
-      description: 'true면 오류 상태(destructive 보더/ring)로 표시한다.',
+      description: '켜면 보더와 링이 destructive 색으로 바뀌어 오류임을 알린다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' } }
     }
@@ -39,14 +37,14 @@ const meta: Meta<typeof Input> = {
 export default meta
 type Story = StoryObj<typeof Input>
 
-/** 기본 텍스트 입력. */
+/** 아무것도 건드리지 않은 기본 텍스트 입력. */
 export const Default: Story = {}
 
-/** 비활성화 상태. */
+/** 잠겨서 입력할 수 없는 상태. */
 export const Disabled: Story = { args: { disabled: true } }
 
-/** 비밀번호 입력 타입. */
+/** 입력값이 가려지는 비밀번호 타입. */
 export const Password: Story = { args: { type: 'password', placeholder: '••••••••' } }
 
-/** aria-invalid로 오류 상태를 표현한 입력. */
+/** aria-invalid를 켜서 오류로 보이게 한 경우. */
 export const Invalid: Story = { args: { 'aria-invalid': true, placeholder: '잘못된 값' } }

--- a/src/renderer/src/components/atoms/Label/Label.stories.tsx
+++ b/src/renderer/src/components/atoms/Label/Label.stories.tsx
@@ -3,10 +3,9 @@ import { Input } from '../Input'
 import { Label } from './Label'
 
 /**
- * 폼 컨트롤에 붙는 접근성 라벨. Radix Label 기반이라 `htmlFor`로 입력과 연결된다.
- *
- * - 연결된 입력이 disabled면(peer/group-data) 라벨도 흐려지고 클릭이 막힌다.
- * - `flex` + `gap-2`라 아이콘이나 보조 텍스트를 children으로 나란히 둘 수 있다.
+ * 폼 컨트롤에 붙이는 접근성 라벨로, Radix Label 기반이라 htmlFor로 입력과 묶인다. 연결된 입력이
+ * disabled면 peer와 group-data 덕에 라벨까지 같이 흐려지고 클릭도 막힌다. 안쪽이 flex에 gap-2라
+ * 아이콘이나 보조 텍스트를 children으로 나란히 넣어도 잘 붙는다.
  */
 const meta: Meta<typeof Label> = {
   title: 'Atoms/Label',
@@ -14,12 +13,12 @@ const meta: Meta<typeof Label> = {
   args: { children: 'Email' },
   argTypes: {
     htmlFor: {
-      description: '연결할 폼 컨트롤의 id. 클릭 시 해당 컨트롤에 포커스를 준다.',
+      description: '묶을 폼 컨트롤의 id. 라벨을 클릭하면 그 컨트롤로 포커스가 간다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     children: {
-      description: '라벨 텍스트/노드.',
+      description: '라벨에 들어가는 텍스트나 노드.',
       control: 'text',
       table: { type: { summary: 'ReactNode' } }
     }
@@ -28,10 +27,10 @@ const meta: Meta<typeof Label> = {
 export default meta
 type Story = StoryObj<typeof Label>
 
-/** 단독 라벨 텍스트. */
+/** 입력과 묶지 않고 텍스트만 둔 모양. */
 export const Default: Story = {}
 
-/** htmlFor로 입력과 연결한 예. 라벨 클릭 시 입력에 포커스된다. */
+/** htmlFor로 입력과 묶은 경우. 라벨을 누르면 입력으로 포커스가 간다. */
 export const WithInput: Story = {
   render: () => (
     <div className='grid w-72 gap-2'>

--- a/src/renderer/src/components/atoms/Separator/Separator.stories.tsx
+++ b/src/renderer/src/components/atoms/Separator/Separator.stories.tsx
@@ -2,23 +2,22 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Separator } from './Separator'
 
 /**
- * 콘텐츠를 시각적으로 가르는 1px 구분선. Radix Separator 기반이다.
- *
- * - `orientation`으로 가로/세로를 정한다(세로는 부모 높이를 채우므로 높이 있는 컨테이너 필요).
- * - 기본 `decorative=true`라 스크린리더에 노출되지 않는다. 의미상 분리가 필요하면 `decorative=false`.
+ * 콘텐츠 사이를 가르는 1px 구분선으로, Radix Separator 기반이다. orientation으로 가로나 세로를 정하는데,
+ * 세로선은 부모 높이를 따라가므로 높이가 잡힌 컨테이너 안에 둬야 보인다. 기본값인 decorative가 켜져 있어
+ * 스크린리더에는 안 잡히고, 의미상 꼭 나눠 읽혀야 하는 자리라면 decorative를 꺼주면 된다.
  */
 const meta: Meta<typeof Separator> = {
   title: 'Atoms/Separator',
   component: Separator,
   argTypes: {
     orientation: {
-      description: '구분선 방향. horizontal=가로 1px, vertical=세로 1px.',
+      description: '선의 방향. horizontal이면 가로로 눕고 vertical이면 세로로 선다.',
       control: 'inline-radio',
       options: ['horizontal', 'vertical'],
       table: { type: { summary: 'horizontal | vertical' }, defaultValue: { summary: 'horizontal' } }
     },
     decorative: {
-      description: 'true면 장식용으로 간주되어 접근성 트리에서 제외된다.',
+      description: '켜면 그냥 장식으로 보고 접근성 트리에서 빼버린다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } }
     }
@@ -27,7 +26,7 @@ const meta: Meta<typeof Separator> = {
 export default meta
 type Story = StoryObj<typeof Separator>
 
-/** 가로 구분선으로 위/아래 영역을 나눈다. */
+/** 가로선으로 위아래를 가른 모양. */
 export const Horizontal: Story = {
   render: () => (
     <div className='w-64'>
@@ -38,7 +37,7 @@ export const Horizontal: Story = {
   )
 }
 
-/** 세로 구분선으로 좌/우 영역을 나눈다. 부모에 높이가 필요하다. */
+/** 세로선으로 좌우를 가른 모양. 부모에 높이가 있어야 보인다. */
 export const Vertical: Story = {
   render: () => (
     <div className='flex h-8 items-center'>

--- a/src/renderer/src/components/atoms/Skeleton/Skeleton.stories.tsx
+++ b/src/renderer/src/components/atoms/Skeleton/Skeleton.stories.tsx
@@ -2,10 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Skeleton } from './Skeleton'
 
 /**
- * 로딩 중 콘텐츠 자리를 채우는 펄스 플레이스홀더. `animate-pulse`로 깜빡인다.
- *
- * - 크기/모양은 전적으로 `className`으로 지정한다(폭·높이·둥글기).
- * - 실제 콘텐츠와 비슷한 형태로 배치해 레이아웃 점프를 줄인다.
+ * 데이터가 오기 전 콘텐츠 자리를 미리 채워두는 플레이스홀더로, animate-pulse 덕에 은은하게 깜빡인다.
+ * 폭이든 높이든 둥글기든 모양은 전부 className으로 잡는다. 실제로 들어올 내용과 비슷한 형태로 깔아두면
+ * 로딩이 끝나는 순간 레이아웃이 덜컥 튀는 걸 줄일 수 있다.
  */
 const meta: Meta<typeof Skeleton> = {
   title: 'Atoms/Skeleton',
@@ -13,7 +12,7 @@ const meta: Meta<typeof Skeleton> = {
   parameters: { layout: 'centered' },
   argTypes: {
     className: {
-      description: '스켈레톤 크기/모양을 정하는 유틸리티 클래스(h-*, w-*, rounded-* 등).',
+      description: '크기와 모양을 잡는 유틸리티 클래스. h-*로 높이, w-*로 폭, rounded-*로 둥글기를 준다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -23,17 +22,17 @@ const meta: Meta<typeof Skeleton> = {
 export default meta
 type Story = StoryObj<typeof Skeleton>
 
-/** 한 줄 텍스트 폭의 막대 스켈레톤. */
+/** 한 줄 텍스트만 한 막대 모양. */
 export const Default: Story = {
   args: { className: 'h-6 w-40' }
 }
 
-/** 원형 스켈레톤. 아바타 자리에 사용한다. */
+/** 동그란 모양. 아바타 들어갈 자리에 깐다. */
 export const Circle: Story = {
   args: { className: 'h-12 w-12 rounded-full' }
 }
 
-/** 여러 스켈레톤을 조합해 카드 로딩 형태를 표현한 예. */
+/** 여러 개를 조합해 카드가 로딩되는 모습을 흉내 낸 경우. */
 export const CardPlaceholder: Story = {
   render: () => (
     <div className='flex w-72 items-center gap-3'>

--- a/src/renderer/src/components/atoms/Tabs/Tabs.stories.tsx
+++ b/src/renderer/src/components/atoms/Tabs/Tabs.stories.tsx
@@ -2,34 +2,33 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './Tabs'
 
 /**
- * 같은 영역에서 여러 패널을 전환하는 탭. Radix Tabs 기반의 합성 컴포넌트다.
- *
- * - `TabsList`/`TabsTrigger`(value)로 탭 버튼을, `TabsContent`(value)로 패널을 정의한다.
- * - 루트 `Tabs`는 `defaultValue`(비제어) 또는 `value`/`onValueChange`(제어)로 활성 탭을 정한다.
- * - 활성 트리거는 `bg-background` + 그림자로 강조된다.
+ * 한 자리에서 여러 패널을 갈아 끼우는 탭으로, Radix Tabs 기반의 합성 컴포넌트다. 탭 버튼은 TabsList
+ * 안에 TabsTrigger를 넣어 만들고, 각 버튼의 value와 같은 value를 가진 TabsContent가 그 패널이 된다.
+ * 어느 탭이 켜질지는 루트 Tabs에서 정하는데, 처음 값만 던지려면 defaultValue를, 직접 쥐려면 value와
+ * onValueChange를 쓴다. 켜진 트리거는 bg-background에 그림자가 붙어 도드라진다.
  */
 const meta: Meta<typeof Tabs> = {
   title: 'Atoms/Tabs',
   component: Tabs,
   argTypes: {
     defaultValue: {
-      description: '비제어형 초기 활성 탭 value.',
+      description: '처음 켜둘 탭의 value만 정하고 나머지는 맡긴다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     value: {
-      description: '제어형 활성 탭 value.',
+      description: '활성 탭을 직접 쥐고 있을 때의 value.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     orientation: {
-      description: '탭 배치 방향. 키보드 내비게이션 축에 영향을 준다.',
+      description: '탭이 늘어서는 방향. 방향키로 이동하는 축도 여기 따라간다.',
       control: 'inline-radio',
       options: ['horizontal', 'vertical'],
       table: { type: { summary: 'horizontal | vertical' }, defaultValue: { summary: 'horizontal' } }
     },
     onValueChange: {
-      description: '활성 탭 변경 콜백.',
+      description: '다른 탭으로 바뀔 때마다 불린다.',
       control: false,
       table: { category: 'Events', type: { summary: '(value: string) => void' } }
     }
@@ -38,7 +37,7 @@ const meta: Meta<typeof Tabs> = {
 export default meta
 type Story = StoryObj<typeof Tabs>
 
-/** 두 개의 탭을 전환하는 기본 예시. */
+/** 탭 두 개를 오가는 기본 모양. */
 export const Default: Story = {
   render: () => (
     <Tabs defaultValue='overview' className='w-80'>
@@ -52,7 +51,7 @@ export const Default: Story = {
   )
 }
 
-/** 세 개 이상의 탭과 비활성(disabled) 트리거를 포함한 예. */
+/** 탭이 셋 이상이고 그중 하나는 disabled로 잠긴 경우. */
 export const ManyTabs: Story = {
   render: () => (
     <Tabs defaultValue='issues' className='w-96'>

--- a/src/renderer/src/components/atoms/Textarea/Textarea.stories.tsx
+++ b/src/renderer/src/components/atoms/Textarea/Textarea.stories.tsx
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Textarea } from './Textarea'
 
 /**
- * 여러 줄 텍스트 입력 필드. 네이티브 `<textarea>`를 Hydra 토큰으로 감쌌다.
- *
- * - `field-sizing-content`라 내용에 맞춰 높이가 자라며 최소 `min-h-16`을 유지한다.
- * - 표준 textarea 속성(`placeholder`, `value`, `rows`, `disabled` 등)을 그대로 받는다.
- * - 포커스 ring, `aria-invalid` 오류 스타일을 내장한다.
+ * 여러 줄을 입력하는 필드로, 네이티브 textarea를 Hydra 토큰으로 감싼 것이다. field-sizing-content라
+ * 내용이 늘면 높이도 따라 자라되 min-h-16 밑으로는 안 내려간다. placeholder나 value, rows, disabled
+ * 같은 표준 textarea 속성은 그대로 넘기면 되고, 포커스 링이나 aria-invalid 오류 스타일도 들어가 있다.
  */
 const meta: Meta<typeof Textarea> = {
   title: 'Atoms/Textarea',
@@ -14,22 +12,22 @@ const meta: Meta<typeof Textarea> = {
   args: { placeholder: 'Write a description…' },
   argTypes: {
     placeholder: {
-      description: '비어 있을 때 표시되는 안내 문구.',
+      description: '비어 있을 때 자리에 깔리는 안내 문구.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     rows: {
-      description: '초기 표시 행 수. 내용에 따라 더 늘어날 수 있다.',
+      description: '처음 보여줄 행 수. 내용이 많아지면 더 늘어난다.',
       control: 'number',
       table: { type: { summary: 'number' } }
     },
     disabled: {
-      description: 'true면 입력을 막고 투명도를 낮춘다.',
+      description: '켜면 입력이 막히고 흐릿해진다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     'aria-invalid': {
-      description: 'true면 오류 상태(destructive 보더/ring)로 표시한다.',
+      description: '켜면 보더와 링이 destructive 색으로 바뀌어 오류임을 알린다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' } }
     }
@@ -38,13 +36,13 @@ const meta: Meta<typeof Textarea> = {
 export default meta
 type Story = StoryObj<typeof Textarea>
 
-/** 기본 textarea. */
+/** 아무것도 건드리지 않은 기본 모양. */
 export const Default: Story = {}
 
-/** 비활성화 상태. */
+/** 잠겨서 입력할 수 없는 상태. */
 export const Disabled: Story = { args: { disabled: true } }
 
-/** 초기 내용이 채워진 textarea. */
+/** 처음부터 내용이 채워져 있는 경우. */
 export const WithValue: Story = {
   args: { defaultValue: '여러 줄에 걸친\n설명 텍스트입니다.' }
 }

--- a/src/renderer/src/components/atoms/Tooltip/Tooltip.stories.tsx
+++ b/src/renderer/src/components/atoms/Tooltip/Tooltip.stories.tsx
@@ -2,34 +2,32 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './Tooltip'
 
 /**
- * 트리거에 호버/포커스하면 짧은 보조 설명을 띄우는 툴팁. Radix Tooltip 기반이다.
- *
- * - `TooltipTrigger`(트리거 요소) + `TooltipContent`(말풍선)로 구성한다.
- * - 루트 `Tooltip`이 자체 `TooltipProvider`를 감싸므로 단독 사용이 가능하지만,
- *   `delayDuration`을 공유하려면 상위에 `TooltipProvider`를 두는 것이 좋다(기본 delay 0).
- * - `TooltipContent`의 `side`/`sideOffset`로 위치를 조정한다.
+ * 트리거에 마우스를 올리거나 포커스가 가면 짧은 설명을 띄우는 툴팁으로, Radix Tooltip 기반이다.
+ * 트리거 역할인 TooltipTrigger와 말풍선인 TooltipContent를 짝지어 쓴다. 루트 Tooltip이 안에서
+ * TooltipProvider를 감싸주니 단독으로도 동작하지만, 여러 툴팁이 delayDuration을 함께 쓰게 하려면
+ * 상위에 TooltipProvider를 한 번 두는 편이 낫다. 뜨는 위치는 TooltipContent의 side와 sideOffset으로 잡는다.
  */
 const meta: Meta<typeof Tooltip> = {
   title: 'Atoms/Tooltip',
   component: Tooltip,
   argTypes: {
     open: {
-      description: '제어형 열림 상태.',
+      description: '열고 닫는 걸 직접 쥐고 있을 때.',
       control: 'boolean',
       table: { type: { summary: 'boolean' } }
     },
     defaultOpen: {
-      description: '비제어형 초기 열림 상태.',
+      description: '처음 열려 있을지만 정하고 나머지는 맡긴다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     delayDuration: {
-      description: '호버 후 툴팁이 뜨기까지의 지연(ms). Provider 기본은 0이다.',
+      description: '마우스를 올리고 툴팁이 뜨기까지 기다리는 시간. Provider 기본값은 0이다.',
       control: 'number',
       table: { type: { summary: 'number' }, defaultValue: { summary: '0' } }
     },
     onOpenChange: {
-      description: '열림 상태 변경 콜백.',
+      description: '열리거나 닫힐 때마다 불린다.',
       control: false,
       table: { category: 'Events', type: { summary: '(open: boolean) => void' } }
     }
@@ -38,7 +36,7 @@ const meta: Meta<typeof Tooltip> = {
 export default meta
 type Story = StoryObj<typeof Tooltip>
 
-/** 트리거에 호버하면 말풍선이 뜨는 기본 예시. */
+/** 트리거에 마우스를 올리면 말풍선이 뜨는 기본 모양. */
 export const Default: Story = {
   render: () => (
     <TooltipProvider>
@@ -50,7 +48,7 @@ export const Default: Story = {
   )
 }
 
-/** side로 툴팁이 트리거 오른쪽에 뜨도록 한 예. */
+/** side를 줘서 툴팁을 트리거 오른쪽에 띄운 경우. */
 export const SidePlacement: Story = {
   render: () => (
     <TooltipProvider>

--- a/src/renderer/src/components/atoms/charts/AreaTrendChart/AreaTrendChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/AreaTrendChart/AreaTrendChart.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { AreaTrendChart } from './AreaTrendChart'
 
 /**
- * 시간 흐름에 따른 추세를 그라데이션 면적 차트로 보여준다. 여러 시리즈를 겹쳐 그릴 수 있어
- * 생성/완료 이슈처럼 둘 이상의 추세를 비교할 때 적합하다. X축은 데이터의 `name` 키를 사용하고,
- * 각 시리즈는 `lines`로 dataKey·색상·그라데이션 id를 지정한다.
+ * 시간 흐름을 그라데이션 면적으로 깔아 추세를 보여주는 차트다. 시리즈를 여러 개 겹칠 수 있어서
+ * 생성 이슈와 완료 이슈를 나란히 비교하는 식으로 쓴다. X축은 데이터의 name 키를 그대로 쓰고, 어떤
+ * 값을 무슨 색과 그라데이션으로 그릴지는 lines에서 시리즈별로 잡는다.
  */
 const meta: Meta<typeof AreaTrendChart> = {
   title: 'Atoms/Charts/AreaTrendChart',
@@ -18,20 +18,20 @@ const meta: Meta<typeof AreaTrendChart> = {
   ],
   argTypes: {
     data: {
-      description: '시계열 데이터 배열. 각 항목은 X축 라벨이 되는 { name } + lines의 dataKey에 대응하는 숫자 필드.',
+      description: '시계열 데이터. 항목마다 X축 라벨이 될 name과, lines의 dataKey가 가리키는 숫자 필드를 담는다.',
       control: 'object',
       table: { type: { summary: 'Array<{ name: string; [key: string]: string | number }>' } }
     },
     lines: {
       description:
-        '그릴 면적 시리즈 정의. 각 항목은 { dataKey, name?, color, gradientId }. color는 CSS 변수 권장, gradientId는 시리즈마다 고유해야 한다.',
+        '그릴 면적 시리즈들. 항목은 dataKey와 name, color, gradientId로 이뤄진다. color는 CSS 변수를 쓰는 게 좋고 gradientId는 시리즈마다 달라야 한다.',
       control: 'object',
       table: {
         type: { summary: 'Array<{ dataKey: string; name?: string; color: string; gradientId: string }>' }
       }
     },
     height: {
-      description: '차트 높이(px).',
+      description: '차트 높이.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
     }
@@ -40,7 +40,7 @@ const meta: Meta<typeof AreaTrendChart> = {
 export default meta
 type Story = StoryObj<typeof AreaTrendChart>
 
-/** 생성/완료 두 시리즈를 겹쳐 보여주는 기본 예시. */
+/** 생성과 완료 두 시리즈를 겹쳐 둔 기본 모양. */
 export const Default: Story = {
   args: {
     data: [
@@ -57,7 +57,7 @@ export const Default: Story = {
   }
 }
 
-/** 시리즈가 하나뿐인 단일 추세 예시. */
+/** 시리즈가 하나뿐일 때. */
 export const SingleLine: Story = {
   args: {
     data: [
@@ -70,7 +70,7 @@ export const SingleLine: Story = {
   }
 }
 
-/** 데이터가 비어 있을 때. 축만 그려지고 면적은 표시되지 않는다. */
+/** 데이터가 없으면 축만 남고 면적은 안 그려진다. */
 export const Empty: Story = {
   args: {
     data: [],

--- a/src/renderer/src/components/atoms/charts/BubbleChart/BubbleChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/BubbleChart/BubbleChart.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { BubbleChart } from './BubbleChart'
 
 /**
- * 세 개의 축(X 카테고리/숫자, Y 값, Z 버블 크기)으로 데이터를 산점도 버블로 표현한다.
- * 예를 들어 이슈 유형별 중요도(Y)와 개수(버블 크기)를 동시에 비교할 때 사용한다.
- * 색상은 토큰을 런타임 hex로 읽어 라이트/다크 테마를 자동으로 따른다.
+ * 세 축으로 데이터를 흩뿌리는 산점도다. X는 카테고리나 숫자, Y는 값, 버블 크기는 또 다른 값이
+ * 맡는다. 이슈 유형별로 중요도는 Y에, 개수는 버블 크기에 태워 한눈에 비교하는 식으로 쓴다. 색은
+ * 토큰을 런타임 hex로 읽어 라이트와 다크 테마를 알아서 따라간다.
  */
 const meta: Meta<typeof BubbleChart> = {
   title: 'Atoms/Charts/BubbleChart',
@@ -19,17 +19,17 @@ const meta: Meta<typeof BubbleChart> = {
   argTypes: {
     data: {
       description:
-        '버블 데이터 배열. 각 항목은 { name, value, count }(+추가 필드 허용). 기본 설정에서 name→X, value→Y, count→버블 크기에 매핑된다.',
+        '버블 데이터. 항목은 name, value, count로 이뤄지고 필드를 더 붙여도 된다. 기본 설정에서는 name이 X축, value가 Y축, count가 버블 크기로 들어간다.',
       control: 'object',
       table: { type: { summary: 'Array<{ name: string; value: number; count: number }>' } }
     },
     colors: {
-      description: '버블 색상 배열. 인덱스를 순환 적용한다. 미지정 시 차트 토큰 기반 기본 팔레트.',
+      description: '버블 색상. 인덱스를 돌려가며 적용하고, 안 주면 차트 토큰 기반 기본 팔레트를 쓴다.',
       control: 'object',
       table: { type: { summary: 'string[]' }, defaultValue: { summary: '토큰 기반 기본 팔레트' } }
     },
     height: {
-      description: '차트 높이(px).',
+      description: '차트 높이.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
     },
@@ -42,7 +42,7 @@ const meta: Meta<typeof BubbleChart> = {
       }
     },
     xAxisConfig: {
-      description: 'X축 설정. { dataKey, name, type }. type은 카테고리/숫자 축을 결정한다.',
+      description: 'X축 설정. dataKey와 name을 잡고, type으로 카테고리 축인지 숫자 축인지 정한다.',
       control: 'object',
       table: {
         type: { summary: "{ dataKey: string; name: string; type: 'category' | 'number' }" },
@@ -50,7 +50,7 @@ const meta: Meta<typeof BubbleChart> = {
       }
     },
     yAxisConfig: {
-      description: 'Y축 설정. { dataKey, name }. 항상 숫자 축이다.',
+      description: 'Y축 설정. dataKey와 name을 잡으며 언제나 숫자 축이다.',
       control: 'object',
       table: {
         type: { summary: '{ dataKey: string; name: string }' },
@@ -58,7 +58,7 @@ const meta: Meta<typeof BubbleChart> = {
       }
     },
     zAxisConfig: {
-      description: 'Z축(버블 크기) 설정. { dataKey, name, range }. range는 [최소, 최대] 픽셀 크기.',
+      description: '버블 크기를 정하는 Z축 설정. dataKey와 name을 잡고, range로 버블의 최소와 최대 크기를 준다.',
       control: 'object',
       table: {
         type: { summary: '{ dataKey: string; name: string; range: [number, number] }' },
@@ -66,7 +66,7 @@ const meta: Meta<typeof BubbleChart> = {
       }
     },
     tooltipFormatter: {
-      description: '툴팁 값 포매터. (value, name) => [표시값, 표시라벨].',
+      description: '툴팁 값 포매터. value와 name을 받아 화면에 띄울 값과 라벨을 돌려준다.',
       control: false,
       table: { type: { summary: '(value: any, name: string) => [string, string]' } }
     }
@@ -75,7 +75,7 @@ const meta: Meta<typeof BubbleChart> = {
 export default meta
 type Story = StoryObj<typeof BubbleChart>
 
-/** 이슈 유형별 중요도(Y)와 개수(버블 크기) 기본 예시. */
+/** 이슈 유형별로 중요도는 Y에, 개수는 버블 크기에 태운 기본 모양. */
 export const Default: Story = {
   args: {
     data: [
@@ -87,7 +87,7 @@ export const Default: Story = {
   }
 }
 
-/** 단색 팔레트로 모든 버블을 동일 색상으로 통일한 예시. */
+/** 팔레트를 한 색만 줘서 버블 색을 통일한 경우. */
 export const SingleColor: Story = {
   args: {
     data: [
@@ -99,7 +99,7 @@ export const SingleColor: Story = {
   }
 }
 
-/** 데이터가 비어 있을 때. 축만 그려지고 버블은 표시되지 않는다. */
+/** 데이터가 없으면 축만 남고 버블은 안 그려진다. */
 export const Empty: Story = {
   args: {
     data: []

--- a/src/renderer/src/components/atoms/charts/HorizontalBarChart/HorizontalBarChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/HorizontalBarChart/HorizontalBarChart.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { HorizontalBarChart } from './HorizontalBarChart'
 
 /**
- * 카테고리별 값을 가로 막대로 보여준다(세로 레이아웃 BarChart). 라벨이 긴 항목을
- * 비교하기 좋아 담당자별/프로젝트별 이슈 수 같은 순위형 데이터에 적합하다.
- * 단색 또는 가로 그라데이션(gradientId + gradientColors)으로 막대를 채울 수 있다.
+ * 카테고리별 값을 가로로 누운 막대로 보여준다. 라벨이 긴 항목도 잘 들어가서 담당자별이나
+ * 프로젝트별 이슈 수처럼 순위를 매기는 데이터에 잘 맞는다. 막대는 단색으로 채워도 되고, gradientId와
+ * gradientColors를 같이 주면 가로 그라데이션으로도 채울 수 있다.
  */
 const meta: Meta<typeof HorizontalBarChart> = {
   title: 'Atoms/Charts/HorizontalBarChart',
@@ -18,7 +18,7 @@ const meta: Meta<typeof HorizontalBarChart> = {
   ],
   argTypes: {
     data: {
-      description: '막대 데이터 배열. 각 항목은 Y축 라벨 { name } + dataKey에 대응하는 숫자 필드.',
+      description: '막대 데이터. 항목마다 Y축 라벨이 될 name과, dataKey가 가리키는 숫자 필드를 담는다.',
       control: 'object',
       table: { type: { summary: 'Array<{ name: string; [key: string]: string | number }>' } }
     },
@@ -28,32 +28,32 @@ const meta: Meta<typeof HorizontalBarChart> = {
       table: { type: { summary: 'string' } }
     },
     fill: {
-      description: '막대 단색 채움. gradientId가 없을 때 사용된다. 기본값은 --chart-1 토큰의 런타임 hex.',
+      description: '막대를 채우는 단색. gradientId가 없을 때 쓰이고, 기본값은 --chart-1 토큰의 런타임 hex다.',
       control: 'color',
       table: { type: { summary: 'string' }, defaultValue: { summary: 'var(--chart-1)' } }
     },
     gradientId: {
-      description: '그라데이션 채움 id. gradientColors와 함께 지정하면 fill 대신 그라데이션을 적용한다.',
+      description: '그라데이션 채움 id. gradientColors와 같이 주면 fill 대신 그라데이션이 적용된다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     gradientColors: {
-      description: '가로 그라데이션 시작/끝 색상. { start, end }.',
+      description: '가로 그라데이션의 시작 색과 끝 색.',
       control: 'object',
       table: { type: { summary: '{ start: string; end: string }' } }
     },
     height: {
-      description: '차트 높이(px).',
+      description: '차트 높이.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
     },
     yAxisWidth: {
-      description: 'Y축(라벨) 영역 너비(px).',
+      description: '라벨이 들어가는 Y축 영역 너비.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '80' } }
     },
     barSize: {
-      description: '막대 두께(px).',
+      description: '막대 두께.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '14' } }
     },
@@ -66,12 +66,12 @@ const meta: Meta<typeof HorizontalBarChart> = {
       }
     },
     domain: {
-      description: 'X축(값) 범위 [최소, 최대]. 미지정 시 데이터에 맞춰 자동 계산.',
+      description: '값을 그리는 X축의 최소와 최대 범위. 안 주면 데이터에 맞춰 알아서 잡힌다.',
       control: 'object',
       table: { type: { summary: '[number, number]' } }
     },
     formatter: {
-      description: '툴팁 값 포매터. (value) => [표시값, 표시라벨].',
+      description: '툴팁 값 포매터. value를 받아 화면에 띄울 값과 라벨을 돌려준다.',
       control: false,
       table: { type: { summary: '(value: any) => [string, string]' } }
     }
@@ -80,7 +80,7 @@ const meta: Meta<typeof HorizontalBarChart> = {
 export default meta
 type Story = StoryObj<typeof HorizontalBarChart>
 
-/** 담당자별 이슈 수 기본 예시. */
+/** 담당자별 이슈 수를 보여주는 기본 모양. */
 export const Default: Story = {
   args: {
     dataKey: 'count',
@@ -93,7 +93,7 @@ export const Default: Story = {
   }
 }
 
-/** 가로 그라데이션으로 막대를 채운 예시. */
+/** 막대를 가로 그라데이션으로 채운 경우. */
 export const Gradient: Story = {
   args: {
     dataKey: 'count',
@@ -107,7 +107,7 @@ export const Gradient: Story = {
   }
 }
 
-/** 데이터가 비어 있을 때. 축만 그려지고 막대는 표시되지 않는다. */
+/** 데이터가 없으면 축만 남고 막대는 안 그려진다. */
 export const Empty: Story = {
   args: {
     dataKey: 'count',

--- a/src/renderer/src/components/atoms/charts/StackedBarChart/StackedBarChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/StackedBarChart/StackedBarChart.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { StackedBarChart } from './StackedBarChart'
 
 /**
- * 여러 시리즈를 같은 stackId로 쌓아 누적 막대로 보여준다. 스프린트별 done/in-progress처럼
- * 부분 합과 전체 합을 함께 비교할 때 사용한다. layout으로 가로(vertical)/세로(horizontal)
- * 막대를 전환할 수 있고, 각 막대는 bars 설정으로 dataKey·색상·모서리 반경을 지정한다.
+ * 같은 stackId를 가진 시리즈들을 위로 쌓아 누적 막대로 보여준다. 스프린트마다 done과 in-progress를
+ * 한 막대에 쌓아 부분 합과 전체 합을 같이 보는 식으로 쓴다. layout을 vertical로 두면 막대가 가로로,
+ * horizontal로 두면 세로로 눕고, 막대별 dataKey와 색, 모서리 반경은 bars에서 잡는다.
  */
 const meta: Meta<typeof StackedBarChart> = {
   title: 'Atoms/Charts/StackedBarChart',
@@ -18,13 +18,13 @@ const meta: Meta<typeof StackedBarChart> = {
   ],
   argTypes: {
     data: {
-      description: '막대 데이터 배열. 각 항목은 축 라벨 { name } + bars의 dataKey에 대응하는 숫자 필드.',
+      description: '막대 데이터. 항목마다 축 라벨이 될 name과, bars의 dataKey가 가리키는 숫자 필드를 담는다.',
       control: 'object',
       table: { type: { summary: 'Array<{ name: string; [key: string]: string | number }>' } }
     },
     bars: {
       description:
-        '쌓을 막대 시리즈 정의. 각 항목은 { dataKey, stackId, fill, radius? }. 같은 stackId끼리 누적되며 fill은 CSS 변수 권장.',
+        '쌓을 막대 시리즈들. 항목은 dataKey와 stackId, fill로 이뤄지고 radius는 선택이다. stackId가 같은 것끼리 누적되며 fill은 CSS 변수를 쓰는 게 좋다.',
       control: 'object',
       table: {
         type: {
@@ -34,23 +34,23 @@ const meta: Meta<typeof StackedBarChart> = {
       }
     },
     layout: {
-      description: '막대 방향. vertical은 가로 막대, horizontal은 세로 막대.',
+      description: '막대 방향. vertical이면 가로로 눕고 horizontal이면 세로로 선다.',
       control: 'inline-radio',
       options: ['vertical', 'horizontal'],
       table: { type: { summary: "'vertical' | 'horizontal'" }, defaultValue: { summary: "'vertical'" } }
     },
     height: {
-      description: '차트 높이(px).',
+      description: '차트 높이.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
     },
     yAxisWidth: {
-      description: 'Y축(라벨) 영역 너비(px). vertical 레이아웃에서 의미 있다.',
+      description: '라벨이 들어가는 Y축 영역 너비. vertical 레이아웃에서만 의미가 있다.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '80' } }
     },
     barSize: {
-      description: '막대 두께(px).',
+      description: '막대 두께.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '14' } }
     },
@@ -67,7 +67,7 @@ const meta: Meta<typeof StackedBarChart> = {
 export default meta
 type Story = StoryObj<typeof StackedBarChart>
 
-/** 스프린트별 done/in-progress 누적 막대 기본 예시(가로 막대). */
+/** 스프린트별 done과 in-progress를 쌓은 기본 모양, 가로 막대다. */
 export const Default: Story = {
   args: {
     data: [
@@ -82,7 +82,7 @@ export const Default: Story = {
   }
 }
 
-/** 세로 막대(horizontal) 레이아웃 예시. */
+/** layout을 horizontal로 둬서 막대를 세로로 세운 경우. */
 export const Horizontal: Story = {
   args: {
     layout: 'horizontal',
@@ -98,7 +98,7 @@ export const Horizontal: Story = {
   }
 }
 
-/** 데이터가 비어 있을 때. 축과 범례만 그려지고 막대는 표시되지 않는다. */
+/** 데이터가 없으면 축과 범례만 남고 막대는 안 그려진다. */
 export const Empty: Story = {
   args: {
     data: [],

--- a/src/renderer/src/components/atoms/charts/StatusDonutChart/StatusDonutChart.stories.tsx
+++ b/src/renderer/src/components/atoms/charts/StatusDonutChart/StatusDonutChart.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { StatusDonutChart } from './StatusDonutChart'
 
 /**
- * 상태별 이슈 분포를 도넛 차트로 보여준다. 각 조각의 색상은 데이터가 직접 지정하며,
- * 가운데가 비어 있어 범례나 합계 텍스트를 함께 배치하기 좋다.
- * 프로젝트 대시보드에서 Backlog/In Progress/Done 같은 상태 비중을 한눈에 비교할 때 사용한다.
+ * 상태별 이슈 분포를 도넛으로 보여준다. 조각 색은 데이터에 직접 적어 넣고, 가운데가 뚫려 있어서
+ * 그 자리에 범례나 합계 텍스트를 얹기 좋다. 프로젝트 대시보드에서 Backlog, In Progress, Done 같은
+ * 상태 비중을 한눈에 견주는 데 쓴다.
  */
 const meta: Meta<typeof StatusDonutChart> = {
   title: 'Atoms/Charts/StatusDonutChart',
@@ -18,17 +18,18 @@ const meta: Meta<typeof StatusDonutChart> = {
   ],
   argTypes: {
     data: {
-      description: '도넛 조각 배열. 각 항목은 { name, value, color }. color는 CSS 변수(var(--chart-1)) 권장.',
+      description:
+        '도넛 조각들. 항목은 name과 value, color로 이뤄지고 color는 var(--chart-1) 같은 CSS 변수를 쓰는 게 좋다.',
       control: 'object',
       table: { type: { summary: 'Array<{ name: string; value: number; color: string }>' } }
     },
     height: {
-      description: '차트 높이(px). innerRadius/outerRadius가 이 값에 비례해 계산된다.',
+      description: '차트 높이. 안쪽과 바깥쪽 반지름이 이 값에 비례해 잡힌다.',
       control: { type: 'number' },
       table: { type: { summary: 'number' }, defaultValue: { summary: '200' } }
     },
     showLabels: {
-      description: '각 조각에 백분율 라벨을 표시할지 여부.',
+      description: '조각마다 백분율 라벨을 띄울지 여부.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } }
     }
@@ -37,7 +38,7 @@ const meta: Meta<typeof StatusDonutChart> = {
 export default meta
 type Story = StoryObj<typeof StatusDonutChart>
 
-/** 기본 상태 분포 예시. */
+/** 상태 분포를 보여주는 기본 모양. */
 export const Default: Story = {
   args: {
     data: [
@@ -49,7 +50,7 @@ export const Default: Story = {
   }
 }
 
-/** 백분율 라벨을 숨긴 형태. 범례를 외부에 따로 둘 때 적합하다. */
+/** 백분율 라벨을 끈 모양. 범례를 바깥에 따로 둘 때 쓴다. */
 export const WithoutLabels: Story = {
   args: {
     data: [
@@ -61,7 +62,7 @@ export const WithoutLabels: Story = {
   }
 }
 
-/** 데이터가 비어 있을 때. 조각 없이 빈 도넛 영역만 렌더된다. */
+/** 데이터가 없으면 조각 없이 빈 도넛 자리만 남는다. */
 export const Empty: Story = {
   args: {
     data: []

--- a/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.stories.tsx
+++ b/src/renderer/src/components/molecules/ActivityTimeline/ActivityTimeline.stories.tsx
@@ -14,9 +14,9 @@ const sample = (over: Partial<ActivityLogRecord>): ActivityLogRecord => ({
 })
 
 /**
- * 이슈의 활동 로그(상태 변경 / 담당자 변경 / 댓글 작성)를 시간순 목록으로 표시하는 컴포넌트.
- * 각 항목은 `activity_action`과 `activity_metadata`를 사람이 읽을 문장으로 변환해 보여준다.
- * 로딩 중이거나 활동이 없을 때는 안내 문구를 대신 렌더한다.
+ * 이슈에 쌓인 활동 로그를 시간순으로 늘어놓는다. 상태나 담당자 변경, 댓글 작성 같은 기록을
+ * 다루는데, 각 줄은 activity_action과 activity_metadata를 사람이 읽을 만한 문장으로 바꿔 보여준다.
+ * 불러오는 중이거나 아직 활동이 하나도 없으면 목록 대신 짤막한 안내 문구만 뜬다.
  */
 const meta: Meta<typeof ActivityTimeline> = {
   title: 'Molecules/ActivityTimeline',
@@ -24,12 +24,12 @@ const meta: Meta<typeof ActivityTimeline> = {
   argTypes: {
     activities: {
       description:
-        '표시할 활동 로그 배열. 각 항목은 ActivityLogRecord(activity_id, activity_action, activity_metadata, activity_created_at 등)이며 status_changed/assigned는 metadata의 from→to를, comment_created는 고정 문구를 렌더한다.',
+        '보여줄 활동 로그 배열. status_changed나 assigned면 metadata를 읽어 무엇이 어떻게 바뀌었는지 적고, comment_created는 정해진 문구를 쓴다.',
       control: 'object',
       table: { type: { summary: 'ActivityLogRecord[]' } }
     },
     isLoading: {
-      description: 'true이면 활동 대신 로딩 안내 문구를 표시한다.',
+      description: '켜면 활동 목록 대신 불러오는 중이라는 문구를 띄운다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     }
@@ -38,7 +38,7 @@ const meta: Meta<typeof ActivityTimeline> = {
 export default meta
 type Story = StoryObj<typeof ActivityTimeline>
 
-/** 상태 변경 + 댓글 작성 활동이 섞인 기본 타임라인. */
+/** 상태 변경과 댓글 작성이 섞여 있는 흔한 타임라인. */
 export const Default: Story = {
   args: {
     activities: [
@@ -51,8 +51,8 @@ export const Default: Story = {
   }
 }
 
-/** 데이터를 불러오는 중인 로딩 상태. */
+/** 아직 데이터를 받아오는 중일 때. */
 export const Loading: Story = { args: { activities: [], isLoading: true } }
 
-/** 활동이 하나도 없을 때의 빈 상태. */
+/** 활동이 전혀 없을 때 보이는 모습. */
 export const Empty: Story = { args: { activities: [] } }

--- a/src/renderer/src/components/molecules/Divider/Divider.stories.tsx
+++ b/src/renderer/src/components/molecules/Divider/Divider.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Divider } from './Divider'
 
 /**
- * 가운데에 텍스트 라벨을 둔 수평 구분선. 라벨 양옆으로 가로선이 이어져
- * "OR", "Or continue with" 같은 섹션 구분 문구를 표시할 때 사용한다.
+ * 가운데에 라벨이 박힌 가로 구분선이다. 라벨을 사이에 두고 양옆으로 선이 뻗어서,
+ * "OR"이나 "Or continue with"처럼 섹션을 나누는 문구를 끼워 넣을 때 쓴다.
  */
 const meta: Meta<typeof Divider> = {
   title: 'Molecules/Divider',
@@ -17,12 +17,12 @@ const meta: Meta<typeof Divider> = {
   ],
   argTypes: {
     text: {
-      description: '구분선 가운데에 표시되는 라벨 텍스트',
+      description: '선 가운데에 들어갈 라벨 글자.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     className: {
-      description: '루트 요소에 합쳐지는 추가 Tailwind 클래스',
+      description: '루트에 덧붙일 Tailwind 클래스.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -31,8 +31,8 @@ const meta: Meta<typeof Divider> = {
 export default meta
 type Story = StoryObj<typeof Divider>
 
-/** 짧은 라벨("OR")이 들어간 기본 구분선. */
+/** 짧은 "OR" 한 단어만 끼운 기본 모양. */
 export const Default: Story = { args: { text: 'OR' } }
 
-/** 소셜 로그인 등에서 쓰는 긴 안내 라벨. */
+/** 소셜 로그인 같은 데서 보게 되는 좀 더 긴 안내 라벨. */
 export const Continue: Story = { args: { text: 'Or continue with' } }

--- a/src/renderer/src/components/molecules/InfoRow/InfoRow.stories.tsx
+++ b/src/renderer/src/components/molecules/InfoRow/InfoRow.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { InfoRow } from './InfoRow'
 
 /**
- * 라벨 + 값을 4칸 그리드로 나란히 배치하는 정보 행. 상세 패널이나 설정 화면에서
- * "Status: In Progress"처럼 속성을 한 줄씩 표시할 때 사용한다.
- * `labelWidth`로 라벨이 차지하는 칸 수를 조절하면 값 칸은 자동으로 나머지를 채운다.
+ * 라벨과 값을 4칸 그리드에 나란히 앉히는 정보 한 줄이다. 상세 패널이나 설정 화면에서
+ * "Status: In Progress"처럼 속성을 한 줄씩 나열할 때 쓴다. labelWidth로 라벨이 차지할 칸 수를
+ * 정하면 값은 알아서 남는 칸을 채운다.
  */
 const meta: Meta<typeof InfoRow> = {
   title: 'Molecules/InfoRow',
@@ -18,17 +18,17 @@ const meta: Meta<typeof InfoRow> = {
   ],
   argTypes: {
     label: {
-      description: '왼쪽에 굵게 표시되는 속성 라벨',
+      description: '왼쪽에 굵게 들어가는 속성 이름.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     value: {
-      description: '오른쪽에 표시되는 값(텍스트 또는 ReactNode)',
+      description: '오른쪽에 들어가는 값. 글자든 노드든 받는다.',
       control: 'text',
       table: { type: { summary: 'ReactNode' } }
     },
     labelWidth: {
-      description: '4칸 그리드 중 라벨이 차지하는 칸 수. 값 칸은 (4 - labelWidth)칸을 차지한다.',
+      description: '4칸 중 라벨이 먹을 칸 수. 나머지는 값이 가져간다.',
       control: 'select',
       options: [1, 2, 3, 4],
       table: { type: { summary: '1 | 2 | 3 | 4' }, defaultValue: { summary: '1' } }
@@ -38,8 +38,8 @@ const meta: Meta<typeof InfoRow> = {
 export default meta
 type Story = StoryObj<typeof InfoRow>
 
-/** 라벨 1칸 + 값 3칸의 기본 비율. */
+/** 라벨 한 칸, 값 세 칸인 기본 비율. */
 export const Default: Story = { args: { label: 'Status', value: 'In Progress' } }
 
-/** 라벨을 2칸으로 넓혀 긴 라벨을 수용. */
+/** 라벨이 길어 두 칸까지 넓힌 경우. */
 export const WideLabel: Story = { args: { label: 'Created at', value: '2026-06-14', labelWidth: 2 } }

--- a/src/renderer/src/components/molecules/InputField/InputField.stories.tsx
+++ b/src/renderer/src/components/molecules/InputField/InputField.stories.tsx
@@ -2,10 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { InputField } from './InputField'
 
 /**
- * 라벨 + 입력 + 에러 메시지를 묶는 폼 필드 컨테이너. Context로 `id`/`error`를 자식에 내려주며,
- * 실제 입력은 compound 서브컴포넌트로 조합한다: `InputField.Input`, `InputField.Email`,
- * `InputField.Password`, `InputField.OTP`. `error`가 있으면 하단에 destructive 메시지를 렌더하고
- * 입력에 `aria-invalid`를 부여한다.
+ * 라벨과 입력, 에러 메시지를 한 덩어리로 묶는 폼 필드 컨테이너다. id와 error는 Context로 자식에게
+ * 내려보내고, 실제 입력칸은 InputField.Input, .Email, .Password, .OTP 같은 서브컴포넌트를 끼워
+ * 조립한다. error가 들어오면 아래에 빨간 메시지를 띄우면서 입력에 aria-invalid를 달아준다.
  */
 const meta: Meta<typeof InputField> = {
   title: 'Molecules/InputField',
@@ -19,22 +18,22 @@ const meta: Meta<typeof InputField> = {
   ],
   argTypes: {
     label: {
-      description: '필드 상단에 표시되는 라벨. 생략하면 라벨을 렌더하지 않는다.',
+      description: '필드 위에 붙는 라벨. 안 주면 라벨 자체가 안 나온다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     error: {
-      description: '설정 시 하단에 빨간 에러 메시지를 표시하고 입력에 aria-invalid를 부여한다.',
+      description: '넣으면 아래에 빨간 메시지가 뜨고 입력에 aria-invalid가 붙는다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     id: {
-      description: '라벨/입력을 연결하는 id. 생략하면 useId로 자동 생성한다.',
+      description: '라벨과 입력을 이어주는 id. 안 주면 useId로 알아서 만든다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     children: {
-      description: 'InputField.Input / .Email / .Password / .OTP 등 입력 서브컴포넌트',
+      description: '안에 끼울 입력 서브컴포넌트. Input이나 Email, Password, OTP 등을 넣는다.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     }
@@ -43,7 +42,7 @@ const meta: Meta<typeof InputField> = {
 export default meta
 type Story = StoryObj<typeof InputField>
 
-/** 이메일 입력(InputField.Email)을 감싼 기본 텍스트 필드. */
+/** 이메일 입력을 감싼 가장 기본적인 필드. */
 export const Text: Story = {
   render: () => (
     <InputField label='Email'>
@@ -52,7 +51,7 @@ export const Text: Story = {
   )
 }
 
-/** 비밀번호 입력(InputField.Password) 필드. */
+/** 비밀번호 입력칸을 넣은 필드. */
 export const Password: Story = {
   render: () => (
     <InputField label='Password'>
@@ -61,7 +60,7 @@ export const Password: Story = {
   )
 }
 
-/** error prop이 설정되어 에러 메시지가 노출된 상태. */
+/** error를 넘겨 에러 메시지가 보이는 상태. */
 export const WithError: Story = {
   render: () => (
     <InputField label='Email' error='Invalid email address'>
@@ -70,7 +69,7 @@ export const WithError: Story = {
   )
 }
 
-/** 6자리 OTP 입력(InputField.OTP). */
+/** 여섯 자리 OTP를 받는 입력. */
 export const OTP: Story = {
   render: () => (
     <InputField label='Verification code'>

--- a/src/renderer/src/components/molecules/cards/ChartCard/ChartCard.stories.tsx
+++ b/src/renderer/src/components/molecules/cards/ChartCard/ChartCard.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ChartCard } from './ChartCard'
 
 /**
- * 대시보드 차트를 감싸는 유리 효과(glass-soft) 카드. 제목 + 선택적 설명 헤더 아래
- * children 영역에 Recharts 등 차트를 배치한다. 카드 배경은 투명 처리되어 있다.
+ * 대시보드 차트를 담는 glass-soft 카드다. 위에는 제목이, 필요하면 설명까지 붙은 헤더가 오고
+ * 그 아래 children 자리에 Recharts 같은 차트를 넣는다. 카드 배경은 비쳐 보이게 투명하다.
  */
 const meta: Meta<typeof ChartCard> = {
   title: 'Molecules/ChartCard',
@@ -17,17 +17,17 @@ const meta: Meta<typeof ChartCard> = {
   ],
   argTypes: {
     title: {
-      description: '카드 헤더에 표시되는 제목',
+      description: '카드 헤더에 들어가는 제목.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     description: {
-      description: '제목 아래에 표시되는 보조 설명(선택)',
+      description: '제목 밑에 한 줄 덧붙이는 설명. 없어도 된다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     children: {
-      description: '본문에 렌더되는 차트/콘텐츠(ReactNode)',
+      description: '본문에 그릴 차트나 콘텐츠.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     }
@@ -36,7 +36,7 @@ const meta: Meta<typeof ChartCard> = {
 export default meta
 type Story = StoryObj<typeof ChartCard>
 
-/** 제목 + 설명 + 플레이스홀더 차트 영역. */
+/** 제목과 설명을 다 갖추고 자리만 잡아둔 차트 영역. */
 export const Default: Story = {
   args: {
     title: 'Issues by status',
@@ -49,7 +49,7 @@ export const Default: Story = {
   }
 }
 
-/** 설명 없이 제목만 있는 카드. */
+/** 설명은 빼고 제목만 둔 카드. */
 export const WithoutDescription: Story = {
   args: {
     title: 'Throughput',

--- a/src/renderer/src/components/molecules/cards/SettingCard/SettingCard.stories.tsx
+++ b/src/renderer/src/components/molecules/cards/SettingCard/SettingCard.stories.tsx
@@ -3,8 +3,8 @@ import { Button } from '@/atoms/Button'
 import { SettingCard } from './SettingCard'
 
 /**
- * 설정 화면의 한 섹션을 담는 카드. 제목 + 선택적 설명 헤더, 본문(children),
- * 그리고 footer가 있으면 상단 구분선이 그어진 우측 정렬 푸터(보통 저장 버튼)를 렌더한다.
+ * 설정 화면의 섹션 하나를 통째로 담는 카드다. 제목과 (있으면) 설명이 헤더에 오고 그 아래 본문이
+ * 들어간다. footer를 넘기면 위에 구분선을 긋고 오른쪽으로 정렬한 푸터를 붙이는데, 보통 저장 버튼이 온다.
  */
 const meta: Meta<typeof SettingCard> = {
   title: 'Molecules/SettingCard',
@@ -18,27 +18,27 @@ const meta: Meta<typeof SettingCard> = {
   ],
   argTypes: {
     title: {
-      description: '카드 헤더 제목',
+      description: '카드 헤더에 들어가는 제목.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     description: {
-      description: '제목 아래 보조 설명(선택)',
+      description: '제목 밑에 붙이는 설명. 없어도 된다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     children: {
-      description: '본문에 렌더되는 설정 폼/콘텐츠(ReactNode)',
+      description: '본문에 들어갈 설정 폼이나 콘텐츠.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     },
     footer: {
-      description: '설정 시 상단 구분선 + 우측 정렬 푸터로 렌더된다(보통 저장 버튼). 없으면 푸터를 생략한다.',
+      description: '넘기면 구분선과 함께 오른쪽 정렬 푸터로 나온다. 안 주면 푸터를 통째로 뺀다.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     },
     className: {
-      description: 'Card 루트에 합쳐지는 추가 클래스',
+      description: 'Card 루트에 덧붙일 클래스.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -47,7 +47,7 @@ const meta: Meta<typeof SettingCard> = {
 export default meta
 type Story = StoryObj<typeof SettingCard>
 
-/** 제목 + 설명 + 본문 + 저장 버튼 푸터를 모두 갖춘 기본 카드. */
+/** 제목, 설명, 본문, 저장 버튼 푸터까지 다 붙은 기본 카드. */
 export const Default: Story = {
   args: {
     title: 'Profile',
@@ -57,7 +57,7 @@ export const Default: Story = {
   }
 }
 
-/** footer가 없어 푸터/구분선이 생략된 카드. */
+/** footer를 안 줘서 푸터와 구분선이 빠진 카드. */
 export const WithoutFooter: Story = {
   args: {
     title: 'Danger zone',

--- a/src/renderer/src/components/molecules/cards/StatCard/StatCard.stories.tsx
+++ b/src/renderer/src/components/molecules/cards/StatCard/StatCard.stories.tsx
@@ -3,8 +3,9 @@ import { CircleDashed } from 'lucide-react'
 import { StatCard } from './StatCard'
 
 /**
- * 대시보드 상단의 단일 지표 카드. 좌측 아이콘 박스 + (라벨 / 큰 수치 + 보조 설명)으로 구성한다.
- * `iconColor`로 아이콘 박스의 텍스트 색을 바꿔 지표별 강조 톤을 지정할 수 있다.
+ * 대시보드 위쪽에 지표 하나를 보여주는 카드다. 왼쪽에 아이콘 박스가 있고 그 옆으로 작은 라벨,
+ * 큼직한 수치, 그리고 짤막한 보조 설명이 따라온다. iconColor를 바꾸면 아이콘 박스의 글자색이 달라져서
+ * 지표마다 강조 톤을 다르게 줄 수 있다.
  */
 const meta: Meta<typeof StatCard> = {
   title: 'Molecules/StatCard',
@@ -18,27 +19,27 @@ const meta: Meta<typeof StatCard> = {
   ],
   argTypes: {
     title: {
-      description: '지표 라벨(작은 글씨)',
+      description: '지표 이름. 작은 글씨로 들어간다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     value: {
-      description: '큰 글씨로 표시되는 지표 값',
+      description: '큰 글씨로 보이는 지표 값.',
       control: 'text',
       table: { type: { summary: 'string | number' } }
     },
     icon: {
-      description: '좌측 아이콘 박스에 들어가는 아이콘(ReactNode)',
+      description: '왼쪽 박스에 들어갈 아이콘.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     },
     iconColor: {
-      description: '아이콘 박스의 텍스트 색상 Tailwind 클래스',
+      description: '아이콘 박스 글자색을 정하는 Tailwind 클래스.',
       control: 'text',
       table: { type: { summary: 'string' }, defaultValue: { summary: 'text-muted-foreground' } }
     },
     description: {
-      description: '값 옆에 표시되는 보조 설명(선택)',
+      description: '값 옆에 붙는 보조 설명. 없어도 된다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -47,7 +48,7 @@ const meta: Meta<typeof StatCard> = {
 export default meta
 type Story = StoryObj<typeof StatCard>
 
-/** 기본 지표 카드. */
+/** 가장 평범한 지표 카드. */
 export const Default: Story = {
   args: {
     title: 'Open issues',
@@ -57,7 +58,7 @@ export const Default: Story = {
   }
 }
 
-/** iconColor로 아이콘 톤을 강조한 카드. */
+/** iconColor를 줘서 아이콘을 눈에 띄게 만든 카드. */
 export const ColoredIcon: Story = {
   args: {
     title: 'Blocked',

--- a/src/renderer/src/components/molecules/issues/IssueBadge/IssueBadge.stories.tsx
+++ b/src/renderer/src/components/molecules/issues/IssueBadge/IssueBadge.stories.tsx
@@ -2,33 +2,33 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { IssueBadge } from './IssueBadge'
 
 /**
- * 이슈 상태(IssueStatus)를 색상 틴트 배경 + 동계열 텍스트 + 아이콘 배지로 표시하는 컴포넌트.
- * 라벨/색상/아이콘은 상태값에 따라 statusTokens(STATUS_LABEL/STATUS_CLASS)와 내부 STATUS_ICON에서 결정된다.
- * `variant`는 호환을 위해 받지만 무시되며 항상 동일한 틴트 스타일로 렌더한다.
+ * 이슈 상태를 옅은 색 배경에 같은 계열 글자와 아이콘을 얹은 배지로 보여준다. 라벨과 색은
+ * statusTokens의 STATUS_LABEL, STATUS_CLASS에서, 아이콘은 내부 STATUS_ICON에서 상태값에 맞춰 꺼내 쓴다.
+ * variant는 받기만 하고 실제로는 무시하므로, 어떤 값을 줘도 틴트 스타일 하나로만 그린다.
  */
 const meta: Meta<typeof IssueBadge> = {
   title: 'Molecules/IssueBadge',
   component: IssueBadge,
   argTypes: {
     state: {
-      description: '이슈 상태값(공유 IssueStatus union). 라벨/색상/아이콘을 결정한다.',
+      description: '공유 IssueStatus 값. 라벨과 색, 아이콘이 여기서 갈린다.',
       control: 'select',
       options: ['backlog', 'in_progress', 'review', 'done', 'blocked'],
       table: { type: { summary: "'backlog' | 'in_progress' | 'review' | 'done' | 'blocked'" } }
     },
     size: {
-      description: '배지 크기',
+      description: '배지 크기.',
       control: 'radio',
       options: ['sm', 'lg'],
       table: { type: { summary: "'sm' | 'lg'" }, defaultValue: { summary: 'sm' } }
     },
     variant: {
-      description: '호환용으로 받지만 사용하지 않는다(스타일에 영향 없음).',
+      description: '호환 때문에 받아둘 뿐, 스타일에는 아무 영향이 없다.',
       control: false,
       table: { type: { summary: "'solid' | 'subtle' | 'outline' | 'surface' | 'plain'" } }
     },
     className: {
-      description: '배지에 합쳐지는 추가 클래스',
+      description: '배지에 덧붙일 클래스.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -37,18 +37,18 @@ const meta: Meta<typeof IssueBadge> = {
 export default meta
 type Story = StoryObj<typeof IssueBadge>
 
-/** Backlog 상태 배지. */
+/** 아직 손대지 않은 backlog 상태. */
 export const Backlog: Story = { args: { state: 'backlog' } }
-/** In progress 상태 배지. */
+/** 작업이 진행 중일 때. */
 export const InProgress: Story = { args: { state: 'in_progress' } }
-/** Review 상태 배지. */
+/** 리뷰를 기다리는 상태. */
 export const Review: Story = { args: { state: 'review' } }
-/** Done 상태 배지. */
+/** 끝난 이슈. */
 export const Done: Story = { args: { state: 'done' } }
-/** Blocked 상태 배지. */
+/** 뭔가에 막혀 멈춘 상태. */
 export const Blocked: Story = { args: { state: 'blocked' } }
 
-/** 모든 상태값을 한눈에 비교. */
+/** 다섯 상태를 나란히 놓고 비교해보는 용도. */
 export const AllStates: Story = {
   render: () => (
     <div className='flex flex-wrap gap-2'>
@@ -61,5 +61,5 @@ export const AllStates: Story = {
   )
 }
 
-/** lg 크기 배지. */
+/** size를 lg로 키운 배지. */
 export const LargeSize: Story = { args: { state: 'in_progress', size: 'lg' } }

--- a/src/renderer/src/components/molecules/tables/TableEmpty/TableEmpty.stories.tsx
+++ b/src/renderer/src/components/molecules/tables/TableEmpty/TableEmpty.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { TableEmpty } from './TableEmpty'
 
 /**
- * 테이블에 표시할 데이터가 없거나 로딩 중일 때 보여주는 상태 컴포넌트.
- * 기본 아이콘(ClipboardList) + 메시지를 가운데 정렬로 렌더하며, `isLoading`이면
- * pulse 애니메이션과 함께 `loadingMessage`를 표시한다. 빈 상태에서는 `description`을 추가로 보여준다.
+ * 테이블에 보여줄 데이터가 없거나 아직 불러오는 중일 때 그 자리를 채우는 컴포넌트다. 기본 아이콘인
+ * ClipboardList와 메시지를 가운데로 모아 띄운다. isLoading이면 pulse 애니메이션과 함께 loadingMessage를
+ * 보여주고, 그냥 비어 있을 때는 description까지 한 줄 더 붙는다.
  */
 const meta: Meta<typeof TableEmpty> = {
   title: 'Molecules/TableEmpty',
@@ -18,32 +18,32 @@ const meta: Meta<typeof TableEmpty> = {
   ],
   argTypes: {
     message: {
-      description: '빈 상태일 때 표시되는 주 메시지',
+      description: '비어 있을 때 보여줄 메인 문구.',
       control: 'text',
       table: { type: { summary: 'string' }, defaultValue: { summary: 'No data available' } }
     },
     description: {
-      description: '빈 상태에서 메시지 아래에 표시되는 보조 설명(선택)',
+      description: '빈 상태에서 메시지 아래 덧붙는 설명. 없어도 된다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     icon: {
-      description: '기본 아이콘 대신 사용할 아이콘(ReactNode). 미지정 시 ClipboardList 사용.',
+      description: '기본 아이콘 대신 쓸 아이콘. 안 주면 ClipboardList가 나온다.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     },
     isLoading: {
-      description: 'true이면 pulse 애니메이션과 loadingMessage를 표시한다.',
+      description: '켜면 pulse 애니메이션과 loadingMessage로 바뀐다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     loadingMessage: {
-      description: '로딩 중 표시되는 메시지',
+      description: '불러오는 동안 보여줄 문구.',
       control: 'text',
       table: { type: { summary: 'string' }, defaultValue: { summary: 'Loading data...' } }
     },
     className: {
-      description: '컨테이너에 합쳐지는 추가 클래스',
+      description: '컨테이너에 덧붙일 클래스.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -52,10 +52,10 @@ const meta: Meta<typeof TableEmpty> = {
 export default meta
 type Story = StoryObj<typeof TableEmpty>
 
-/** 메시지 + 설명이 있는 빈 상태. */
+/** 메시지와 설명이 같이 있는 빈 상태. */
 export const Empty: Story = {
   args: { message: 'No issues found', description: 'Create your first issue to get started' }
 }
 
-/** 데이터를 불러오는 중인 로딩 상태. */
+/** 아직 데이터를 받아오는 중일 때. */
 export const Loading: Story = { args: { isLoading: true } }

--- a/src/renderer/src/components/molecules/users/UserAvatar/UserAvatar.stories.tsx
+++ b/src/renderer/src/components/molecules/users/UserAvatar/UserAvatar.stories.tsx
@@ -2,54 +2,53 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { UserAvatar } from './UserAvatar'
 
 /**
- * 사용자 아바타 + 이름(선택적으로 이메일)을 한 줄로 표시하는 컴포넌트.
- * `avatar` 이미지가 없으면 User 아이콘 fallback을 보여준다. `showInfo`가 true면
- * 이름/이메일을 세로 스택으로, false면 이름만 옆에 표시한다. `size`로 4단계 크기를,
- * `align`으로 좌측/가운데 정렬을 조절한다.
+ * 사용자 아바타와 이름을, 필요하면 이메일까지 한 줄에 늘어놓는 컴포넌트다. avatar 이미지가 없으면
+ * User 아이콘으로 대신 채운다. showInfo를 켜면 이름과 이메일을 위아래로 쌓고, 끄면 이름만 아바타 옆에
+ * 붙인다. 크기는 size로 네 단계 중 고르고 좌측이나 가운데 정렬은 align으로 정한다.
  */
 const meta: Meta<typeof UserAvatar> = {
   title: 'Molecules/UserAvatar',
   component: UserAvatar,
   argTypes: {
     name: {
-      description: '사용자 이름. fallback alt 및 라벨로 사용된다.',
+      description: '사용자 이름. 라벨로도 쓰고 이미지 alt로도 쓴다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     avatar: {
-      description: '아바타 이미지 URL. 없으면 User 아이콘 fallback을 표시한다.',
+      description: '아바타 이미지 URL. 비면 User 아이콘으로 대신한다.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     email: {
-      description: 'showInfo가 true일 때 이름 아래에 표시되는 이메일',
+      description: 'showInfo를 켰을 때 이름 밑에 따라오는 이메일.',
       control: 'text',
       table: { type: { summary: 'string' } }
     },
     size: {
-      description: '아바타/텍스트 크기 단계',
+      description: '아바타와 글자 크기 단계.',
       control: 'select',
       options: ['xs', 'sm', 'md', 'lg'],
       table: { type: { summary: "'xs' | 'sm' | 'md' | 'lg'" }, defaultValue: { summary: 'md' } }
     },
     showInfo: {
-      description: 'true면 이름+이메일을 세로 스택으로, false면 이름만 옆에 표시한다.',
+      description: '켜면 이름과 이메일을 위아래로 쌓고, 끄면 이름만 옆에 둔다.',
       control: 'boolean',
       table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
     align: {
-      description: '컨테이너 내 정렬',
+      description: '컨테이너 안에서의 정렬.',
       control: 'radio',
       options: ['left', 'center'],
       table: { type: { summary: "'left' | 'center'" }, defaultValue: { summary: 'left' } }
     },
     fallback: {
-      description: '기본 User 아이콘 대신 사용할 fallback 노드(ReactNode)',
+      description: '기본 User 아이콘 대신 채울 노드.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     },
     className: {
-      description: '컨테이너에 합쳐지는 추가 클래스',
+      description: '컨테이너에 덧붙일 클래스.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -58,11 +57,11 @@ const meta: Meta<typeof UserAvatar> = {
 export default meta
 type Story = StoryObj<typeof UserAvatar>
 
-/** 이름만 옆에 표시되는 기본 아바타. */
+/** 이름만 옆에 붙는 가장 기본 모양. */
 export const Default: Story = { args: { name: 'Alice Kim' } }
 
-/** showInfo로 이름 + 이메일을 함께 표시. */
+/** showInfo를 켜서 이름과 이메일을 같이 보여주는 경우. */
 export const WithInfo: Story = { args: { name: 'Alice Kim', email: 'alice@example.com', showInfo: true } }
 
-/** lg 크기의 정보 포함 아바타. */
+/** 정보까지 보여주면서 lg 크기로 키운 아바타. */
 export const Large: Story = { args: { name: 'Alice Kim', email: 'alice@example.com', showInfo: true, size: 'lg' } }

--- a/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.stories.tsx
+++ b/src/renderer/src/components/organisms/KanbanBoard/KanbanBoard.stories.tsx
@@ -16,26 +16,26 @@ const issue = (over: Partial<Issue>): Issue => ({
 })
 
 /**
- * dnd-kit 기반 칸반 보드. 이슈 상태(backlog / in_progress / review / done / blocked)별 컬럼에 카드를 배치하고,
- * 카드를 다른 컬럼으로 드래그하면 `onMove(issueId, newState)`를 호출한다. 카드 클릭 시 `onSelectIssue`가 호출된다.
- * 프로젝트 보드 화면에서 이슈를 상태별로 시각화/이동할 때 사용한다.
+ * dnd-kit으로 만든 칸반 보드다. backlog, in_progress, review, done, blocked 같은 상태마다 컬럼이 하나씩
+ * 있고 이슈는 자기 state에 맞는 컬럼으로 들어간다. 카드를 다른 컬럼으로 끌어다 놓으면 onMove가 새 상태를 들고
+ * 불리고, 카드를 그냥 누르면 onSelectIssue가 불린다. 프로젝트 보드에서 이슈를 상태별로 펼쳐 보거나 옮길 때 쓴다.
  */
 const meta: Meta<typeof KanbanBoard> = {
   title: 'Organisms/KanbanBoard',
   component: KanbanBoard,
   argTypes: {
     issues: {
-      description: '보드에 표시할 이슈 배열. 각 이슈의 state 값에 따라 컬럼으로 분류된다.',
+      description: '보드에 뿌릴 이슈 목록인데, 각자 state 값을 보고 알아서 컬럼에 나뉘어 들어간다.',
       control: 'object',
       table: { type: { summary: 'Issue[]' } }
     },
     onMove: {
-      description: '카드를 다른 상태 컬럼으로 드롭했을 때 호출. (issueId: string, newState: IssueStatus) => void',
+      description: '카드를 다른 상태 컬럼에 떨어뜨렸을 때 불린다.',
       control: false,
       table: { type: { summary: '(issueId: string, newState: IssueStatus) => void' } }
     },
     onSelectIssue: {
-      description: '카드 클릭 시 호출(선택). (issue: Issue) => void',
+      description: '카드를 클릭하면 불린다. 굳이 안 넘겨도 된다.',
       control: false,
       table: { type: { summary: '(issue: Issue) => void' } }
     }
@@ -45,7 +45,7 @@ const meta: Meta<typeof KanbanBoard> = {
 export default meta
 type Story = StoryObj<typeof KanbanBoard>
 
-/** 다섯 개 상태 컬럼에 이슈가 하나씩 배치된 기본 보드. */
+/** 다섯 컬럼에 이슈를 하나씩 깔아둔 기본 보드. */
 export const Default: Story = {
   args: {
     issues: [
@@ -58,5 +58,5 @@ export const Default: Story = {
   }
 }
 
-/** 이슈가 없을 때 빈 컬럼만 표시되는 상태. */
+/** 이슈가 하나도 없어서 빈 컬럼만 남은 상태. */
 export const Empty: Story = { args: { issues: [] } }

--- a/src/renderer/src/components/templates/AuthLayout/AuthLayout.stories.tsx
+++ b/src/renderer/src/components/templates/AuthLayout/AuthLayout.stories.tsx
@@ -2,23 +2,24 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { AuthLayout } from './AuthLayout'
 
 /**
- * 로그인/관리자 설정 등 인증 화면의 공통 셸. 좌측 브랜드 패널(md 이상에서만 표시) + 우측 폼 카드 구조이며,
- * 제목/부제 슬롯과 본문(`children`) 슬롯을 제공한다. 로그인·셋업 등 인증 흐름의 페이지 골격으로 사용한다.
+ * 로그인이나 관리자 설정 같은 인증 화면이 공통으로 쓰는 껍데기다. 왼쪽엔 브랜드 패널이 오고 오른쪽엔 폼 카드가
+ * 놓이는 2열 구조인데, 브랜드 패널은 md 이상에서만 보인다. 제목과 부제는 따로 슬롯으로 받고 실제 폼은 children
+ * 자리에 끼워 넣으면 된다. 로그인이나 셋업 흐름의 페이지 골격으로 쓴다.
  */
 const meta: Meta<typeof AuthLayout> = {
   title: 'Templates/AuthLayout',
   component: AuthLayout,
   parameters: { layout: 'fullscreen' },
   argTypes: {
-    title: { description: '카드 상단 제목', control: 'text', table: { type: { summary: 'string' } } },
-    subtitle: { description: '제목 아래 보조 설명', control: 'text', table: { type: { summary: 'string' } } },
-    children: { description: '폼 등 카드 본문 슬롯', control: false, table: { type: { summary: 'ReactNode' } } }
+    title: { description: '카드 맨 위에 굵게 들어가는 제목.', control: 'text', table: { type: { summary: 'string' } } },
+    subtitle: { description: '제목 아래 한 줄 거드는 설명.', control: 'text', table: { type: { summary: 'string' } } },
+    children: { description: '카드에 들어갈 폼이나 본문.', control: false, table: { type: { summary: 'ReactNode' } } }
   }
 }
 export default meta
 type Story = StoryObj<typeof AuthLayout>
 
-/** 워크스페이스 로그인 화면 예시. */
+/** 워크스페이스에 로그인하는 화면 모습. */
 export const SignIn: Story = {
   args: {
     title: '로그인',
@@ -29,7 +30,7 @@ export const SignIn: Story = {
   }
 }
 
-/** 빈 DB 최초 연결 시 노출되는 관리자 계정 셋업 화면 예시. */
+/** 빈 DB에 처음 붙었을 때 첫 관리자 계정을 만드는 셋업 화면. */
 export const AdminSetup: Story = {
   args: {
     title: '관리자 설정',

--- a/src/renderer/src/components/templates/DialogTemplate/DialogTemplate.stories.tsx
+++ b/src/renderer/src/components/templates/DialogTemplate/DialogTemplate.stories.tsx
@@ -3,31 +3,31 @@ import { Button } from '@/atoms/Button'
 import { DialogTemplate } from './DialogTemplate'
 
 /**
- * 제목·설명·본문·푸터 슬롯을 갖춘 표준 다이얼로그 셸. shadcn `Dialog`를 감싸 모달의 공통 골격을 제공한다.
- * `onSubmit`을 넘기면 본문/푸터를 `<form>`으로 감싸 폼 제출형 다이얼로그(생성/수정 등)로 동작한다.
- * 프로젝트·이슈 생성처럼 입력 폼이 들어가는 모달에 사용한다.
+ * 제목, 설명, 본문, 푸터 자리를 갖춘 모달 껍데기다. shadcn Dialog를 감싸서 공통 골격만 잡아준다. onSubmit을
+ * 넘기면 본문과 푸터를 form으로 묶어주기 때문에 프로젝트나 이슈를 새로 만들거나 고치는 입력 폼 모달로 바로 쓸 수
+ * 있다.
  */
 const meta: Meta<typeof DialogTemplate> = {
   title: 'Templates/DialogTemplate',
   component: DialogTemplate,
   argTypes: {
-    open: { description: '다이얼로그 열림/닫힘 상태', control: 'boolean', table: { type: { summary: 'boolean' } } },
+    open: { description: '모달이 떠 있는지 여부.', control: 'boolean', table: { type: { summary: 'boolean' } } },
     onOpenChange: {
-      description: '열림 상태 변경 핸들러. (open: boolean) => void',
+      description: '바깥 클릭이나 ESC 등으로 열림 상태가 바뀔 때 불린다.',
       control: false,
       table: { type: { summary: '(open: boolean) => void' } }
     },
-    title: { description: '다이얼로그 제목', control: 'text', table: { type: { summary: 'string' } } },
-    description: { description: '제목 아래 보조 설명(선택)', control: 'text', table: { type: { summary: 'string' } } },
-    children: { description: '본문 슬롯(폼/컨텐츠 영역)', control: false, table: { type: { summary: 'ReactNode' } } },
-    footer: { description: '푸터 슬롯(주로 액션 버튼)', control: false, table: { type: { summary: 'ReactNode' } } },
+    title: { description: '모달 헤더에 들어가는 제목.', control: 'text', table: { type: { summary: 'string' } } },
+    description: { description: '제목 밑에 덧붙이는 설명.', control: 'text', table: { type: { summary: 'string' } } },
+    children: { description: '폼이나 내용을 채우는 본문.', control: false, table: { type: { summary: 'ReactNode' } } },
+    footer: { description: '주로 액션 버튼이 오는 푸터.', control: false, table: { type: { summary: 'ReactNode' } } },
     maxWidthClass: {
-      description: '컨텐츠 최대 너비 Tailwind 클래스',
+      description: '본문 최대 너비를 정하는 Tailwind 클래스.',
       control: 'text',
       table: { type: { summary: 'string' }, defaultValue: { summary: 'sm:max-w-[425px]' } }
     },
     onSubmit: {
-      description: '폼 제출 핸들러(선택). 지정 시 본문/푸터가 <form>으로 감싸진다. (e: FormEvent) => void',
+      description: '넘기면 본문과 푸터가 form으로 묶여서 제출 시 이 핸들러가 불린다.',
       control: false,
       table: { type: { summary: '(e: React.FormEvent) => void' } }
     }
@@ -36,7 +36,7 @@ const meta: Meta<typeof DialogTemplate> = {
 export default meta
 type Story = StoryObj<typeof DialogTemplate>
 
-/** 제목·설명·본문·취소/생성 버튼 푸터를 갖춘 기본 다이얼로그. */
+/** 제목과 설명, 본문, 그리고 취소와 생성 버튼이 들어간 푸터까지 다 채운 기본 모습. */
 export const Default: Story = {
   args: {
     open: true,

--- a/src/renderer/src/components/templates/SignInTemplate/SignInTemplate.stories.tsx
+++ b/src/renderer/src/components/templates/SignInTemplate/SignInTemplate.stories.tsx
@@ -2,21 +2,21 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { SignInTemplate } from './SignInTemplate'
 
 /**
- * 로그인 화면용 2열 카드 셸. 좌측은 폼(`children`)을 감싼 `<form>`, 우측은 일러스트 이미지(md 이상에서만 표시)이며
- * 하단에 약관/개인정보 고지 문구가 붙는다. `div`의 기본 속성(`className` 포함)을 그대로 받아 전달한다.
- * 로그인 폼을 카드 형태로 배치할 때 사용한다.
+ * 로그인 화면을 위한 2열 카드다. 왼쪽은 children을 form으로 감싼 폼 영역이고 오른쪽엔 일러스트가 들어가는데,
+ * 일러스트는 md 이상에서만 보인다. 카드 밑으로는 약관과 개인정보 고지 문구가 따라붙는다. className을 비롯한 div
+ * 속성은 그대로 받아서 루트로 넘긴다.
  */
 const meta: Meta<typeof SignInTemplate> = {
   title: 'Templates/SignInTemplate',
   component: SignInTemplate,
   argTypes: {
     children: {
-      description: '좌측 폼 영역에 렌더링될 본문',
+      description: '왼쪽 폼 영역을 채울 본문.',
       control: false,
       table: { type: { summary: 'ReactNode' } }
     },
     className: {
-      description: '루트 컨테이너에 병합되는 추가 클래스',
+      description: '루트 컨테이너에 덧붙일 클래스.',
       control: 'text',
       table: { type: { summary: 'string' } }
     }
@@ -32,7 +32,7 @@ const meta: Meta<typeof SignInTemplate> = {
 export default meta
 type Story = StoryObj<typeof SignInTemplate>
 
-/** 기본 로그인 폼이 좌측에 배치된 예시. */
+/** 왼쪽에 기본 로그인 폼을 끼운 모습. */
 export const Default: Story = {
   args: {
     children: (


### PR DESCRIPTION
## 개요

머지된 #90(스토리 문서화 + `argTypes`)에 이어, **스토리 설명 글의 글투만** 사람이 쓴 것처럼 다듬은 후속 PR입니다. 기능 코드(`control`/`options`/`table`/`args`/mock 데이터)는 건드리지 않고, 자연어 문장만 손봤습니다.

## 없앤 "AI 티"

- 화살표 연결(`xs→lg`, `name→X, value→Y`, `from→to`) → 말로 풀어 씀
- JSDoc 안의 불릿 목록 → 자연스럽게 이어지는 2~4문장
- 슬래시 나열(`상태 변경 / 담당자 변경 / 댓글 작성`) → 쉼표와 "같은/등"
- 획일적인 "~한다" 반복 → 문장 끝맺음 다양화
- 매 줄 붙던 괄호 타입 주석(`(ReactNode)`, `(선택)`, `(px)`) 제거 (타입은 이미 `table`에 노출)

예) Button: `기본(gradient) → outline → destructive` → "default가 그라데이션으로 가장 세고, outline이나 secondary, ghost는 보조용, destructive는 위험한 액션, link는 텍스트처럼 보인다"

## 범위

스토리 32개 파일, prose만 변경 (327 insertions / 338 deletions).

## 검증

| 항목 | 결과 |
|------|------|
| `typecheck:web` | ✅ 통과 |
| 스토리 스모크 테스트 | ✅ 94개 통과 |
| `lint:ci` (Biome) | ✅ 에러 없음 (경고 27건은 모두 기존 a11y) |
| `build-storybook` | ✅ 성공 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013bHPg24sPPzWCSAS5rfZgR)_