### PR TITLE
feat(issues): 이슈 생성 다이얼로그 설명을 Tiptap 에디터로 전환

### DIFF
--- a/src/renderer/src/components/organisms/dialogs/CreateIssueDialog/CreateIssueDialog.tsx
+++ b/src/renderer/src/components/organisms/dialogs/CreateIssueDialog/CreateIssueDialog.tsx
@@ -6,8 +6,8 @@ import { Button } from '@/atoms/Button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/atoms/Dialog'
 import { Input } from '@/atoms/Input'
 import { Label } from '@/atoms/Label'
+import { RichTextEditor } from '@/atoms/RichTextEditor'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/atoms/Select'
-import { Textarea } from '@/atoms/Textarea'
 import { useCreateIssue } from '@/hooks/use-issues'
 import { useProjectMembers } from '@/hooks/use-members'
 import { useProjects } from '@/hooks/use-projects'
@@ -235,14 +235,12 @@ export function CreateIssueDialog({ open, onOpenChange, userId }: CreateIssueDia
               {t('label.description')}
             </Label>
             <div className='col-span-3'>
-              <Textarea
-                id='description'
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
+              <RichTextEditor
+                content={description}
+                onChange={setDescription}
                 placeholder={t('placeholder.description')}
-                className='min-h-[240px] resize-y'
+                className='min-h-[240px]'
               />
-              <p className='text-xs text-muted-foreground mt-1'>{t('help.editorNote')}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 개요

이슈 생성 다이얼로그(`CreateIssueDialog`)의 설명 입력을 평문 `Textarea`에서 `RichTextEditor`(Tiptap)로 전환했습니다. 이미 이슈 상세·댓글에서 쓰는 것과 동일한 컴포넌트·패턴이라 편집 경험이 일관됩니다. (HYDRA-032)

## 변경 사항

- `Textarea` → `RichTextEditor`로 교체 (`content={description}` / `onChange={setDescription}`). `description`은 그대로 HTML 문자열로 저장됩니다(기존 저장 경로 변경 없음).
- "기본 텍스트 편집만 가능" 안내 문구(`editorNote`) `<p>` 제거 — 이제 리치 편집을 지원하므로 사실과 맞지 않습니다.
- 사용하지 않게 된 `Textarea` import 제거.

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm typecheck:web` | ✅ 통과 |
| `pnpm test` | ✅ 166 passed / 27 skipped(DB 게이트) |
| `lint:ci` | ✅ 에러 없음 |

## #98과의 관계

`editorNote` i18n 키는 PR #98이 텍스트를 정정하고 있어, 충돌을 피하려고 이 PR에서는 표시용 `<p>`만 제거하고 키 자체는 두었습니다. 이 PR이 머지되면 해당 키는 미사용이 되므로, #98 머지 후 정리하거나 후속으로 제거하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013bHPg24sPPzWCSAS5rfZgR)_