### PR TITLE
fix(projects): 프로젝트 수정 시 설명(projectDesc) 유실 수정

### DIFF
--- a/src/main/handler/projects/UpdateProjectHandler.ts
+++ b/src/main/handler/projects/UpdateProjectHandler.ts
@@ -14,6 +14,7 @@ export class UpdateProjectHandler extends CoreBaseHandler<IpcChannel.PROJECT_UPD
     // 2. 프로젝트 업데이트 (public.projects)
     const project = await this.repos.projects.update(params.projectId, {
       projectName: params.projectName,
+      projectDesc: params.projectDesc,
       modifiedBy: params.userId
     })
 


### PR DESCRIPTION
## 문제

`UpdateProjectHandler`가 `repos.projects.update()`를 호출할 때 `projectName`과 `modifiedBy`만 전달하고 `projectDesc`를 누락했습니다. 그 결과 사용자가 프로젝트 설명을 수정해도 **조용히 저장되지 않는 데이터 유실**이 발생합니다.

- 리포지토리(`DrizzleProjectRepository.update`)는 `projectDesc`를 이미 지원합니다.
- `UpdateProjectParams`와 설정 UI도 `projectDesc`를 넘깁니다.
- 핸들러만 전달 누락이었습니다. (backlog HYDRA-030)

## 수정

핸들러의 update 호출에 `projectDesc: params.projectDesc`를 추가했습니다(1줄).

## 검증

`pnpm typecheck:node` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013bHPg24sPPzWCSAS5rfZgR)_