### PR TITLE
refactor(handlers): IPC 핸들러 에러 처리 패턴을 throw로 단일화

### DIFF
--- a/src/main/core/error/NetworkError.ts
+++ b/src/main/core/error/NetworkError.ts
@@ -1,0 +1,8 @@
+import { BaseError } from '@/error/BaseError'
+import { ErrorCode } from '@/interface/CoreInterface'
+
+export class NetworkError extends BaseError {
+  constructor(message: string, data: unknown = null) {
+    super(ErrorCode.NETWORK_ERROR, data, message)
+  }
+}

--- a/src/main/core/error/NotFoundError.ts
+++ b/src/main/core/error/NotFoundError.ts
@@ -1,0 +1,8 @@
+import { BaseError } from '@/error/BaseError'
+import { ErrorCode } from '@/interface/CoreInterface'
+
+export class NotFoundError extends BaseError {
+  constructor(message: string, data: unknown = null) {
+    super(ErrorCode.NOT_FOUND_ERROR, data, message)
+  }
+}

--- a/src/main/handler/integrations/TestSlackWebhookHandler.ts
+++ b/src/main/handler/integrations/TestSlackWebhookHandler.ts
@@ -1,5 +1,6 @@
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
-import { ErrorCode, IpcChannel, type TestSlackWebhookParams } from '@/interface/CoreInterface'
+import { NetworkError } from '@/error/NetworkError'
+import { IpcChannel, type TestSlackWebhookParams } from '@/interface/CoreInterface'
 
 export class TestSlackWebhookHandler extends CoreBaseHandler<IpcChannel.INTEGRATION_TEST_SLACK> {
   constructor() {
@@ -14,25 +15,12 @@ export class TestSlackWebhookHandler extends CoreBaseHandler<IpcChannel.INTEGRAT
         body: JSON.stringify({ text: 'Hydra test notification - connection successful!' })
       })
       if (!response.ok) {
-        return {
-          data: false,
-          error: {
-            code: ErrorCode.NETWORK_ERROR,
-            message: `Slack responded with ${response.status}`,
-            data: null
-          }
-        }
+        throw new NetworkError(`Slack responded with ${response.status}`)
       }
       return { data: true, error: null }
     } catch (error: unknown) {
-      return {
-        data: false,
-        error: {
-          code: ErrorCode.NETWORK_ERROR,
-          message: error instanceof Error ? error.message : 'Failed to send test message',
-          data: null
-        }
-      }
+      if (error instanceof NetworkError) throw error
+      throw new NetworkError(error instanceof Error ? error.message : 'Failed to send test message')
     }
   }
 }

--- a/src/main/handler/invite/ApplyInviteHandler.ts
+++ b/src/main/handler/invite/ApplyInviteHandler.ts
@@ -1,5 +1,6 @@
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
-import { ErrorCode, type InviteApplyParams, type InviteCodeInfo, IpcChannel } from '@/interface/CoreInterface'
+import { ValidationError } from '@/error/ValidationError'
+import { type InviteApplyParams, type InviteCodeInfo, IpcChannel } from '@/interface/CoreInterface'
 
 export class ApplyInviteHandler extends CoreBaseHandler<IpcChannel.INVITE_APPLY> {
   constructor() {
@@ -15,14 +16,7 @@ export class ApplyInviteHandler extends CoreBaseHandler<IpcChannel.INVITE_APPLY>
 
     // 초대 코드 만료 확인
     if (info.expiresAt && new Date(info.expiresAt) < new Date()) {
-      return {
-        data: null,
-        error: {
-          code: ErrorCode.VALIDATION_ERROR,
-          message: 'Invite code has expired',
-          data: null
-        }
-      }
+      throw new ValidationError('Invite code has expired', null)
     }
 
     return { data: info, error: null }

--- a/src/main/handler/issues/GetIssueHandler.ts
+++ b/src/main/handler/issues/GetIssueHandler.ts
@@ -1,5 +1,6 @@
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
-import { ErrorCode, type GetIssueParams, IpcChannel } from '@/interface/CoreInterface'
+import { NotFoundError } from '@/error/NotFoundError'
+import { type GetIssueParams, IpcChannel } from '@/interface/CoreInterface'
 
 export class GetIssueHandler extends CoreBaseHandler<IpcChannel.ISSUE_GET> {
   constructor() {
@@ -9,7 +10,7 @@ export class GetIssueHandler extends CoreBaseHandler<IpcChannel.ISSUE_GET> {
   async handler(params: GetIssueParams) {
     const issue = await this.repos.issues.findById(params.issueId)
     if (!issue) {
-      return { data: null, error: { code: ErrorCode.NOT_FOUND_ERROR, message: 'Issue not found', data: null } }
+      throw new NotFoundError('Issue not found')
     }
     return { data: issue, error: null }
   }

--- a/src/main/handler/projects/GetProjectHandler.ts
+++ b/src/main/handler/projects/GetProjectHandler.ts
@@ -1,5 +1,6 @@
 import { CoreBaseHandler } from '@/base/CoreBaseHandler'
-import { ErrorCode, type GetProjectParams, IpcChannel } from '@/interface/CoreInterface'
+import { NotFoundError } from '@/error/NotFoundError'
+import { type GetProjectParams, IpcChannel } from '@/interface/CoreInterface'
 
 export class GetProjectHandler extends CoreBaseHandler<IpcChannel.PROJECT_GET> {
   constructor() {
@@ -9,7 +10,7 @@ export class GetProjectHandler extends CoreBaseHandler<IpcChannel.PROJECT_GET> {
   async handler(params: GetProjectParams) {
     const project = await this.repos.projects.findById(params.projectId)
     if (!project) {
-      return { data: null, error: { code: ErrorCode.NOT_FOUND_ERROR, message: 'Project not found', data: null } }
+      throw new NotFoundError('Project not found')
     }
     return { data: project, error: null }
   }


### PR DESCRIPTION
## 개요

IPC 핸들러의 에러 처리 패턴을 **throw 단일 패턴**으로 통일합니다. 백엔드 리뷰에서 일부 핸들러는 throw, 일부는 수동으로 `{ data, error: {...} }`를 반환하는 혼재가 확인됐습니다.

## 표준 패턴

`initHandler.ts`의 디스패치 래퍼가 이미 throw를 잡아 `{ data: null, error: error.toJSON() }`으로 변환합니다. 따라서 핸들러는 **성공 시 `{ data, error: null }` 반환, 실패 시 `BaseError` throw**만 하면 됩니다. 수동 error 객체 반환은 래퍼가 하는 일을 중복하던 셈입니다.

## 변경 사항

- `NotFoundError`, `NetworkError` 에러 클래스 추가 (`ValidationError`/`StorageError`와 동일 형태, 에러 코드 의미 보존)
- `GetProjectHandler`/`GetIssueHandler`: `NOT_FOUND_ERROR` 객체 반환 → `NotFoundError` throw
- `ApplyInviteHandler`: 만료 시 `VALIDATION_ERROR` 객체 반환 → `ValidationError` throw
- `TestSlackWebhookHandler`: 실패 시 `NETWORK_ERROR` 객체 반환 → `NetworkError` throw (성공 시 `{ data: true, error: null }` 유지)

렌더러 동작은 동일합니다 — `invokeApi`가 `result.error`든 throw든 똑같이 토스트 후 throw하므로, 기존 UX(예: Slack 테스트 실패 토스트, `.catch(() => false)`)가 그대로 유지됩니다.

## 검증

| 항목 | 결과 |
|------|------|
| `typecheck:node` | ✅ 통과 |
| `pnpm test` | ✅ 166 passed / 27 skipped |
| `lint:ci` | ✅ 에러 없음 |
| 잔여 수동 error 반환 | 0건 (전수 확인) |

## 후속

리뷰에서 나온 나머지 항목(`invite_codes` UNIQUE 정합, `activity_logs` charset, 로그인 상수시간화, `DeleteProject` 트랜잭션, validator 커버리지)은 별도 PR로 이어서 처리하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013bHPg24sPPzWCSAS5rfZgR)_